### PR TITLE
fix: Use correct instanceFamily for Trainium

### DIFF
--- a/ai-ml/jupyterhub/addons.tf
+++ b/ai-ml/jupyterhub/addons.tf
@@ -237,8 +237,8 @@ module "eks_blueprints_addons" {
         <<-EOT
           name: trainium
           clusterName: ${module.eks.cluster_name}
-          instanceSizes: ["2xlarge", "32xlarge"]
-          instanceFamilies: ["inf2"]
+          instanceSizes: ["32xlarge"]
+          instanceFamilies: ["trn1"]
           taints:
             - key: aws.amazon.com/neuroncore
               value: "true"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
Uses correct instance family in the karpenter provisioner for Trainium instances.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
