### PR TITLE
Removing link from Adopters page

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -9,6 +9,6 @@ If you are open to others contacting you about your use of Data on EKS on Slack,
 
 ## Adopters (Alphabetical)
 
-| Organization | Description | Contacts | Link |
-| --- | --- | --- | --- |
-| Adobe Inc. | Used EMR on EKS with Karpenter templates in PoC, DEV, QE | `@srikaanthpenugonda` | [Homepage](http://example.com)
+| Organization | Description | Contacts |
+| --- | --- | --- | 
+| Adobe Inc. | Used EMR on EKS with Karpenter templates in PoC, DEV, QE | `@srikaanthpenugonda` | 


### PR DESCRIPTION
Removing link from adopters

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/awslabs/data-on-eks/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR to add a new Add-on for [Terraform EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints) repo (if applicable)
- [ ] Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
