### PR TITLE
Reduce the number of times we run apply

### DIFF
--- a/ai-ml/emr-spark-rapids/install.sh
+++ b/ai-ml/emr-spark-rapids/install.sh
@@ -20,8 +20,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -auto-approve
-  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -32,8 +31,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -auto-approve
-apply_output=$(terraform apply -auto-approve 2>&1)
+apply_output=$(terraform apply -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/ai-ml/ray/terraform/install.sh
+++ b/ai-ml/ray/terraform/install.sh
@@ -5,8 +5,7 @@ terraform init || echo "\"terraform init\" failed"
 
 
 echo "Applying ..."
-terraform apply -auto-approve
-apply_output=$(terraform apply -auto-approve 2>&1)
+apply_output=$(terraform apply -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply completed successfully"
 else

--- a/analytics/terraform/datahub-on-eks/install.sh
+++ b/analytics/terraform/datahub-on-eks/install.sh
@@ -24,8 +24,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -auto-approve
-  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -36,8 +35,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -auto-approve
-apply_output=$(terraform apply -auto-approve 2>&1)
+apply_output=$(terraform apply -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/analytics/terraform/emr-eks-ack/install.sh
+++ b/analytics/terraform/emr-eks-ack/install.sh
@@ -21,8 +21,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -var="region=$region" -auto-approve
-  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -33,8 +32,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -var="region=$region" -auto-approve
-apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1)
+apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/analytics/terraform/emr-eks-fargate/install.sh
+++ b/analytics/terraform/emr-eks-fargate/install.sh
@@ -16,8 +16,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -var="region=$region" -auto-approve
-  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -28,8 +27,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -var="region=$region" -auto-approve
-apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1)
+apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/analytics/terraform/emr-eks-karpenter/install.sh
+++ b/analytics/terraform/emr-eks-karpenter/install.sh
@@ -21,8 +21,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -auto-approve
-  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -33,8 +32,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -auto-approve
-apply_output=$(terraform apply -auto-approve 2>&1)
+apply_output=$(terraform apply -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/analytics/terraform/spark-k8s-operator/install.sh
+++ b/analytics/terraform/spark-k8s-operator/install.sh
@@ -21,8 +21,7 @@ terraform init --upgrade
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -var="region=$region" -auto-approve
-  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -33,8 +32,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -var="region=$region" -auto-approve
-apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1)
+apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/distributed-databases/cloudnative-postgres/install.sh
+++ b/distributed-databases/cloudnative-postgres/install.sh
@@ -21,8 +21,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -var="region=$region" -auto-approve
-  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -33,8 +32,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -var="region=$region" -auto-approve
-apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1)
+apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/streaming/flink/install.sh
+++ b/streaming/flink/install.sh
@@ -20,8 +20,7 @@ terraform init --upgrade
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -var="region=$region" -auto-approve
-  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -32,8 +31,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -var="region=$region" -auto-approve
-apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1)
+apply_output=$(terraform apply -var="region=$region" -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/streaming/kafka/install.sh
+++ b/streaming/kafka/install.sh
@@ -15,8 +15,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -auto-approve
-  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -27,8 +26,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -auto-approve
-apply_output=$(terraform apply -auto-approve 2>&1)
+apply_output=$(terraform apply -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else

--- a/workshop/emr-eks/install.sh
+++ b/workshop/emr-eks/install.sh
@@ -15,8 +15,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  terraform apply -target="$target" -auto-approve
-  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1)
+  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1 | tee /dev/tty)
   if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -27,8 +26,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-terraform apply -auto-approve
-apply_output=$(terraform apply -auto-approve 2>&1)
+apply_output=$(terraform apply -auto-approve 2>&1 | tee /dev/tty)
 if [[ $? -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else


### PR DESCRIPTION
### What does this PR do?

The current implementation of the install scripts runs `terraform apply` 2 times per terraform module using -target. Additionally apply is run
  again 2 more times at the end of the script.

This means that we are running terraform apply twice as much as required.

This commit adds ` | tee /dev/tty` to all the apply steps so that the output can be captured and evaluated, as well as having the output print to screen.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

