### PR TITLE
fix: Cleanup VPC as when cleaning jupyterhub

### DIFF
--- a/ai-ml/jupyterhub/cleanup.sh
+++ b/ai-ml/jupyterhub/cleanup.sh
@@ -6,6 +6,7 @@ targets=(
   "module.eks_data_addons"
   "module.eks_blueprints_addons"
   "module.eks"
+  "module.vpc"
 )
 
 #-------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/awslabs/data-on-eks/issues/381

Adds VPC to the cleanup script

### Motivation

Bringing the cluster up and down, I noticed a build-up of VPCs, which ended up causing my `nodeclaim` issue (and spending unnecessary $):

```
`creating instance, with fleet error(s), InvalidParameter: Security group sg-063f3ce9c9129f915 and subnet subnet-03c6b3adbd7c25760 belong to different networks.; InvalidParameter: Security group sg-063f3ce9c9129f915 and subnet subnet-0355df2dfc137557b belong to different networks.
```

I cleaned up those VPCs by hand (which was a little tedious), brought the cluster down, and I think `./cleanup.sh` has actually cleaned up.


### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
