### PR TITLE
fixing bug in CloudWatch Logs autocreate in helm bcoz terraform alrea…

### DIFF
--- a/analytics/terraform/emr-eks-ack-crossplane/helm-values/aws-for-fluentbit-values.yaml
+++ b/analytics/terraform/emr-eks-ack-crossplane/helm-values/aws-for-fluentbit-values.yaml
@@ -35,7 +35,7 @@ cloudWatch:
   logKey:
   logFormat:
   roleArn:
-  autoCreateGroup: true
+  autoCreateGroup: false
   endpoint:
   credentialsEndpoint:  {}
 

--- a/analytics/terraform/emr-eks-karpenter/helm-values/aws-for-fluentbit-values.yaml
+++ b/analytics/terraform/emr-eks-karpenter/helm-values/aws-for-fluentbit-values.yaml
@@ -35,7 +35,7 @@ cloudWatch:
   logKey:
   logFormat:
   roleArn:
-  autoCreateGroup: true
+  autoCreateGroup: false
   endpoint:
   credentialsEndpoint:  {}
 

--- a/analytics/terraform/emr-eks-yunikorn/helm-values/aws-for-fluentbit-values.yaml
+++ b/analytics/terraform/emr-eks-yunikorn/helm-values/aws-for-fluentbit-values.yaml
@@ -35,7 +35,7 @@ cloudWatch:
   logKey:
   logFormat:
   roleArn:
-  autoCreateGroup: true
+  autoCreateGroup: false
   endpoint:
   credentialsEndpoint:  {}
 

--- a/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
@@ -37,7 +37,7 @@ cloudWatch:
   logKey:
   logFormat:
   roleArn:
-  autoCreateGroup: true
+  autoCreateGroup: false
   endpoint:
   credentialsEndpoint:  {}
 

--- a/streaming/kafka/helm-values/aws-for-fluentbit-values.yaml
+++ b/streaming/kafka/helm-values/aws-for-fluentbit-values.yaml
@@ -37,7 +37,7 @@ cloudWatch:
   logKey:
   logFormat:
   roleArn:
-  autoCreateGroup: true
+  autoCreateGroup: false
   endpoint:
   credentialsEndpoint:  {}
 


### PR DESCRIPTION
### What does this PR do?

I was getting this error and worked with Vara to resolve the issue. Looks like both Helm and Terraform is trying to create CloudWatch Logs group and we only need one. Hence, disabling autocreate from helm values

```
│ Error: creating CloudWatch Logs Log Group (/emr-eks-karpenter/worker-fluentbit-logs): ResourceAlreadyExistsException: The specified log group already exists
│ 
│   with module.eks_blueprints_kubernetes_addons.module.aws_for_fluent_bit[0].aws_cloudwatch_log_group.aws_for_fluent_bit[0],
│   on .terraform/modules/eks_blueprints_kubernetes_addons/modules/kubernetes-addons/aws-for-fluentbit/main.tf line 10, in resource "aws_cloudwatch_log_group" "aws_for_fluent_bit":
│   10: resource "aws_cloudwatch_log_group" "aws_for_fluent_bit" {
```

<!-- A brief description of the change being made with this pull request. -->
Changed from true to false for ` autoCreateGroup: false`
