### PR TITLE
Fix BERT pretraining trn1 example

### DIFF
--- a/ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain/1-bert-pretrain-build-image.sh
+++ b/ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain/1-bert-pretrain-build-image.sh
@@ -48,6 +48,19 @@ aws ecr get-login-password --region "$region" | docker login --username AWS --pa
 echo -e "Pushing Docker image..."
 docker push "$ECR_REPO_URI:$IMAGE_TAG"
 
+# Create Volcano job queue
+cat <<EOF | kubectl apply -f -
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: test
+spec:
+  weight: 1
+  reclaimable: false
+  capability:
+    cpu: 2
+EOF
+
 # Sleep for 5 seconds
 echo -e "Sleeping for 5 seconds..."
 sleep 5

--- a/ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain/docker/Dockerfile.bert_pretrain
+++ b/ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain/docker/Dockerfile.bert_pretrain
@@ -70,8 +70,8 @@ RUN wget -qO - $APT_REPO/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add -
 RUN apt-get update \
  && apt-get install -y \
     aws-neuronx-tools \
-    aws-neuronx-collectives \
-    aws-neuronx-runtime-lib \
+    aws-neuronx-collectives=2.19.7.0* \
+    aws-neuronx-runtime-lib=2.19.5.0* \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /tmp/tmp* \
  && apt-get clean
@@ -95,7 +95,7 @@ RUN ${PIP} install --no-cache-dir -U \
 
 RUN mkdir -p /etc/pki/tls/certs && cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 RUN ${PIP} config set global.extra-index-url $PIP_REPO \
- && ${PIP} install --force-reinstall torch-neuronx==1.13.0.* neuronx-cc==2.* --extra-index-url $PIP_REPO
+ && ${PIP} install --force-reinstall torch-neuronx==1.13.1.1.13.0 neuronx-cc==2.12.68.0 --extra-index-url $PIP_REPO
 
 # attrs, neurox-cc required: >=19.2.0, sagemaker 2.103.0 <22,>=20.3.0
 # protobuf neurox-cc<4 , sagemaker training <3.20,>=3.9.2

--- a/ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain/lib/trn1_dist_ddp.py
+++ b/ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain/lib/trn1_dist_ddp.py
@@ -109,10 +109,10 @@ def generateAppDef(script_args: str, nnodes: int, nproc_per_node: int,
     # Determine entrypoint and arguments based on precompile request
     if precompile:
         entrypoint = "neuron_parallel_compile"
-        args = [_args_join(cmd) + " " + script_args]
+        args = cmd + script_args.split()
     else:
-        entrypoint = "bash"
-        args = ["-c", _args_join(cmd) + " " + script_args]
+        entrypoint = "python3"
+        args = cmd[1:] + script_args.split()
 
     # Define the AppDef configuration
     appdef = specs.AppDef(


### PR DESCRIPTION
### What does this PR do?

Corrects a few issues with the BERT pretraining / trn1 example
- adds missing Volcano queue
- pins Neuron version to 2.16.1 to avoid CCOM timeouts
- adjusts torchx entrypoint / args to avoid 'filename too long' errors

### Motivation

User reported an issue with this example

### More

Tested 2-node jobs using both trn1.32xl and trn1n.32xl

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
