### PR TITLE
fix: For issue 429 "Unable to deploy llama2 on Eks/Ray Serve/inf2"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ site
 .tfsec
 
 examples/gradio-ui/*
+ai-ml/trainium-inferentia/examples/gradio-ui/gradio_cached_examples/*
+
+# venv
+**/.venv/*

--- a/ai-ml/trainium-inferentia/eks.tf
+++ b/ai-ml/trainium-inferentia/eks.tf
@@ -122,8 +122,6 @@ module "eks" {
         WorkerType      = "ON_DEMAND"
         NodeGroupType   = "core"
         workload        = "rayhead"
-        instanceType    = "mixed-x86"
-        provisionerType = "Karpenter"
       }
 
       tags = merge(local.tags, {
@@ -512,8 +510,8 @@ module "eks" {
       desired_size = var.inf2_24xl_desired_size
 
       labels = {
-        instanceType    = "inferentia-inf2"
-        provisionerType = "Karpenter"
+        instanceType    = "inf2-24xl"
+        provisionerType = "cluster-autoscaler"
       }
 
       block_device_mappings = {
@@ -579,8 +577,8 @@ module "eks" {
       desired_size = var.inf2_48xl_desired_size
 
       labels = {
-        instanceType    = "inferentia-inf2"
-        provisionerType = "Karpenter"
+        instanceType    = "inf2-48xl"
+        provisionerType = "cluster-autoscaler"
       }
 
       taints = [

--- a/ai-ml/trainium-inferentia/eks.tf
+++ b/ai-ml/trainium-inferentia/eks.tf
@@ -116,12 +116,14 @@ module "eks" {
       max_size     = 8
       desired_size = 3
 
-      instance_types = ["m5.xlarge"]
+      instance_types = ["m5.2xlarge"]
 
       labels = {
-        WorkerType    = "ON_DEMAND"
-        NodeGroupType = "core"
-        workload      = "rayhead"
+        WorkerType      = "ON_DEMAND"
+        NodeGroupType   = "core"
+        workload        = "rayhead"
+        instanceType    = "mixed-x86"
+        provisionerType = "Karpenter"
       }
 
       tags = merge(local.tags, {
@@ -510,8 +512,8 @@ module "eks" {
       desired_size = var.inf2_24xl_desired_size
 
       labels = {
-        instanceType    = "inf2-24xl"
-        provisionerType = "cluster-autoscaler"
+        instanceType    = "inferentia-inf2"
+        provisionerType = "Karpenter"
       }
 
       block_device_mappings = {
@@ -577,8 +579,8 @@ module "eks" {
       desired_size = var.inf2_48xl_desired_size
 
       labels = {
-        instanceType    = "inf2-48xl"
-        provisionerType = "cluster-autoscaler"
+        instanceType    = "inferentia-inf2"
+        provisionerType = "Karpenter"
       }
 
       taints = [

--- a/ai-ml/trainium-inferentia/eks.tf
+++ b/ai-ml/trainium-inferentia/eks.tf
@@ -119,9 +119,9 @@ module "eks" {
       instance_types = ["m5.2xlarge"]
 
       labels = {
-        WorkerType      = "ON_DEMAND"
-        NodeGroupType   = "core"
-        workload        = "rayhead"
+        WorkerType    = "ON_DEMAND"
+        NodeGroupType = "core"
+        workload      = "rayhead"
       }
 
       tags = merge(local.tags, {


### PR DESCRIPTION
### What does this PR do?
This is a fix for issue 429 - "Unable to deploy llama2 on Eks/Ray Serve/inf2"

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
1. Changed the core instance type to m5.2xlarge since the rayhead pod was not getting scheduled due to lack of memory
2. Changed the inf2.24xlarge instance type to ondemand since those seem to be more appropriate for a chat application workload
3. fixed the label on inf2.24xlarge and inf2.48xlarge  node so that the ray serve pod could find it



### Motivation

<!-- What inspired you to submit this pull request? -->
I could not complete the tutorial as it is outlined here -> https://awslabs.github.io/data-on-eks/docs/gen-ai/inference/Llama2

### More

- [ *] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [* ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
I don't know if i broke any other work flow !!
