### PR TITLE
feat: MPI operator installation code for distributed training use case

### DIFF
--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -499,3 +499,20 @@ resource "aws_launch_template" "trn1_lt" {
     }
   }
 }
+
+#---------------------------------------------------------------
+# MPI Operator for distributed training on Trainium
+#---------------------------------------------------------------
+data "http" "mpi_operator_yaml" {
+  url = "https://raw.githubusercontent.com/kubeflow/mpi-operator/${var.mpi_operator_version}/deploy/v2beta1/mpi-operator.yaml"
+}
+
+data "kubectl_file_documents" "mpi_operator_yaml" {
+  content = data.http.mpi_operator_yaml.response_body
+}
+
+resource "kubectl_manifest" "mpi_operator" {
+  for_each   = data.kubectl_file_documents.mpi_operator_yaml.manifests
+  yaml_body  = each.value
+  depends_on = [module.eks.eks_cluster_id]
+}

--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -512,7 +512,8 @@ data "kubectl_file_documents" "mpi_operator_yaml" {
 }
 
 resource "kubectl_manifest" "mpi_operator" {
-  for_each   = data.kubectl_file_documents.mpi_operator_yaml.manifests
+  for_each   = var.enable_mpi_operator ? data.kubectl_file_documents.mpi_operator_yaml.manifests : {}
   yaml_body  = each.value
   depends_on = [module.eks.eks_cluster_id]
 }
+

--- a/ai-ml/trainium-inferentia/variables.tf
+++ b/ai-ml/trainium-inferentia/variables.tf
@@ -42,3 +42,9 @@ variable "mpi_operator_version" {
   description = "The version of the MPI Operator to install"
   default     = "v0.4.0"
 }
+
+variable "enable_mpi_operator" {
+  description = "Flag to enable the MPI Operator deployment"
+  type        = bool
+  default     = false
+}

--- a/ai-ml/trainium-inferentia/variables.tf
+++ b/ai-ml/trainium-inferentia/variables.tf
@@ -41,6 +41,7 @@ variable "enable_amazon_prometheus" {
 variable "mpi_operator_version" {
   description = "The version of the MPI Operator to install"
   default     = "v0.4.0"
+  type        = string
 }
 
 variable "enable_mpi_operator" {

--- a/ai-ml/trainium-inferentia/variables.tf
+++ b/ai-ml/trainium-inferentia/variables.tf
@@ -37,3 +37,8 @@ variable "enable_amazon_prometheus" {
   type        = bool
   default     = true
 }
+
+variable "mpi_operator_version" {
+  description = "The version of the MPI Operator to install"
+  default     = "v0.4.0"
+}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
I have added MPI Operator installation. The goal is to use MPI Operator to run allreduce-style distributed training on Amazon EKS.

### Motivation
I am working on a blog that leverages MPI operator for distributed training.

<!-- What inspired you to submit this pull request? -->

### More

- [ Yes] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ No] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ No] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [Yes ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
<img width="935" alt="Screenshot 2023-11-05 at 7 34 43 PM" src="https://github.com/awslabs/data-on-eks/assets/33555557/fd22aee8-7da6-46af-b354-54e1c8dac08b">

I have tested the installation on Amazon EKS 1.27 cluster, MPI operator installation works great.

<!-- Anything else we should know when reviewing? -->
