### PR TITLE
remove deprecated format and increaes volume timeout to 60 seconds

### DIFF
--- a/analytics/terraform/spark-k8s-operator/helm-values/yunikorn-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/yunikorn-values.yaml
@@ -94,44 +94,47 @@ enableSchedulerPlugin: false
 # Use "CMD + /" to comment-out or uncomment a block before the deployment
 # ------------------------------------------------------------------------
 
-# Use this configuration to configure absolute capacities for yunikorn queues
-configuration: |
-  partitions:
-    -
-      name: default
-      queues:
-        - name: root
-          submitacl: '*'
-          queues:
-            - name: default
-              resources:
-                guaranteed:
-                  memory: 100G
-                  vcore: 10
-                max:
-                  memory: 100G
-                  vcore: 10
-            - name: prod
-              resources:
-                guaranteed:
-                  memory: 500G
-                  vcore: 50
-                max:
-                  memory: 800G
-                  vcore: 80
-            - name: test
-              resources:
-                guaranteed:
-                  memory: 100G
-                  vcore: 10
-                max:
-                  memory: 800G
-                  vcore: 50
-            - name: dev
-              resources:
-                guaranteed:
-                  memory: 100G
-                  vcore: 10
-                max:
-                  memory: 100G
-                  vcore: 10
+# YuniKorn service configuration values. These are rendered to the yunikorn-defaults ConfigMap
+yunikornDefaults:
+  # The default volume bind timeout value of 10 seconds may be too short for EBS.
+  service.volumeBindTimeout: "60s"
+  # Use this configuration to configure absolute capacities for yunikorn queues
+  queues.yaml: |
+    partitions:
+      - name: default
+        queues:
+          - name: root
+            submitacl: '*'
+            queues:
+              - name: default
+                resources:
+                  guaranteed:
+                    memory: 100G
+                    vcore: 10
+                  max:
+                    memory: 100G
+                    vcore: 10
+              - name: prod
+                resources:
+                  guaranteed:
+                    memory: 500G
+                    vcore: 50
+                  max:
+                    memory: 800G
+                    vcore: 80
+              - name: test
+                resources:
+                  guaranteed:
+                    memory: 100G
+                    vcore: 10
+                  max:
+                    memory: 800G
+                    vcore: 50
+              - name: dev
+                resources:
+                  guaranteed:
+                    memory: 100G
+                    vcore: 10
+                  max:
+                    memory: 100G
+                    vcore: 10


### PR DESCRIPTION
### What does this PR do?

This PR does:
1. Increase the volume bind timeout to 60 seconds from default 10 seconds. Sometimes it takes more than 10 seconds for volumes to be provisioned and become ready. 
2. Remove the deprecated setting. [According to the documentation](https://yunikorn.apache.org/docs/user_guide/service_config/#deprecated-settings), `partition` field is now deprecated and was replaced by `yunikornDefaults` field. Note that this is necessary because if both the deprecated parameter and the replacement ConfigMap entry are specified, the ConfigMap entry will take precedence. 



### Motivation

Fixes: #118 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/awslabs/data-on-eks/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR to add a new Add-on for [Terraform EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints) repo (if applicable)
- [ ] Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
