### PR TITLE
fix: Adds a conditional to check for amiFamily to use the right deviceName

### DIFF
--- a/ai-ml/jupyterhub/helm/karpenter-resources/templates/aws-node-template.yaml
+++ b/ai-ml/jupyterhub/helm/karpenter-resources/templates/aws-node-template.yaml
@@ -5,7 +5,11 @@ metadata:
 spec:
   amiFamily: {{ .Values.amiFamily }}
   blockDeviceMappings:
-    - deviceName: /dev/sda1
+    - {{ if eq .Values.amiFamily "Ubuntu" }}
+      deviceName: /dev/sda1
+      {{ else }}
+      deviceName: /dev/xvda
+      {{ end }}
       ebs:
         volumeSize: 200Gi # Big disk for Notebook instances
         volumeType: gp3


### PR DESCRIPTION
### What does this PR do?

Add a check in helm template to use the right `deviceName` in `awsnodetemplate`. 


### Motivation


### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
