### PR TITLE
Fix region mismatch in XGBoost example

### DIFF
--- a/ai-ml/ray/terraform/examples/xgboost/main.tf
+++ b/ai-ml/ray/terraform/examples/xgboost/main.tf
@@ -33,7 +33,7 @@ data "aws_eks_cluster" "this" {
 }
 
 locals {
-  region      = "us-east-1"
+  region      = var.region
   name        = "xgboost"
   eks_cluster = "ray-cluster"
 }

--- a/ai-ml/ray/terraform/examples/xgboost/variables.tf
+++ b/ai-ml/ray/terraform/examples/xgboost/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "region"
+  type        = string
+  default     = "us-west-2"
+}


### PR DESCRIPTION
### What does this PR do?

The Ray on EKS terraform module deploys to us-west-2 by default. The XGBoost example project declared us-east-1 as the region.

This commit moves the variable to variables.tf and defaults it to us-west-2.

Fixes #203 

### Motivation

It's broke yo

### More

- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested locally with `terraform plan`
