### PR TITLE
Github workflow security updates

### DIFF
--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -30,8 +30,7 @@ jobs:
         id: dirs
         run: |
           DIRS=$(python3 .github/workflows/plan-examples.py)
-          echo "::set-output name=directories::$DIRS"
-
+          echo "directories=$DIRS" >> $GITHUB_OUTPUT
   plan:
     name: Plan examples
     needs: getExampleDirectories
@@ -74,8 +73,9 @@ jobs:
               - 'modules/**/*.(tf|yml|yaml)'
               - '*.tf'
 
+      # https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS credentials from Test account
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: ws-actions/configure-aws-credentials@v1-node16
         if: steps.changes.outputs.src== 'true'
         with:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

- Github workflow security updates to fix the following issues
1. The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
2. Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials, aws-actions/configure-aws-credentials

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/awslabs/data-on-eks/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR to add a new Add-on for [Terraform EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints) repo (if applicable)
- [ ] Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
