### PR TITLE
fix: Update ray-cluster karpenter_provisioner capacity-type to on-demand

### DIFF
--- a/ai-ml/ray/terraform/modules/ray-cluster/main.tf
+++ b/ai-ml/ray/terraform/modules/ray-cluster/main.tf
@@ -20,7 +20,7 @@ resource "kubectl_manifest" "karpenter_provisioner" {
         {
           key      = "karpenter.sh/capacity-type"
           operator = "In"
-          values   = ["spot"]
+          values   = ["on-demand"]
         }
       ]
       limits = {


### PR DESCRIPTION
Update ray-cluster karpenter_provisioner  capacity-type to on-demand

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

The Karpenter Provisioner created for the Ray on EKS xgboost example is set to use a "spot" capacity-type, which failed to provision the required additional node. As a result, the the xgboost head node pods got stuck in a pending state. After changing the capacity-type to on-demand, a new M5a.4xlarge instance was successfully deployed and added to the ray-cluster as a node, allowing the xgboost head node pods to run. 

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
