### PR TITLE
Fixed EMR container operator import

### DIFF
--- a/schedulers/terraform/managed-airflow-mwaa/dags/example_emr_eks_new.py
+++ b/schedulers/terraform/managed-airflow-mwaa/dags/example_emr_eks_new.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 from airflow import DAG
 from airflow.hooks.base import BaseHook
-from airflow.providers.amazon.aws.operators.emr_containers import EMRContainerOperator
+from airflow.providers.amazon.aws.operators.emr import EmrContainerOperator
 from airflow.utils.dates import days_ago
 
 
@@ -51,7 +51,7 @@ with DAG(
     c = BaseHook.get_connection("emr_eks")
     cluster_args = c.extra_dejson
     # [START howto_operator_emr_eks_jobrun]
-    job_starter = EMRContainerOperator(
+    job_starter = EmrContainerOperator(
         task_id="start_job",
         virtual_cluster_id=cluster_args.get('virtual_cluster_id'),
         execution_role_arn=cluster_args.get('job_role_arn'),


### PR DESCRIPTION
### What does this PR do?

The EMR containers demo dag `emr_eks_pi_job` does not load on MWAA with the error below. This is even before adding the `emr_eks` connection.

`Error when trying to pre-import module 'airflow.providers.amazon.aws.operators.emr_containers' found in /usr/local/airflow/dags/example_emr_eks_new.py: No module named 'airflow.providers.amazon.aws.operators.emr_containers'`

This is because the import does not follow package structure for AWS provider version [7.1.0](https://airflow.apache.org/docs/apache-airflow-providers-amazon/7.1.0/_api/airflow/providers/amazon/aws/operators/emr/index.html) which is the one [installed with Airflow v2.5.1 on MWAA](https://docs.aws.amazon.com/mwaa/latest/userguide/connections-packages.html#connections-packages-table-251).

This fix updates the EMR container operator import and instance in the DAG code

### Motivation

Building on top of this code for my own project.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
