### PR TITLE
Update main.tf

### DIFF
--- a/ai-ml/ray/terraform/main.tf
+++ b/ai-ml/ray/terraform/main.tf
@@ -196,7 +196,9 @@ module "karpenter" {
   cluster_name                 = module.eks.cluster_name
   irsa_oidc_provider_arn       = module.eks.oidc_provider_arn
   create_irsa                  = false # IRSA will be created by the kubernetes-addons module
-  iam_role_additional_policies = [module.karpenter_policy.arn]
+  iam_role_additional_policies = {
+    additional_policy = module.karpenter_policy.arn
+  }
 
   tags = local.tags
 }


### PR DESCRIPTION
Fixed issue with expected map(string) for karpenter additional IAM policies

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Fixed issue with expected map(string) for karpenter additional IAM policies

```
│ Error: Invalid value for input variable
│
│   on main.tf line 199, in module "karpenter":
│  199:   iam_role_additional_policies = [module.karpenter_policy.arn]
│
│ The given value is not suitable for
│ module.karpenter.var.iam_role_additional_policies declared at
│ .terraform/modules/karpenter/modules/karpenter/variables.tf:224,1-40: map
│ of string required.
```

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
