### PR TITLE
fix: Remove broken links in gen ai doc overview page

### DIFF
--- a/website/docs/gen-ai/index.md
+++ b/website/docs/gen-ai/index.md
@@ -7,13 +7,13 @@ sidebar_label: Overview
 
 Welcome to Gen AI on Amazon Elastic Kubernetes Service (EKS), your gateway to harnessing the power of Large Language Models (LLMs) for a wide range of applications. This introduction page serves as your starting point to explore our offerings for Training, Fine-tuning, and Inference using various LLMs, including BERT-Large, Llama2, Stable Diffusion, and more.
 
-## [Training](https://awslabs.github.io/docs/category/training-on-eks)
+## Training
 Are you ready to dive into the world of LLMs and train models for your specific needs? Discover our comprehensive Training resources to get started.
 
-## [Fine-tuning](https://awslabs.github.io/docs/category/training-on-eks)
+## Fine-tuning
 Fine-tuning LLMs is crucial for tailoring them to your specific tasks. Explore our Fine-tuning section to learn how to adapt LLMs to your unique requirements.
 
-## [Inference](https://awslabs.github.io/docs/category/inference-on-eks)
+## Inference
 Unlock the potential of LLMs for powerful inference tasks. Our Inference resources will guide you through deploying LLMs effectively.
 
 Whether you're an experienced practitioner or new to the field, our Gen AI on EKS capabilities empower you to harness the latest advancements in language modeling. Dive into each section to begin your journey.


### PR DESCRIPTION
### What does this PR do?
Remove broken links in gen ai doc overview page
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
Remove broken links in gen ai doc overview page
<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
