### PR TITLE
fix: [Flink] - Push operator version to 1.7.0 as 1.4.0 is unavailable

### DIFF
--- a/streaming/flink/addons.tf
+++ b/streaming/flink/addons.tf
@@ -192,7 +192,7 @@ module "eks_data_addons" {
   #---------------------------------------------------------------
   enable_flink_operator = true
   flink_operator_helm_config = {
-    version = "1.4.0"
+    version = "1.7.0"
     values  = [templatefile("${path.module}/helm-values/flink-operator-values.yaml", {})]
   }
 


### PR DESCRIPTION
Update Flink operator version to 1.7.0 as 1.4.0 is no longer available and fails to deploy.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
