### PR TITLE
fix: Changed Karpenter provisioner name to match the correct instance type

### DIFF
--- a/ai-ml/jupyterhub/addons.tf
+++ b/ai-ml/jupyterhub/addons.tf
@@ -187,12 +187,12 @@ module "eks_blueprints_addons" {
       ]
     }
     karpenter-resources-mig = {
-      name        = "karpenter-resources-mig"
-      description = "A Helm chart for karpenter GPU based resources - compatible with GPU MIG"
+      name        = "karpenter-resources-gpu"
+      description = "A Helm chart for karpenter GPU based resources - compatible with P4d instances"
       chart       = "${path.module}/helm/karpenter-resources"
       values = [
         <<-EOT
-          name: gpu-mig
+          name: gpu
           clusterName: ${module.eks.cluster_name}
           instanceSizes: ["24xlarge"]
           instanceFamilies: ["p4d"]

--- a/ai-ml/jupyterhub/helm/jupyterhub/jupyterhub-values-cognito.yaml
+++ b/ai-ml/jupyterhub/helm/jupyterhub/jupyterhub-values-cognito.yaml
@@ -196,7 +196,7 @@ singleuser:
         image: cschranz/gpu-jupyter:v1.5_cuda-11.6_ubuntu-20.04_python-only
         node_selector:
           node.kubernetes.io/instance-type: p4d.24xlarge
-          karpenter.sh/provisioner-name: gpu-p4d
+          karpenter.sh/provisioner-name: gpu
         tolerations:
           - key: "nvidia.com/gpu"
             operator: "Exists"

--- a/ai-ml/jupyterhub/helm/jupyterhub/jupyterhub-values-dummy.yaml
+++ b/ai-ml/jupyterhub/helm/jupyterhub/jupyterhub-values-dummy.yaml
@@ -177,7 +177,7 @@ singleuser:
         image: cschranz/gpu-jupyter:v1.5_cuda-11.6_ubuntu-20.04_python-only
         node_selector:
           node.kubernetes.io/instance-type: p4d.24xlarge
-          karpenter.sh/provisioner-name: gpu-p4d
+          karpenter.sh/provisioner-name: gpu
         tolerations:
           - key: "nvidia.com/gpu"
             operator: "Exists"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

As discussed with Vara, change Karpenter provisioner to match the right instance profile in JupyterHub.

### Motivation

PR needed for Blog publication.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

None
