### PR TITLE
fix: Updated karpenter compute provisioner profile with traints

### DIFF
--- a/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-1t.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-1t.yaml
@@ -88,6 +88,10 @@ spec:
     serviceAccount: spark-team-a
     nodeSelector:
       provisioner: spark-compute-optimized
+    tolerations:
+      - key: "spark-compute-optimized"
+        operator: "Exists"
+        effect: "NoSchedule"
   executor:
     volumeMounts:
       - name: spark-local-dir-1
@@ -109,6 +113,9 @@ spec:
     serviceAccount: spark-team-a
     nodeSelector:
       provisioner: spark-compute-optimized
-
+    tolerations:
+      - key: "spark-compute-optimized"
+        operator: "Exists"
+        effect: "NoSchedule"
   restartPolicy:
     type: Never

--- a/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-data-generation-1t.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-data-generation-1t.yaml
@@ -86,7 +86,10 @@ spec:
     serviceAccount: spark-team-a
     nodeSelector:
       provisioner: spark-compute-optimized
-
+    tolerations:
+      - key: "spark-compute-optimized"
+        operator: "Exists"
+        effect: "NoSchedule"
   executor:
     volumeMounts:
       - name: spark-local-dir-1
@@ -107,3 +110,7 @@ spec:
     serviceAccount: spark-team-a
     nodeSelector:
       provisioner: spark-compute-optimized
+    tolerations:
+      - key: "spark-compute-optimized"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/analytics/terraform/spark-k8s-operator/karpenter-provisioners/spark-compute-optimized-provisioner.yaml
+++ b/analytics/terraform/spark-k8s-operator/karpenter-provisioners/spark-compute-optimized-provisioner.yaml
@@ -29,6 +29,11 @@ spec:
   labels:
     type: karpenter
     provisioner: spark-compute-optimized
+    NodeGroupType: SparkComputeOptimized
+  taints:
+    - key: spark-compute-optimized
+      value: 'true'
+      effect: NoSchedule
   ttlSecondsAfterEmpty: 120 # optional, but never scales down if not set
 
 ---


### PR DESCRIPTION


### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

fixes issue #329

- Fixed the karpenter provisioner issue to support examples

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
