### PR TITLE
fix: Fixed the karpenter example hard-coded the provisioner region

### DIFF
--- a/analytics/emr-eks-karpenter/addons.tf
+++ b/analytics/emr-eks-karpenter/addons.tf
@@ -214,7 +214,7 @@ module "karpenter_launch_templates" {
 data "kubectl_path_documents" "karpenter_provisioners" {
   pattern = "${path.module}/provisioners/spark-*.yaml"
   vars = {
-    azs                  = "eu-west-1"
+    azs                  = local.region
     eks_cluster_id       = local.name
     instance_profile     = format("%s-%s", local.name, local.core_node_group) # This is using core-node-group instance profile
     launch_template_name = format("%s-%s", "karpenter", local.name)


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Fixed the hard-coded Karpenter region in the example.

### Motivation

 In case people may not use the default region (eu-west-1), and the karpenter doesn't work well due to the setting.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/awslabs/data-on-eks/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR to add a new Add-on for [Terraform EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints) repo (if applicable)
- [ ] Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [x] E2E Test successfully complete before merge?

### Additional Notes

N/A
