### PR TITLE
fix: Automate init and pass Default Region for data-on-eks/streaming/kafka/install.sh

### DIFF
--- a/streaming/kafka/cleanup.sh
+++ b/streaming/kafka/cleanup.sh
@@ -13,7 +13,7 @@ targets=(
 for target in "${targets[@]}"
 do
   terraform destroy -target="$target" -auto-approve
-  destroy_output=$(terraform destroy -target="$target" -auto-approve 2>&1)
+  destroy_output=$(terraform destroy -target="$target" -var=region=$(aws configure get region)  -auto-approve 2>&1)
   if [[ $? -eq 0 && $destroy_output == *"Destroy complete!"* ]]; then
     echo "SUCCESS: Terraform destroy of $target completed successfully"
   else
@@ -23,7 +23,7 @@ do
 done
 
 terraform destroy -auto-approve
-destroy_output=$(terraform destroy -auto-approve 2>&1)
+destroy_output=$(terraform destroy -var=region=$(aws configure get region) -auto-approve 2>&1)
 if [[ $? -eq 0 && $destroy_output == *"Destroy complete!"* ]]; then
   echo "SUCCESS: Terraform destroy of all targets completed successfully"
 else

--- a/streaming/kafka/install.sh
+++ b/streaming/kafka/install.sh
@@ -12,6 +12,10 @@ targets=(
   "module.eks_data_addons"
 )
 
+# Initialize Terraform
+echo "Initializing Terraform..."
+terraform init
+
 # Apply modules in sequence
 for target in "${targets[@]}"
 do

--- a/streaming/kafka/install.sh
+++ b/streaming/kafka/install.sh
@@ -16,7 +16,7 @@ targets=(
 for target in "${targets[@]}"
 do
   echo "Applying module $target..."
-  apply_output=$(terraform apply -target="$target" -auto-approve 2>&1 | tee /dev/tty)
+  apply_output=$(terraform apply -target="$target" -var=region=$(aws configure get region) -auto-approve 2>&1 | tee /dev/tty)
   if [[ ${PIPESTATUS[0]} -eq 0 && $apply_output == *"Apply complete"* ]]; then
     echo "SUCCESS: Terraform apply of $target completed successfully"
   else
@@ -27,7 +27,7 @@ done
 
 # Final apply to catch any remaining resources
 echo "Applying remaining resources..."
-apply_output=$(terraform apply -auto-approve 2>&1 | tee /dev/tty)
+apply_output=$(terraform apply -var=region=$(aws configure get region) -auto-approve 2>&1 | tee /dev/tty)
 if [[ ${PIPESTATUS[0]} -eq 0 && $apply_output == *"Apply complete"* ]]; then
   echo "SUCCESS: Terraform apply of all modules completed successfully"
 else


### PR DESCRIPTION
In data-on-eks/streaming/kafka/install.sh

When using Terraform the AWS_DEFAULT_REGION is not recognised. We are fetching the default with the aws cli as it is a prerequisite. Then passing as a variable. 

This caused the default variable to take presidence causing the cluster to be deployed to "us-west-2"

Added to cleanup.sh for consistency