### PR TITLE
Fix documentation error in ray pytorch example

### DIFF
--- a/website/docs/ai-ml/ray.md
+++ b/website/docs/ai-ml/ray.md
@@ -289,7 +289,7 @@ pytorch-kuberay-head-9tx56   0/2     Pending   0          43s
 Once running, we can forward the port for server, taking care that we foward it to another local port as 8265 may be occupied by the xgboost connection.
 
 ```bash
-kubectl port-forward service/xgboost-kuberay-head-svc -n pytorch 8265:8266
+kubectl port-forward service/pytorch-kuberay-head-svc -n pytorch 8265:8266
 ```
 
 We can then submit the job for PyTorch benchmark workload.


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

It fixes an error in the documentation for the ray pytorch example, specifically in the port-forwarding call.

### Motivation

It's an easy fix I noticed while implementing the example.

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I didn't run any tests since it's a simple documentation fix.
