### PR TITLE
Fixed type for kubectl

### DIFF
--- a/website/docs/blueprints/ai-ml/ray.md
+++ b/website/docs/blueprints/ai-ml/ray.md
@@ -106,7 +106,7 @@ aws eks update-kubeconfig --name ray-cluster #or whatever you used for EKS clust
 First, lets verify that we have worker nodes running in the cluster.
 
 ```bash
-kuebctl get nodes
+kubectl get nodes
 ```
 :::info
 ```bash


### PR DESCRIPTION
### What does this PR do?
Corrects simple typo - "kuebctl" was present in the Ray doc

 ```bash
-kuebctl get nodes
+kubectl get nodes
```

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
Just simple cleanup

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
