### PR TITLE
Update script name to install cuda as per the latest instructions at …

### DIFF
--- a/ai-ml/jark-stack/terraform/src/notebook/dogbooth.ipynb
+++ b/ai-ml/jark-stack/terraform/src/notebook/dogbooth.ipynb
@@ -82,8 +82,8 @@
    "outputs": [],
    "source": [
     "# Fix for bitsandbytes https://github.com/TimDettmers/bitsandbytes/blob/main/how_to_use_nonpytorch_cuda.md\n",
-    "! wget https://raw.githubusercontent.com/TimDettmers/bitsandbytes/main/cuda_install.sh\n",
-    "! bash cuda_install.sh 117 ~/local 1"
+    "! wget https://raw.githubusercontent.com/TimDettmers/bitsandbytes/main/install_cuda.sh\n",
+    "! bash install_cuda.sh 117 ~/local 1"
    ]
   },
   {


### PR DESCRIPTION
…https://github.com/TimDettmers/bitsandbytes/blob/main/how_to_use_nonpytorch_cuda.md

### What does this PR do?

This pull request updates the name of the script to install the cuda.

### Motivation

The cell with the cuda install instructions encountered an issue saying the script not found. When I opened the URL in the comment, I noticed the instructions were to used "install_cuda.sh". I updated the script name locally and the cuda installation completed successfully.

### More

- [Y] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [NA] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [NA] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [N] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
