### PR TITLE
Fix region mismatch in pytorch example

### DIFF
--- a/ai-ml/ray/terraform/examples/pytorch/main.tf
+++ b/ai-ml/ray/terraform/examples/pytorch/main.tf
@@ -33,7 +33,7 @@ data "aws_eks_cluster" "this" {
 }
 
 locals {
-  region      = "us-east-1"
+  region      = var.region
   name        = "pytorch"
   eks_cluster = "ray-cluster"
 }

--- a/ai-ml/ray/terraform/examples/pytorch/variables.tf
+++ b/ai-ml/ray/terraform/examples/pytorch/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "region"
+  type        = string
+  default     = "us-west-2"
+}


### PR DESCRIPTION
### What does this PR do?
The Ray on EKS module deploys to us-west-2, the example application attempts to target us-east-1.

This commit moves the region to variables and corrects the mismatch.

### Motivation

Fixing it :)

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
