### PR TITLE
fix: Disable service mutation webhook when deploying LBC in jark-stack

### DIFF
--- a/ai-ml/jark-stack/terraform/addons.tf
+++ b/ai-ml/jark-stack/terraform/addons.tf
@@ -88,6 +88,14 @@ module "eks_blueprints_addons" {
   # AWS Load Balancer Controller Add-on
   #---------------------------------------
   enable_aws_load_balancer_controller = true
+  # turn off the mutating webhook for services because we are using
+  # service.beta.kubernetes.io/aws-load-balancer-type: external
+  aws_load_balancer_controller = {
+    set = [{
+      name  = "enableServiceMutatorWebhook"
+      value = "false"
+    }]
+  }
 
   #---------------------------------------
   # Ingress Nginx Add-on


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Sets `enableServiceMutatorWebhook` to `false` in Load Balancer because to work around the ordering issue as observed in  https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/233. Another possible workaround is to use an Ingress but this seems good enough for this blueprint.

### Motivation

Noticed an internal error on install as seen in https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/233

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
