### PR TITLE
update karpenter provisioner

### DIFF
--- a/ai-ml/trainium-inferentia/karpenter-provisioners/trainium-provisioner.yaml
+++ b/ai-ml/trainium-inferentia/karpenter-provisioners/trainium-provisioner.yaml
@@ -15,27 +15,17 @@ spec:
     - key: "karpenter.sh/capacity-type"
       operator: In
       values: ["spot", "on-demand"]
-    - key: "node.kubernetes.io/instance-family" #If not included, all instance types are considered
+    - key: karpenter.k8s.aws/instance-family
       operator: In
-      values: ["trn1n"] # trn1.2xlarge, trn1n.32xlarge
-    - key: "node.kubernetes.io/instance-type" #If not included, all instance types are considered
-      operator: In
-      values: ["trn1.32xlarge"] # trn1.2xlarge, trn1n.32xlarge
-    - key: "kubernetes.io/arch"
-      operator: In
-      values: ["amd64"]
+      values: ["trn1n"] 
   limits:
   providerRef:
     name: trainium
   labels:
     type: karpenter
     provisioner: trainium
-    WorkerType: trn1-32xl
-    NodeGroupType: trainium-karpenter
-  taints:
-    - key: trainium-karpenter
-      value: 'true'
-      effect: NoSchedule
+    #WorkerType: trn1-32xl
+    #NodeGroupType: trainium-karpenter
   ttlSecondsAfterEmpty: 120 # optional, but never scales down if not set
 
 # TODO: Network interface configuraiton for 8 network interfaces
@@ -65,12 +55,6 @@ spec:
   #  instanceProfile: ""      # optional, if already set in controller args
   #RAID0 config example
   userData: |
-    MIME-Version: 1.0
-    Content-Type: multipart/mixed; boundary="BOUNDARY"
-
-    --BOUNDARY
-    Content-Type: text/x-shellscript; charset="us-ascii"
-
     #!/bin/bash
     echo "Running a custom user data script"
     # Configure NVMe volumes in RAID0 configuration
@@ -83,35 +67,40 @@ spec:
     export PATH=/opt/aws/neuron/bin:$PATH
 
     # Create 8 network interfaces similar to Terraform configuration
-    INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+    TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+    INSTANCE_ID=`curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id`
+    echo INSTANCE_ID=${INSTANCE_ID}
+    SUBNET_ID=`curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/network/interfaces/macs/${INSTANCE_MACS}/subnet-id`
+    echo SUBNET_ID=${SUBNET_ID}
 
-    # Create network interface with device_index = 0
-    INTERFACE_ID=$(aws ec2 create-network-interface \
-      --description "NetworkInterfaces Configuration For EFA and EKS" \
-      --delete-on-termination \
-      --query 'NetworkInterface.NetworkInterfaceId' \
-      --output text
-    )
-    aws ec2 attach-network-interface \
-      --network-interface-id $INTERFACE_ID \
-      --instance-id $INSTANCE_ID \
-      --device-index 0 \
-      --network-card-index 0
+    #INTERFACE_ID=$(aws ec2 create-network-interface \
+    #  --description "NetworkInterfaces Configuration For EFA and EKS" \
+    #  --delete-on-termination \
+    #  --query 'NetworkInterface.NetworkInterfaceId' \
+    #  --output text
+    #)
+    #aws ec2 attach-network-interface \
+    #  --network-interface-id $INTERFACE_ID \
+    #  --instance-id $INSTANCE_ID \
+    #  --device-index 0 \
+    #  --network-card-index 0
 
     # Create network interfaces with device_index = 1 and network_card_index from 1 to 7
     for ((network_card_index=1; network_card_index<8; network_card_index++))
     do
       INTERFACE_ID=$(aws ec2 create-network-interface \
         --description "NetworkInterfaces Configuration For EFA and EKS" \
-        --delete-on-termination \
+        --subnet-id $SUBNET_ID \
         --query 'NetworkInterface.NetworkInterfaceId' \
         --output text
       )
       aws ec2 attach-network-interface \
         --network-interface-id $INTERFACE_ID \
         --instance-id $INSTANCE_ID \
-        --device-index 1 \
+        --device-index $network_card_index \
         --network-card-index $network_card_index
+
+      echo Attached interface ${INTERFACE_ID} to device-index $network_card_index and network-card-index $network_card_index in instance $INSTANCE_ID
     done
 
     # EFA Setup for Trainium and Inferentia


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
https://github.com/awslabs/data-on-eks/issues/288

<!-- What inspired you to submit this pull request? -->

### More
* No need for `kubeletConfiguration` default is containerd

* Use `karpenter.k8s.aws/instance-family` instead of `node.kubernetes.io/instance-family` no need for `kubernetes.io/arch` BTW `beta.kubernetes.io/arch` trn1n is amd64.

* Commenting the labels `WorkerType: trn1-32xl` and `NodeGroupType: trainium-karpenter` create unnecessary dependency between node group and individual ec2 instances. 

* Removed MIME-Version, Content-Type, --BOUNDARY and Content-Type. Those are appended by kapenter now. 

* Adopting IMDSv2 (add Token) 

* Not sure why we need --device-index 0, vpc-cni takes device 0. Commenting but good idea to remove 

* update create-network-interface - remove `--delete-on-termination` not needed; Add subnet-id because it is required.

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
