### PR TITLE
fix: Modify kubectl_manifest resource to depoloy volcano and torchx e…

### DIFF
--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -239,11 +239,13 @@ data "http" "torchx_etcd_yaml" {
   url = "https://raw.githubusercontent.com/pytorch/torchx/main/resources/etcd.yaml"
 }
 
-resource "kubectl_manifest" "torchx_etcd" {
-  yaml_body = <<-YAML
-    ${data.http.torchx_etcd_yaml.response_body}
-  YAML
+data "kubectl_file_documents" "torchx_etcd_yaml" {
+  content = data.http.torchx_etcd_yaml.response_body
+}
 
+resource "kubectl_manifest" "torchx_etcd" {
+  for_each  = data.kubectl_file_documents.torchx_etcd_yaml.manifests
+  yaml_body = each.value
   depends_on = [module.eks.eks_cluster_id]
 }
 
@@ -251,15 +253,19 @@ resource "kubectl_manifest" "torchx_etcd" {
 # Volcano Schduler for TorchX
 # NOTE: This will be replaced with Helm Chart deployment with eks_data_addons
 #---------------------------------------------------------------
+
 data "http" "volcano_development_yaml" {
   url = "https://raw.githubusercontent.com/volcano-sh/volcano/master/installer/volcano-development.yaml"
 }
 
-resource "kubectl_manifest" "volcano" {
-  yaml_body = <<-YAML
-    ${data.http.volcano_development_yaml.response_body}
-  YAML
+data "kubectl_file_documents" "volcano_development_yaml" {
+  content = data.http.volcano_development_yaml.response_body
+}
 
+resource "kubectl_manifest" "volcano" {
+  for_each  = data.kubectl_file_documents.volcano_development_yaml.manifests
+  yaml_body = each.value
+  server_side_apply = true
   depends_on = [module.eks.eks_cluster_id]
 }
 


### PR DESCRIPTION
…tcd from remote url

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

kubectl_manifest resource only supports a single yaml resource. Because of this, volcano and torchx etcd yaml files (from a URL) are not deployed in the cluster. This PR uses kubectl_file_documents to fix this Issue. 

### Motivation

Discussed this Issue with Vara and providing the fix

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
