### PR TITLE
Aligned provided output to match the command shown (Ray install validation)

### DIFF
--- a/website/docs/blueprints/ai-ml/ray.md
+++ b/website/docs/blueprints/ai-ml/ray.md
@@ -124,24 +124,8 @@ kubectl get pods -n kuberay-operator
 ```
 :::info
 ```bash
-NAMESPACE            NAME                               READY   STATUS    RESTARTS        AGE
-amazon-cloudwatch    aws-cloudwatch-metrics-d4xrr       1/1     Running   1 (1h37m ago)   1h
-amazon-cloudwatch    aws-cloudwatch-metrics-tpqsz       1/1     Running   1 (1h37m ago)   1h
-amazon-cloudwatch    aws-cloudwatch-metrics-z7wbn       1/1     Running   1 (1h37m ago)   1h
-aws-for-fluent-bit   aws-for-fluent-bit-h82w4           1/1     Running   1 (1h37m ago)   1h
-aws-for-fluent-bit   aws-for-fluent-bit-r5kxt           1/1     Running   1 (1h37m ago)   1h
-aws-for-fluent-bit   aws-for-fluent-bit-wgxxl           1/1     Running   1 (1h37m ago)   1h
-karpenter            karpenter-668c669897-fmxdr         1/1     Running   1 (1h37m ago)   1h
-karpenter            karpenter-668c669897-prbr6         1/1     Running   1 (1h37m ago)   1h
-kube-system          aws-node-fnwp5                     1/1     Running   1 (1h37m ago)   1h
-kube-system          aws-node-r45xd                     1/1     Running   1 (1h37m ago)   1h
-kube-system          aws-node-vfq66                     1/1     Running   1 (1h37m ago)   1h
-kube-system          coredns-79989457d9-2jldd           1/1     Running   1 (1h37m ago)   1h
-kube-system          coredns-79989457d9-cgtkf           1/1     Running   1 (1h37m ago)   1h
-kube-system          kube-proxy-5jrtf                   1/1     Running   1 (1h37m ago)   1h
-kube-system          kube-proxy-fjxsk                   1/1     Running   1 (1h37m ago)   1h
-kube-system          kube-proxy-tzr79                   1/1     Running   1 (1h37m ago)   1h
-kuberay-operator     kuberay-operator-7b5c85998-vfsjr   1/1     Running   1 (1h37m ago)   1h
+NAME                               READY   STATUS    RESTARTS        AGE
+kuberay-operator-7b5c85998-vfsjr   1/1     Running   1 (1h37m ago)   1h
 ```
 :::
 


### PR DESCRIPTION
### What does this PR do?
This PR provides clarity for the verification steps for installing Ray. (It is currently confusing as the output does not match the command suggested)

Command given
```
kubectl get pods -n kuberay-operator
```

output provided
```
NAMESPACE            NAME                               READY   STATUS    RESTARTS        AGE
amazon-cloudwatch    aws-cloudwatch-metrics-d4xrr       1/1     Running   1 (1h37m ago)   1h
amazon-cloudwatch    aws-cloudwatch-metrics-tpqsz       1/1     Running   1 (1h37m ago)   1h
....
```
As you can see the output is showing other namespaces (the output from `kubectl get pods -A` likely.

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

I have cleaned up the example output to match the command.
```
kubectl get pods -n kuberay-operator
NAME                               READY   STATUS    RESTARTS        AGE
kuberay-operator-7b5c85998-vfsjr   1/1     Running   1 (1h37m ago)   1h
```

### Motivation
Accuracy.  Also with this nuanced erroneous output, it gives the impression that you should be seeing numerous pods when you run the command (which is not the case), and as a result, you may conclude (as I had) that there is something wrong.

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
