### PR TITLE
Fix ray example docs

### DIFF
--- a/ai-ml/ray/terraform/examples/pytorch/job/pytorch_submit.py
+++ b/ai-ml/ray/terraform/examples/pytorch/job/pytorch_submit.py
@@ -1,6 +1,8 @@
 from ray.job_submission import JobSubmissionClient
 
-client = JobSubmissionClient("http://127.0.0.1:8266")
+address = "http://127.0.0.1:8266"
+
+client = JobSubmissionClient(address)
 
 kick_off_pytorch_benchmark = (
     # Clone ray. If ray is already present, don't clone again.
@@ -15,4 +17,4 @@ submission_id = client.submit_job(
 )
 
 print("Use the following command to follow this Job's logs:")
-print(f"ray job logs '{submission_id}' --follow")
+print(f"ray job logs '{submission_id}' --follow --address {address}")

--- a/ai-ml/ray/terraform/examples/xgboost/job/xgboost_submit.py
+++ b/ai-ml/ray/terraform/examples/xgboost/job/xgboost_submit.py
@@ -1,6 +1,8 @@
 from ray.job_submission import JobSubmissionClient
 
-client = JobSubmissionClient("http://127.0.0.1:8265")
+address = "http://127.0.0.1:8265"
+
+client = JobSubmissionClient(address)
 
 kick_off_xgboost_benchmark = (
     # Clone ray. If ray is already present, don't clone again.
@@ -16,4 +18,4 @@ submission_id = client.submit_job(
 )
 
 print("Use the following command to follow this Job's logs:")
-print(f"ray job logs '{submission_id}' --follow")
+print(f"ray job logs '{submission_id}' --follow --address {address}")

--- a/website/docs/ai-ml/ray.md
+++ b/website/docs/ai-ml/ray.md
@@ -289,7 +289,7 @@ pytorch-kuberay-head-9tx56   0/2     Pending   0          43s
 Once running, we can forward the port for server, taking care that we foward it to another local port as 8265 may be occupied by the xgboost connection.
 
 ```bash
-kubectl port-forward service/pytorch-kuberay-head-svc -n pytorch 8265:8266
+kubectl port-forward service/pytorch-kuberay-head-svc -n pytorch 8266:8265
 ```
 
 We can then submit the job for PyTorch benchmark workload.


### PR DESCRIPTION
### What does this PR do?

This PR does two things.
1) Update the 'ray job logs' prompts at the end of the submit scripts for both pytorch and xgboost to include the --address arg.
2) Fix the port-forward ports on the pytorch example. We want locahost:8266 to forward to the pod at 8265.

### Motivation

Getting the docs to line up with the expected behavior

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
