### PR TITLE
fix spark operator installation script

### DIFF
--- a/analytics/terraform/spark-k8s-operator/install.sh
+++ b/analytics/terraform/spark-k8s-operator/install.sh
@@ -7,8 +7,6 @@ export AWS_DEFAULT_REGION=$region
 targets=(
   "module.vpc"
   "module.eks"
-  "module.eks_blueprints_addons"
-  "module.eks_data_addons"
 )
 
 # Initialize Terraform


### PR DESCRIPTION
### What does this PR do?

Removes explicit ordering of modules in the spark operator installation script. 

fixes #310 


### Motivation

The installation script for Spark Operator is broken. see #310 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
