### PR TITLE
Update Kafka with remote Amazon Managed Prometheus for kube-prometheus-stack 

### DIFF
--- a/streaming/kafka/README.md
+++ b/streaming/kafka/README.md
@@ -21,11 +21,13 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.14 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_amp_ingest_irsa"></a> [amp\_ingest\_irsa](#module\_amp\_ingest\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.20 |
 | <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.20 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.13 |
 | <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | ~> 1.0 |
@@ -37,14 +39,19 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 | Name | Type |
 |------|------|
+| [aws_prometheus_workspace.amp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_workspace) | resource |
+| [aws_secretsmanager_secret.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [kubectl_manifest.grafana_strimzi_dashboard](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.kafka_cluster](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.podmonitor_metrics](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_annotations.gp2_default](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [kubernetes_namespace.kafka_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_storage_class.ebs_csi_encrypted_gp3_storage_class](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class) | resource |
+| [random_password.grafana](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_secretsmanager_secret_version.admin_password_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [kubectl_path_documents.grafana_strimzi_dashboard](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
 | [kubectl_path_documents.kafka_cluster](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
 | [kubectl_path_documents.podmonitor_metrics](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
@@ -54,6 +61,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | EKS Cluster version | `string` | `"1.27"` | no |
+| <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the VPC and EKS Cluster | `string` | `"kafka-on-eks"` | no |
 | <a name="input_region"></a> [region](#input\_region) | region | `string` | `"us-west-2"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | VPC CIDR | `string` | `"10.1.0.0/16"` | no |

--- a/streaming/kafka/amp.tf
+++ b/streaming/kafka/amp.tf
@@ -1,0 +1,36 @@
+#------------------------------------------
+# Amazon Prometheus
+#------------------------------------------
+locals {
+  amp_ingest_service_account = "amp-iamproxy-ingest-service-account"
+  amp_namespace              = "kube-prometheus-stack"
+}
+
+resource "aws_prometheus_workspace" "amp" {
+  count = var.enable_amazon_prometheus ? 1 : 0
+
+  alias = format("%s-%s", "amp-ws", local.name)
+  tags  = local.tags
+}
+
+#---------------------------------------------------------------
+# IRSA for VPC AMP
+#---------------------------------------------------------------
+module "amp_ingest_irsa" {
+  count = var.enable_amazon_prometheus ? 1 : 0
+
+  source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version   = "~> 5.20"
+  role_name = format("%s-%s", local.name, "amp-ingest")
+
+  attach_amazon_managed_service_prometheus_policy  = true
+  amazon_managed_service_prometheus_workspace_arns = [aws_prometheus_workspace.amp[0].arn]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["${local.amp_namespace}:${local.amp_ingest_service_account}"]
+    }
+  }
+  tags = local.tags
+}

--- a/streaming/kafka/helm-values/prom-grafana-values.yaml
+++ b/streaming/kafka/helm-values/prom-grafana-values.yaml
@@ -1,21 +1,32 @@
 prometheus:
   prometheusSpec:
-    serviceMonitorSelectorNilUsesHelmValues: false
-    podMonitorSelectorNilUsesHelmValues: false
-    serviceMonitorSelector: {}
-    serviceMonitorNamespaceSelector: {}
+#    serviceMonitorSelectorNilUsesHelmValues: false
+#    podMonitorSelectorNilUsesHelmValues: false
+    retention: 5h
+#    remoteWrite: 
+#      - queueConfig:
+#          max_samples_per_send: 1000
+#          max_shards: 200
+#          capacity: 2500
+    scrapeInterval: 30s
+    evaluationInterval: 30s
+    scrapeTimeout: 10s
+
+#    serviceMonitorSelector: {}
+#    serviceMonitorNamespaceSelector: {}
+alertmanager:
+ enabled: false
+
 grafana:
   enabled: true
-  adminUser: admin
-  #adminPassword: secret
   defaultDashboardsEnabled: false
   # -- Additional plugins to be installed during Grafana startup,
   # `grafana-polystat-panel` is used by the default Cassandra dashboards.
-  plugins:
-    - grafana-polystat-panel
-  grafana.ini: {}
-  image:
-    repository: grafana/grafana
-    tag: 7.5.11
-    sha: ""
-    pullPolicy: IfNotPresent
+#  plugins:
+#    - grafana-polystat-panel
+#  grafana.ini: {}
+#  image:
+#    repository: grafana/grafana
+#    tag: 7.5.11
+#    sha: ""
+#    pullPolicy: IfNotPresent

--- a/streaming/kafka/helm-values/prom-grafana-values.yaml
+++ b/streaming/kafka/helm-values/prom-grafana-values.yaml
@@ -1,32 +1,11 @@
 prometheus:
   prometheusSpec:
-#    serviceMonitorSelectorNilUsesHelmValues: false
-#    podMonitorSelectorNilUsesHelmValues: false
     retention: 5h
-#    remoteWrite: 
-#      - queueConfig:
-#          max_samples_per_send: 1000
-#          max_shards: 200
-#          capacity: 2500
     scrapeInterval: 30s
     evaluationInterval: 30s
     scrapeTimeout: 10s
-
-#    serviceMonitorSelector: {}
-#    serviceMonitorNamespaceSelector: {}
 alertmanager:
  enabled: false
-
 grafana:
   enabled: true
   defaultDashboardsEnabled: false
-  # -- Additional plugins to be installed during Grafana startup,
-  # `grafana-polystat-panel` is used by the default Cassandra dashboards.
-#  plugins:
-#    - grafana-polystat-panel
-#  grafana.ini: {}
-#  image:
-#    repository: grafana/grafana
-#    tag: 7.5.11
-#    sha: ""
-#    pullPolicy: IfNotPresent

--- a/streaming/kafka/variables.tf
+++ b/streaming/kafka/variables.tf
@@ -21,3 +21,9 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.1.0.0/16"
 }
+
+variable "enable_amazon_prometheus" {
+  description = "Enable AWS Managed Prometheus service"
+  type        = bool
+  default     = true
+}

--- a/website/docs/blueprints/streaming-platforms/kafka.md
+++ b/website/docs/blueprints/streaming-platforms/kafka.md
@@ -242,10 +242,11 @@ kubectl port-forward svc/kube-prometheus-stack-grafana 8080:80 -n kube-prometheu
 ```
 Open browser with local [Grafana Web UI](http://localhost:8080/)
 
-Enter username as `admin` and **password** can be extracted from the below command.
+Enter username as `admin` and **password** can be extracted from AWS Secrets Manager with the below command.
 
 ```bash
-kubectl get secret kube-prometheus-stack-grafana -n kube-prometheus-stack -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+aws secretsmanager get-secret-value \
+    --secret-id kafka-on-eks-grafana --region $AWS_REGION --query "SecretString" --output text
 ```
 
 ### Open Strimzi Kafka Dashboard


### PR DESCRIPTION
### What does this PR do?

- Update Kafka blueprint with remote optional Amazon Managed Prometheus for kube-prometheus-stack
- Create the secret for Grafana Dashboard using AWS Secrets Manager

### Motivation

Adding the option for customers to use existing Prometheus instance

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
