### PR TITLE
closes #312 Allow access to EKS cluster from MWAA security group

### DIFF
--- a/schedulers/terraform/managed-airflow-mwaa/eks.tf
+++ b/schedulers/terraform/managed-airflow-mwaa/eks.tf
@@ -40,13 +40,14 @@ module "eks" {
       source_node_security_group = true
     }
 
+    # MWAA needs access to the EKS control plane in order to submit a job
     allow_access_from_mwaa = {
-      description = "Nodes on ephemeral ports"
+      description = "Access from MWAA"
       protocol    = "tcp"
-      from_port   = 1025
-      to_port     = 65535
+      from_port   = 443
+      to_port     = 443
       type        = "ingress"
-      cidr_blocks = [local.vpc_cidr]
+      source_security_group_id = module.mwaa.mwaa_security_group_id
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

This PR closes issue #312. 

It updates the EKS security group rule to allow traffic to control plane (port 443) from MWAA security group.

### Motivation

Building on top of this code for my own project.

### More

- [x ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
