### PR TITLE
feat: Add architecture diagram in doc website for stable-diffusion-inf2 blueprint

### DIFF
--- a/website/docs/gen-ai/excalidraw/stable-diffusion-inf2.excalidraw
+++ b/website/docs/gen-ai/excalidraw/stable-diffusion-inf2.excalidraw
@@ -1,0 +1,5461 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [
+    {
+      "type": "rectangle",
+      "version": 895,
+      "versionNonce": 306363304,
+      "isDeleted": false,
+      "id": "-YG7fGSnRvvbARaZZ8RQi",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4856.937624473492,
+      "y": -22539.647618238338,
+      "strokeColor": "#000000",
+      "backgroundColor": "#000000",
+      "width": 3455.418526785716,
+      "height": 2052.5390625,
+      "seed": 429263899,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [],
+      "updated": 1708470387484,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "text",
+      "version": 1224,
+      "versionNonce": 610237144,
+      "isDeleted": false,
+      "id": "Lt16MOTM_zVuK8J-L_UKK",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4563.1205686350395,
+      "y": -22471.451623744546,
+      "strokeColor": "#ffffff",
+      "backgroundColor": "transparent",
+      "width": 2687.716552734375,
+      "height": 117.87444226723821,
+      "seed": 940396187,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 94.29955381379057,
+      "fontFamily": 1,
+      "text": "Inference for Stable diffusion XL Model on Inf2 and EKS",
+      "textAlign": "right",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Inference for Stable diffusion XL Model on Inf2 and EKS",
+      "lineHeight": 1.25,
+      "baseline": 83
+    },
+    {
+      "type": "rectangle",
+      "version": 1339,
+      "versionNonce": 2051623384,
+      "isDeleted": false,
+      "id": "TE-hAqBLt5DM34qiJN2II",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 0,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4821.80927625921,
+      "y": -22164.181658416896,
+      "strokeColor": "#ffffff",
+      "backgroundColor": "#846358",
+      "width": 757.1465773809547,
+      "height": 1317.2079613095202,
+      "seed": 1058611413,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [],
+      "updated": 1708470309255,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "rectangle",
+      "version": 1503,
+      "versionNonce": 337018328,
+      "isDeleted": false,
+      "id": "7e9xUqz6Rk17k4YXbwM8F",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3109.02467804492,
+      "y": -22168.57339948833,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#ffec99",
+      "width": 801.3885788690491,
+      "height": 1326.2779017857113,
+      "seed": 1072152443,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [],
+      "updated": 1708470524182,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "text",
+      "version": 759,
+      "versionNonce": 333326760,
+      "isDeleted": false,
+      "id": "IppDZejxXnLfovvAxHGIE",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4666.239137055452,
+      "y": -22134.05610038118,
+      "strokeColor": "#ffffff",
+      "backgroundColor": "transparent",
+      "width": 494.54998779296875,
+      "height": 74.2629665798644,
+      "seed": 463222171,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 59.410373263891515,
+      "fontFamily": 1,
+      "text": "Core Node Group",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Core Node Group",
+      "lineHeight": 1.25,
+      "baseline": 52
+    },
+    {
+      "type": "text",
+      "version": 1078,
+      "versionNonce": 1068541144,
+      "isDeleted": false,
+      "id": "8vlvWSQEgZ0hhwN4mkKiP",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3014.6700587008445,
+      "y": -22160.632848893085,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 529.9000244140625,
+      "height": 103.36447704081654,
+      "seed": 712416661,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 43.06853210034023,
+      "fontFamily": 3,
+      "text": "Karpenter Worker Node\ninf2.24xlarge",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Karpenter Worker Node\ninf2.24xlarge",
+      "lineHeight": 1.2,
+      "baseline": 93
+    },
+    {
+      "type": "text",
+      "version": 841,
+      "versionNonce": 1287304360,
+      "isDeleted": false,
+      "id": "C77cATy9fOK-K1rNeBHrg",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4537.961431817476,
+      "y": -21688.967744726426,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 191.43333435058594,
+      "height": 59.07767351969383,
+      "seed": 343250427,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 47.262138815755065,
+      "fontFamily": 1,
+      "text": "KubeRay",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "KubeRay",
+      "lineHeight": 1.25,
+      "baseline": 42
+    },
+    {
+      "type": "rectangle",
+      "version": 1399,
+      "versionNonce": 2029406680,
+      "isDeleted": false,
+      "id": "n5ElbMKCMhyg44OsRCq9V",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3987.9132569139674,
+      "y": -22162.527547553796,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#343",
+      "width": 825.7245163690474,
+      "height": 1331.0481770833323,
+      "seed": 1142766267,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "text",
+      "version": 819,
+      "versionNonce": 1875763112,
+      "isDeleted": false,
+      "id": "7Ev8xXDBhvH5h414J3qYb",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3873.493066920247,
+      "y": -22136.56214576808,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 637.2666829427085,
+      "height": 141.37934054728822,
+      "seed": 1941711707,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 56.55173621891524,
+      "fontFamily": 1,
+      "text": "Karpenter Worker Node\n",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Karpenter Worker Node\n",
+      "lineHeight": 1.25,
+      "baseline": 121.00000000000011
+    },
+    {
+      "type": "line",
+      "version": 2335,
+      "versionNonce": 608128728,
+      "isDeleted": false,
+      "id": "XZFpL2UYAzU3EMYUuv_u6",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3446.6566290453097,
+      "y": -21213.30197357848,
+      "strokeColor": "#000000",
+      "backgroundColor": "#326ce5",
+      "width": 192.09189463144514,
+      "height": 188.01888021465223,
+      "seed": 303725851,
+      "groupIds": [
+        "jNhlkrWYaKWh_QKNE0fD1",
+        "C7RbHnVZSVGSpygZiKdNF",
+        "fit2XhbLllUmykzslA_Vx",
+        "5CDoiteAFSkt5pl4q7dNU"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -79.28899480531993,
+          37.92655523643198
+        ],
+        [
+          -95.63724115693232,
+          119.0248276036961
+        ],
+        [
+          -40.87061587903092,
+          188.01888021465223
+        ],
+        [
+          51.08826984878859,
+          187.61540622277525
+        ],
+        [
+          96.45465347451284,
+          113.7796657092958
+        ],
+        [
+          78.47158248773927,
+          33.891815317662626
+        ],
+        [
+          0,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 1631,
+      "versionNonce": 1027844776,
+      "isDeleted": false,
+      "id": "DCPXLEUjmQZGXBcStHibU",
+      "fillStyle": "hachure",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3479.9861559568153,
+      "y": -21074.76754719363,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 73.56206415132786,
+      "height": 46.50582973632049,
+      "seed": 1772233147,
+      "groupIds": [
+        "C7RbHnVZSVGSpygZiKdNF",
+        "fit2XhbLllUmykzslA_Vx",
+        "5CDoiteAFSkt5pl4q7dNU"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 37.2046637890564,
+      "fontFamily": 1,
+      "text": "ING",
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "ING",
+      "lineHeight": 1.25,
+      "baseline": 33
+    },
+    {
+      "type": "line",
+      "version": 1176,
+      "versionNonce": 1780462552,
+      "isDeleted": false,
+      "id": "NV-IJioihRYHV7i9EJ9Hx",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3432.643520124355,
+      "y": -21086.179930521736,
+      "strokeColor": "#326ce5",
+      "backgroundColor": "transparent",
+      "width": 22.075068632945108,
+      "height": 20.021573876391805,
+      "seed": 101462619,
+      "groupIds": [
+        "5CDoiteAFSkt5pl4q7dNU"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          22.075068632945108,
+          20.021573876391805
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1565,
+      "versionNonce": 264770984,
+      "isDeleted": false,
+      "id": "P4GYy4URpmoqeQ-VICbNg",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 3.141592653589793,
+      "x": -3373.6055458734563,
+      "y": -21151.60567632339,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 138.0975223781904,
+      "height": 54.41761104865511,
+      "seed": 2016095995,
+      "groupIds": [
+        "JkBtDI34gBiX2Kl8CH4FB",
+        "5CDoiteAFSkt5pl4q7dNU"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -33.369289793986255,
+          6.160484269658967
+        ],
+        [
+          -86.7601534643651,
+          52.87748998124034
+        ],
+        [
+          -138.0975223781904,
+          54.41761104865511
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1627,
+      "versionNonce": 1084979416,
+      "isDeleted": false,
+      "id": "IeB-IL9Gi97MjKvg6FSz0",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3510.1629471842302,
+      "y": -21152.66182326514,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 138.0975223781904,
+      "height": 54.41761104865511,
+      "seed": 310482843,
+      "groupIds": [
+        "JkBtDI34gBiX2Kl8CH4FB",
+        "5CDoiteAFSkt5pl4q7dNU"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          33.369289793986255,
+          6.160484269658967
+        ],
+        [
+          86.7601534643651,
+          52.87748998124034
+        ],
+        [
+          138.0975223781904,
+          54.41761104865511
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1265,
+      "versionNonce": 210182312,
+      "isDeleted": false,
+      "id": "8gSl66K3GjzFrdMGeVdcW",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3458.055517736699,
+      "y": -21147.256289643497,
+      "strokeColor": "#326ce5",
+      "backgroundColor": "transparent",
+      "width": 22.075068632945108,
+      "height": 20.021573876391805,
+      "seed": 859958331,
+      "groupIds": [
+        "JkBtDI34gBiX2Kl8CH4FB",
+        "5CDoiteAFSkt5pl4q7dNU"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          22.075068632945108,
+          20.021573876391805
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1335,
+      "versionNonce": 997629400,
+      "isDeleted": false,
+      "id": "ja6-m98Nas6I9ZsEI0z2H",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3469.6064257423086,
+      "y": -21122.629462450557,
+      "strokeColor": "#326ce5",
+      "backgroundColor": "transparent",
+      "width": 22.075068632945108,
+      "height": 20.021573876391805,
+      "seed": 1313778907,
+      "groupIds": [
+        "JkBtDI34gBiX2Kl8CH4FB",
+        "5CDoiteAFSkt5pl4q7dNU"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          22.075068632945108,
+          20.021573876391805
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 2405,
+      "versionNonce": 787725016,
+      "isDeleted": false,
+      "id": "CnLlwxQCq-BI3shwL8ZgL",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3564.7082363564346,
+      "y": -22047.042358666917,
+      "strokeColor": "#000000",
+      "backgroundColor": "#326ce5",
+      "width": 212.89487466440812,
+      "height": 208.3807649179602,
+      "seed": 1402389301,
+      "groupIds": [
+        "T8oCVy3HYWbtThWqtxg8h",
+        "Moox_kb1dYF0QT0MK5M9e",
+        "056FsXtE0Xcw3OM4k4K8M",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470320916,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -87.87575677637271,
+          42.033888202335305
+        ],
+        [
+          -105.99446951376919,
+          131.9148619115842
+        ],
+        [
+          -45.29678184349113,
+          208.3807649179602
+        ],
+        [
+          56.620977304363855,
+          207.93359589453107
+        ],
+        [
+          106.90040515063893,
+          126.10166460700574
+        ],
+        [
+          86.96982113950288,
+          37.56219796804432
+        ],
+        [
+          0,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 1678,
+      "versionNonce": 2070323160,
+      "isDeleted": false,
+      "id": "HvRhKY5XCW-W7tMWr1vZK",
+      "fillStyle": "hachure",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3601.647251758741,
+      "y": -21893.505066536534,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 73.55930081960574,
+      "height": 51.54227257674985,
+      "seed": 446862485,
+      "groupIds": [
+        "Moox_kb1dYF0QT0MK5M9e",
+        "056FsXtE0Xcw3OM4k4K8M",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470320916,
+      "link": null,
+      "locked": false,
+      "fontSize": 41.23381806139987,
+      "fontFamily": 1,
+      "text": "Pod",
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Pod",
+      "lineHeight": 1.25,
+      "baseline": 36.000000000000014
+    },
+    {
+      "type": "arrow",
+      "version": 3660,
+      "versionNonce": 1034970024,
+      "isDeleted": false,
+      "id": "EEeL7jvIbX3oAc12ir889",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3565.5585804389,
+      "y": -21972.557564936593,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 1.74425333389967,
+      "height": 40.4716358752558,
+      "seed": 653081077,
+      "groupIds": [
+        "9Y1i9dcs_uyhGQm2Q8a_1",
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470321421,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "6weqAxGIHgQwVONGqfc2Y",
+        "focus": 0.06357849557365594,
+        "gap": 2.577113628830624
+      },
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.74425333389967,
+          40.4716358752558
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1829,
+      "versionNonce": 1089636824,
+      "isDeleted": false,
+      "id": "h8HyD9I0WOwZhN8RBbpqN",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3558.0092129853724,
+      "y": -21921.506252289946,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 34.04118717098732,
+      "height": 16.068929713090448,
+      "seed": 293352277,
+      "groupIds": [
+        "9Y1i9dcs_uyhGQm2Q8a_1",
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470320917,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          34.04118717098732,
+          -16.068929713090448
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 3317,
+      "versionNonce": 875933352,
+      "isDeleted": false,
+      "id": "OgUKvyz-R0lBZsHQRkvXs",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3523.857357166162,
+      "y": -21987.418937301092,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 1.0322496067950986,
+      "height": 52.074257483972644,
+      "seed": 916783285,
+      "groupIds": [
+        "9Y1i9dcs_uyhGQm2Q8a_1",
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470321422,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "6weqAxGIHgQwVONGqfc2Y",
+        "focus": -0.9764089313008593,
+        "gap": 3.6353924250050227
+      },
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          1.0322496067950986,
+          52.074257483972644
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1688,
+      "versionNonce": 269218776,
+      "isDeleted": false,
+      "id": "ky6fAAQYDlksvqp7psUnX",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3566.8596462880596,
+      "y": -21918.911935629538,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 41.846386710284385,
+      "height": 25.888993621068334,
+      "seed": 1275929109,
+      "groupIds": [
+        "9Y1i9dcs_uyhGQm2Q8a_1",
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470320917,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -41.846386710284385,
+          -25.888993621068334
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 3161,
+      "versionNonce": 1641650600,
+      "isDeleted": false,
+      "id": "OvqtpNhtdPWdwpmxGtl_B",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3599.360452213077,
+      "y": -21940.616596499316,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 3.2074174686086185,
+      "height": 47.72392176034592,
+      "seed": 917116789,
+      "groupIds": [
+        "9Y1i9dcs_uyhGQm2Q8a_1",
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470321422,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "6weqAxGIHgQwVONGqfc2Y",
+        "focus": 0.8589310764378066,
+        "gap": 1
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          3.2074174686086185,
+          -47.72392176034592
+        ]
+      ]
+    },
+    {
+      "type": "diamond",
+      "version": 1643,
+      "versionNonce": 55762392,
+      "isDeleted": false,
+      "id": "6weqAxGIHgQwVONGqfc2Y",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3601.4528610130697,
+      "y": -22009.72645350794,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 78.43384089496581,
+      "height": 35.8541421223256,
+      "seed": 549544149,
+      "groupIds": [
+        "9Y1i9dcs_uyhGQm2Q8a_1",
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "EEeL7jvIbX3oAc12ir889",
+          "type": "arrow"
+        },
+        {
+          "id": "OgUKvyz-R0lBZsHQRkvXs",
+          "type": "arrow"
+        },
+        {
+          "id": "OvqtpNhtdPWdwpmxGtl_B",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470320917,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "line",
+      "version": 1323,
+      "versionNonce": 2028548568,
+      "isDeleted": false,
+      "id": "b9_3LHcXBqM8evTHi1hbD",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3541.8671960757047,
+      "y": -21974.616605645184,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 18.160893319834297,
+      "height": 33.16337041013212,
+      "seed": 1340636725,
+      "groupIds": [
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470320917,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -18.160893319834297,
+          33.16337041013212
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1326,
+      "versionNonce": 1972713176,
+      "isDeleted": false,
+      "id": "J5V8nqK2uJdvOW0t-jz0_",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3590.033043576134,
+      "y": -21983.30225027641,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 19.74010143460246,
+      "height": 30.794558237979786,
+      "seed": 990179221,
+      "groupIds": [
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470320917,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          19.74010143460246,
+          30.794558237979786
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1357,
+      "versionNonce": 1752734680,
+      "isDeleted": false,
+      "id": "ZecCa_SvY4mIRnw0PR3x_",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3528.838729128867,
+      "y": -21966.720565071344,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 18.160893319834297,
+      "height": 33.16337041013212,
+      "seed": 1615607029,
+      "groupIds": [
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470320917,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -18.160893319834297,
+          33.16337041013212
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1382,
+      "versionNonce": 1403478232,
+      "isDeleted": false,
+      "id": "SA4RR5WguGWfpygkDq6KS",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3594.375865891746,
+      "y": -21963.956950870503,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 19.74010143460246,
+      "height": 30.794558237979786,
+      "seed": 1531170389,
+      "groupIds": [
+        "c0L8VkROH2zBCMO0VYuof",
+        "BMh_uyEGdPNPewzF88Kxa"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470320917,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          19.74010143460246,
+          30.794558237979786
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 1473,
+      "versionNonce": 1895559384,
+      "isDeleted": false,
+      "id": "549oXbbQ6bVsWvrHVsfwI",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3667.0982283146404,
+      "y": -21830.442888173384,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 229.76667277018248,
+      "height": 195.5796694436048,
+      "seed": 5381813,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "XWay8ArNXmKdAr3qL5hiD",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470326496,
+      "link": null,
+      "locked": false,
+      "fontSize": 39.115933888720974,
+      "fontFamily": 1,
+      "text": "Ray Cluster\nHead Pod\n\n",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Ray Cluster\nHead Pod\n\n",
+      "lineHeight": 1.25,
+      "baseline": 180.99999999999994
+    },
+    {
+      "type": "text",
+      "version": 1210,
+      "versionNonce": 1905016280,
+      "isDeleted": false,
+      "id": "XCUknI_2r3DOk7PedVDwd",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -2885.088426767956,
+      "y": -21071.334847962513,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 365.90000406901027,
+      "height": 219.56253260076133,
+      "seed": 1661500917,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "-IJ5a50c1h3DYHhmLZ42O",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470409755,
+      "link": null,
+      "locked": false,
+      "fontSize": 58.550008693536356,
+      "fontFamily": 1,
+      "text": "Ray Cluster\nWorker Pod 1\n",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Ray Cluster\nWorker Pod 1\n",
+      "lineHeight": 1.25,
+      "baseline": 197.99999999999997
+    },
+    {
+      "type": "line",
+      "version": 2352,
+      "versionNonce": 524638888,
+      "isDeleted": false,
+      "id": "uQgX5Ax2nJmi6yYP0G5Us",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4445.5884639780315,
+      "y": -21933.70640294191,
+      "strokeColor": "#000000",
+      "backgroundColor": "#1971c2",
+      "width": 234.0038391937559,
+      "height": 229.04214618505443,
+      "seed": 2005140181,
+      "groupIds": [
+        "vMVn9maXlJWkn5F6alT9M",
+        "1d8nXLxR9kD78DeNZ_8hJ",
+        "rb0-_v4zNoMwBL5dCWRHh",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -96.5888187310397,
+          46.20163463818694
+        ],
+        [
+          -116.50403908795512,
+          144.99449168367178
+        ],
+        [
+          -49.78805089228854,
+          229.04214618505443
+        ],
+        [
+          62.235063615360595,
+          228.55063943358434
+        ],
+        [
+          117.49980010580079,
+          138.60490391456065
+        ],
+        [
+          95.59305771319389,
+          41.28656712348621
+        ],
+        [
+          0,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 1624,
+      "versionNonce": 1716585432,
+      "isDeleted": false,
+      "id": "6CjO19pyNCrz4qw8TC0QA",
+      "fillStyle": "hachure",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4486.190058703139,
+      "y": -21764.945572628083,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 80.83333587646484,
+      "height": 56.65279487231772,
+      "seed": 973529141,
+      "groupIds": [
+        "1d8nXLxR9kD78DeNZ_8hJ",
+        "rb0-_v4zNoMwBL5dCWRHh",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 45.32223589785418,
+      "fontFamily": 1,
+      "text": "Pod",
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Pod",
+      "lineHeight": 1.25,
+      "baseline": 40
+    },
+    {
+      "type": "arrow",
+      "version": 3337,
+      "versionNonce": 638829992,
+      "isDeleted": false,
+      "id": "1bpBd8lzSCXXh4WaSeSmK",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4446.52312142456,
+      "y": -21851.8362887744,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 1.9171996380956924,
+      "height": 44.484481780927005,
+      "seed": 1460081045,
+      "groupIds": [
+        "l64RXKQQq_m9vE_WdNpRu",
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "WRmHzNPbzyqVuulzzaQ_1",
+        "focus": 0.06357849557369619,
+        "gap": 2.8326397436193247
+      },
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.9171996380956924,
+          44.484481780927005
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1711,
+      "versionNonce": 1244842200,
+      "isDeleted": false,
+      "id": "OCmD0JUnnPlQAAgjnDcYM",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4438.225218666708,
+      "y": -21795.723133518655,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 37.41644086679361,
+      "height": 17.662197131448433,
+      "seed": 1002051317,
+      "groupIds": [
+        "l64RXKQQq_m9vE_WdNpRu",
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          37.41644086679361,
+          -17.662197131448433
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 2994,
+      "versionNonce": 1037881512,
+      "isDeleted": false,
+      "id": "XjsSms4UoOwJql8PzaaFK",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4400.687136127688,
+      "y": -21868.171196763436,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 1.1345992775874023,
+      "height": 57.23752717683892,
+      "seed": 312832085,
+      "groupIds": [
+        "l64RXKQQq_m9vE_WdNpRu",
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "WRmHzNPbzyqVuulzzaQ_1",
+        "focus": -0.9764089313008385,
+        "gap": 3.9958490582277975
+      },
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          1.1345992775874023,
+          57.23752717683892
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1570,
+      "versionNonce": 932441560,
+      "isDeleted": false,
+      "id": "5xpS-qTNNBrM5VvzX9SDp",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4447.953190627621,
+      "y": -21792.87158502753,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 45.995541987700925,
+      "height": 28.455940565700462,
+      "seed": 429825461,
+      "groupIds": [
+        "l64RXKQQq_m9vE_WdNpRu",
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -45.995541987700925,
+          -28.455940565700462
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 2838,
+      "versionNonce": 776764328,
+      "isDeleted": false,
+      "id": "W4WZ8gMvo_Kw6-viejlUy",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4483.676518280921,
+      "y": -21816.728307646757,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 3.525439504988759,
+      "height": 52.45584672203654,
+      "seed": 936058645,
+      "groupIds": [
+        "l64RXKQQq_m9vE_WdNpRu",
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "WRmHzNPbzyqVuulzzaQ_1",
+        "focus": 0.8589310764378028,
+        "gap": 1.035820934442448
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          3.525439504988759,
+          -52.45584672203654
+        ]
+      ]
+    },
+    {
+      "type": "diamond",
+      "version": 1589,
+      "versionNonce": 126382808,
+      "isDeleted": false,
+      "id": "WRmHzNPbzyqVuulzzaQ_1",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4485.976393715371,
+      "y": -21892.690549065883,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 86.21071747765575,
+      "height": 39.4091540289457,
+      "seed": 1403024501,
+      "groupIds": [
+        "l64RXKQQq_m9vE_WdNpRu",
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "1bpBd8lzSCXXh4WaSeSmK",
+          "type": "arrow"
+        },
+        {
+          "id": "XjsSms4UoOwJql8PzaaFK",
+          "type": "arrow"
+        },
+        {
+          "id": "W4WZ8gMvo_Kw6-viejlUy",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "line",
+      "version": 1269,
+      "versionNonce": 1770964648,
+      "isDeleted": false,
+      "id": "bzesLMR_ASEhW-0P2Fc2_",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4420.482687592876,
+      "y": -21854.099487602583,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 19.96158323082416,
+      "height": 36.451586769330994,
+      "seed": 1759780309,
+      "groupIds": [
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -19.96158323082416,
+          36.451586769330994
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1272,
+      "versionNonce": 1352947672,
+      "isDeleted": false,
+      "id": "KgBARTz5CH2zgCBAFyo5h",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4473.424277900714,
+      "y": -21863.64633175646,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 21.697373076982746,
+      "height": 33.84790200009302,
+      "seed": 1588304693,
+      "groupIds": [
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          21.697373076982746,
+          33.84790200009302
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1303,
+      "versionNonce": 1011855784,
+      "isDeleted": false,
+      "id": "UG_cn9kaYL8UB60pbl_q8",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4406.162421362069,
+      "y": -21845.420538371796,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 19.96158323082416,
+      "height": 36.451586769330994,
+      "seed": 492596373,
+      "groupIds": [
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -19.96158323082416,
+          36.451586769330994
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1322,
+      "versionNonce": 922459352,
+      "isDeleted": false,
+      "id": "b5MgYUB6gQeHx7tBDyt-y",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4478.19769997765,
+      "y": -21842.382906141018,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 21.697373076982746,
+      "height": 33.84790200009302,
+      "seed": 1688998389,
+      "groupIds": [
+        "QvZWl-AOpmfxcdqYVdWDk",
+        "T6yOKrVbvGXo3ugtUGLk0"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          21.697373076982746,
+          33.84790200009302
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 833,
+      "versionNonce": 2109422760,
+      "isDeleted": false,
+      "id": "GNZK1UGt4tC9Qy_2x5plJ",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3752.8564782332555,
+      "y": -21015.353496214513,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 606.433349609375,
+      "height": 107.99598214285835,
+      "seed": 1940158075,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "TYyeNmkJSgCmCNaS2-wQ4",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 44.99832589285765,
+      "fontFamily": 3,
+      "text": "stablediffusion-ingress\nNGINX",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "stablediffusion-ingress\nNGINX",
+      "lineHeight": 1.2,
+      "baseline": 98
+    },
+    {
+      "type": "line",
+      "version": 2347,
+      "versionNonce": 1008878040,
+      "isDeleted": false,
+      "id": "gk2NxUyszYYqxOmgBzug2",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3564.802386043462,
+      "y": -21595.457593719468,
+      "strokeColor": "#000000",
+      "backgroundColor": "#326ce5",
+      "width": 188.92305693369002,
+      "height": 184.91723286687096,
+      "seed": 132598747,
+      "groupIds": [
+        "0VDPoHAzEQN9sk_Z0PBNp",
+        "jA5BTOFYev6V1KG7IzTBk",
+        "hZQ3kmyzNcT5XwDYx3YMK",
+        "2hr6yROaQ6S_4tOpZ4g3u",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -77.98100647901248,
+          37.300901050398856
+        ],
+        [
+          -94.05956451592229,
+          117.06133840284747
+        ],
+        [
+          -40.1963950922745,
+          184.91723286687096
+        ],
+        [
+          50.24549386534307,
+          184.5204147705901
+        ],
+        [
+          94.86349241776772,
+          111.90270315119642
+        ],
+        [
+          77.17707857716697,
+          33.332720087590474
+        ],
+        [
+          0,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 1624,
+      "versionNonce": 1065183144,
+      "isDeleted": false,
+      "id": "Psa40as3SKNgdnFKA3VTP",
+      "fillStyle": "hachure",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3594.845192291028,
+      "y": -21459.651737602515,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 64.72765687612929,
+      "height": 45.73864782728377,
+      "seed": 308746363,
+      "groupIds": [
+        "jA5BTOFYev6V1KG7IzTBk",
+        "hZQ3kmyzNcT5XwDYx3YMK",
+        "2hr6yROaQ6S_4tOpZ4g3u",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "fontSize": 36.590918261827014,
+      "fontFamily": 1,
+      "text": "SVC",
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "SVC",
+      "lineHeight": 1.25,
+      "baseline": 32
+    },
+    {
+      "type": "rectangle",
+      "version": 860,
+      "versionNonce": 254559960,
+      "isDeleted": false,
+      "id": "gwTJwTugesCi93zXeZb4Q",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3599.63533224048,
+      "y": -21558.180742902725,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 66.24349044448357,
+      "height": 22.522786751124414,
+      "seed": 545542427,
+      "groupIds": [
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "rectangle",
+      "version": 940,
+      "versionNonce": 2109878952,
+      "isDeleted": false,
+      "id": "HGqNevop7ri2sOskw9I0W",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3628.7824680360545,
+      "y": -21496.57429678935,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 31.13444050890691,
+      "height": 20.5354820377899,
+      "seed": 867268027,
+      "groupIds": [
+        "5zJqFZxYJ-cMxuG0K-AcI",
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "rectangle",
+      "version": 973,
+      "versionNonce": 1554885592,
+      "isDeleted": false,
+      "id": "tCQnnEp_PpvHfRBzf1bon",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3582.0808072726913,
+      "y": -21494.91820952824,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 31.13444050890691,
+      "height": 20.5354820377899,
+      "seed": 2064713307,
+      "groupIds": [
+        "5zJqFZxYJ-cMxuG0K-AcI",
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "rectangle",
+      "version": 1032,
+      "versionNonce": 1328913832,
+      "isDeleted": false,
+      "id": "rr38zkUdv2zO9WJ5WW07_",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3533.0606243437733,
+      "y": -21494.91820952824,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 31.13444050890691,
+      "height": 20.5354820377899,
+      "seed": 494240507,
+      "groupIds": [
+        "5zJqFZxYJ-cMxuG0K-AcI",
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "line",
+      "version": 844,
+      "versionNonce": 515535064,
+      "isDeleted": false,
+      "id": "ZuTBotXfXklM-4z0FYbJT",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3565.1887172093484,
+      "y": -21535.657956151597,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 1.324869808889671,
+      "height": 41.07096407557981,
+      "seed": 1130458011,
+      "groupIds": [
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.324869808889671,
+          41.07096407557981
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 851,
+      "versionNonce": 352561320,
+      "isDeleted": false,
+      "id": "fT8MMntV614OZEQT9hh4c",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3614.8713350427115,
+      "y": -21515.784909018254,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 100.69010547561606,
+      "height": 0.6624349044448355,
+      "seed": 1627865147,
+      "groupIds": [
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          100.69010547561606,
+          0.6624349044448355
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 843,
+      "versionNonce": 1827050968,
+      "isDeleted": false,
+      "id": "6xGa4N4aJT5kr_w50J2wP",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3515.506099375986,
+      "y": -21516.4473439227,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 0,
+      "height": 19.873047133345068,
+      "seed": 1078558939,
+      "groupIds": [
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          0,
+          19.873047133345068
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 947,
+      "versionNonce": 718820264,
+      "isDeleted": false,
+      "id": "N0cRBwmP9TjGhaN5DA7ss",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -3616.8586397560457,
+      "y": -21515.784909018254,
+      "strokeColor": "#fff",
+      "backgroundColor": "#fff",
+      "width": 3.974609426669014,
+      "height": 19.873047133345068,
+      "seed": 1253748091,
+      "groupIds": [
+        "NyGAM7eHIeMW22DYtCMbi",
+        "gPb_ritB3rEdl1DZOlnAo"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070061,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          3.974609426669014,
+          19.873047133345068
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 959,
+      "versionNonce": 83762600,
+      "isDeleted": false,
+      "id": "6mUdr0lpaTNcULOKUEAnS",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3818.6008169735264,
+      "y": -21400.147655440713,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 545.210199742874,
+      "height": 62.37557020990502,
+      "seed": 2051393109,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "wluTa8SgguX35dPUB3BOo",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470570290,
+      "link": null,
+      "locked": false,
+      "fontSize": 49.900456167924006,
+      "fontFamily": 1,
+      "text": "stablediffusion-service",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "stablediffusion-service",
+      "lineHeight": 1.25,
+      "baseline": 44.000000000000014
+    },
+    {
+      "type": "text",
+      "version": 2359,
+      "versionNonce": 910854616,
+      "isDeleted": false,
+      "id": "IG7lk74mIqIM5bPKuSgQH",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4443.852957450504,
+      "y": -20291.98510331157,
+      "strokeColor": "#000000",
+      "backgroundColor": "white",
+      "width": 101.29288604119301,
+      "height": 56.67465907736471,
+      "seed": 2133321237,
+      "groupIds": [
+        "pKHxLxQMzECktGK5qjNM1"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470213679,
+      "link": null,
+      "locked": false,
+      "fontSize": 45.33972726189176,
+      "fontFamily": 1,
+      "text": "User",
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "User",
+      "lineHeight": 1.25,
+      "baseline": 40.00000000000001
+    },
+    {
+      "type": "line",
+      "version": 2664,
+      "versionNonce": 755732184,
+      "isDeleted": false,
+      "id": "gHuQdJzYCKffLT38eyOki",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 0,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4450.171548651606,
+      "y": -20313.868154940148,
+      "strokeColor": "#000000",
+      "backgroundColor": "#ced4da",
+      "width": 111.69310488558762,
+      "height": 99.45950225344247,
+      "seed": 1103911797,
+      "groupIds": [
+        "80v2OQw22H8hrC-ZpRmT3",
+        "pKHxLxQMzECktGK5qjNM1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470213679,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          12.509627747185801,
+          -65.90689908360645
+        ],
+        [
+          53.612690345082044,
+          -99.45950225344247
+        ],
+        [
+          94.7157529429783,
+          -73.0967426199998
+        ],
+        [
+          111.69310488558762,
+          -6.8435962956967495
+        ],
+        [
+          0,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "ellipse",
+      "version": 2401,
+      "versionNonce": 258208728,
+      "isDeleted": false,
+      "id": "Aj2624VnQpSpwSGkKGLBB",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 0,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4421.938793297938,
+      "y": -20465.05585081118,
+      "strokeColor": "#000000",
+      "backgroundColor": "#ced4da",
+      "width": 57.18686970142091,
+      "height": 50.038510988743475,
+      "seed": 385557717,
+      "groupIds": [
+        "80v2OQw22H8hrC-ZpRmT3",
+        "pKHxLxQMzECktGK5qjNM1"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470213679,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "rectangle",
+      "version": 1066,
+      "versionNonce": 258210216,
+      "isDeleted": false,
+      "id": "2kpb5Cqa5vfvh4HDdOX6n",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4060.1691162889683,
+      "y": -20485.11768087754,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#99e9f2",
+      "width": 638.9248511904768,
+      "height": 283.3593749999966,
+      "seed": 1649001013,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [
+        {
+          "id": "wluTa8SgguX35dPUB3BOo",
+          "type": "arrow"
+        },
+        {
+          "id": "-jH_6IfU4e3h6tQ7sx9W6",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470228220,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "text",
+      "version": 799,
+      "versionNonce": 1647211736,
+      "isDeleted": false,
+      "id": "STYIvNlMEZ81Eki4BlzZ-",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4202.824687636161,
+      "y": -20471.699712127545,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 784.933349609375,
+      "height": 110.84196428571704,
+      "seed": 2023601045,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470234329,
+      "link": null,
+      "locked": false,
+      "fontSize": 46.184151785715436,
+      "fontFamily": 3,
+      "text": "      Web UI Image generator \n    Interface",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "      Web UI Image generator \n    Interface",
+      "lineHeight": 1.2,
+      "baseline": 100
+    },
+    {
+      "type": "image",
+      "version": 739,
+      "versionNonce": 1594110680,
+      "isDeleted": false,
+      "id": "vGfT-8mtkP6qI2mIgtr9h",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3892.224919860395,
+      "y": -20331.591825222782,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "width": 283.9999999999999,
+      "height": 76.07142857142854,
+      "seed": 1982626037,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "-jH_6IfU4e3h6tQ7sx9W6",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470244696,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "027ab987048fc220092d17805a94cf1f502bb875",
+      "scale": [
+        1,
+        1
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1682,
+      "versionNonce": 2076584,
+      "isDeleted": false,
+      "id": "-jH_6IfU4e3h6tQ7sx9W6",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4330.6360061699215,
+      "y": -20354.886096056125,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 251.82220427539278,
+      "height": 2.6076663416461088,
+      "seed": 953276021,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470228220,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "2kpb5Cqa5vfvh4HDdOX6n",
+        "gap": 18.644685605560653,
+        "focus": 0.036825679363060033
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          251.82220427539278,
+          2.6076663416461088
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 2691,
+      "versionNonce": 1996915880,
+      "isDeleted": false,
+      "id": "wluTa8SgguX35dPUB3BOo",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3817.82045209827,
+      "y": -20507.31223877403,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 183.88699900196707,
+      "height": 814.9325027067716,
+      "seed": 1156799829,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470228220,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "2kpb5Cqa5vfvh4HDdOX6n",
+        "gap": 22.19455789649146,
+        "focus": -0.0716195051814661
+      },
+      "endBinding": {
+        "elementId": "6mUdr0lpaTNcULOKUEAnS",
+        "focus": 0.6655830921918477,
+        "gap": 15.527343750009095
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -123.03458308950758,
+          -394.78236607143117
+        ],
+        [
+          60.85241591245949,
+          -814.9325027067716
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1383,
+      "versionNonce": 1877412520,
+      "isDeleted": false,
+      "id": "JGibO1HImUCJB-URtiTso",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3531.7222397316086,
+      "y": -21348.16780307015,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 78.69458549621277,
+      "height": 140.66397203422457,
+      "seed": 1056572469,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          78.69458549621277,
+          140.66397203422457
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1712,
+      "versionNonce": 1504935336,
+      "isDeleted": false,
+      "id": "XWay8ArNXmKdAr3qL5hiD",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3516.3785131332643,
+      "y": -21725.129048698764,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 47.787195035509285,
+      "height": 121.94963349088721,
+      "seed": 1079801915,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470338804,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "549oXbbQ6bVsWvrHVsfwI",
+        "focus": 0.25315866903660844,
+        "gap": 31.683803521906157
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -47.787195035509285,
+          121.94963349088721
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1639,
+      "versionNonce": 845858216,
+      "isDeleted": false,
+      "id": "-IJ5a50c1h3DYHhmLZ42O",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3463.4420073334472,
+      "y": -21490.249712995155,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 620.7370837528129,
+      "height": 381.316474534,
+      "seed": 1043611605,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470624940,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "1xAIoblY9tV0mvEphy56A",
+        "focus": -0.9968299689290492,
+        "gap": 4.659506265232267
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          339.8326062421329,
+          373.4482005302052
+        ],
+        [
+          620.7370837528129,
+          381.316474534
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1060,
+      "versionNonce": 857348312,
+      "isDeleted": false,
+      "id": "IjT7HPwtYblYJulX-Vz0Z",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1122.789558997325,
+      "y": -22380.099627166877,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 825.0781250000241,
+      "height": 135.41333506997307,
+      "seed": 680447771,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          412.9111586998433,
+          -112.91852678571301
+        ],
+        [
+          825.0781250000241,
+          -135.41333506997307
+        ]
+      ]
+    },
+    {
+      "type": "image",
+      "version": 748,
+      "versionNonce": 641760984,
+      "isDeleted": false,
+      "id": "J0C_JCDLOc4ZamEDzkLfo",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1269.8834950092064,
+      "y": -21428.116368238312,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "width": 421.05872903139,
+      "height": 88.50279017857241,
+      "seed": 438129237,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "D7s4qRs1ntHBfYFm8H1gO",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708471005528,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "3a34c550bc3d084ca26009ac81411d3e8bca6b08",
+      "scale": [
+        1,
+        1
+      ]
+    },
+    {
+      "type": "text",
+      "version": 658,
+      "versionNonce": 100362152,
+      "isDeleted": false,
+      "id": "rSk5dBiG9xhYIOYpC0rFF",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1222.4715854516803,
+      "y": -21324.440214964503,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 425.1000061035156,
+      "height": 96.72366071428605,
+      "seed": 744286165,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470991638,
+      "link": null,
+      "locked": false,
+      "fontSize": 40.30152529761919,
+      "fontFamily": 3,
+      "text": "Hugging Face Model\nrepo",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Hugging Face Model\nrepo",
+      "lineHeight": 1.2,
+      "baseline": 87
+    },
+    {
+      "type": "text",
+      "version": 598,
+      "versionNonce": 987480792,
+      "isDeleted": false,
+      "id": "EaK49ulbQdAXA1_ODGQWB",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1145.4426467949197,
+      "y": -21638.412164369267,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 81,
+      "height": 55.29523809523817,
+      "seed": 904497787,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "fontSize": 46.07936507936514,
+      "fontFamily": 3,
+      "text": "ECR",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "ECR",
+      "lineHeight": 1.2,
+      "baseline": 45
+    },
+    {
+      "type": "arrow",
+      "version": 1881,
+      "versionNonce": 1923436968,
+      "isDeleted": false,
+      "id": "TYyeNmkJSgCmCNaS2-wQ4",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3412.3465423887737,
+      "y": -20889.28117478593,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 156.90311345661485,
+      "height": 375.9244791666715,
+      "seed": 211128923,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470301711,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "GNZK1UGt4tC9Qy_2x5plJ",
+        "gap": 18.076339285724316,
+        "focus": -0.022139117569220844
+      },
+      "endBinding": {
+        "elementId": "KwVSzA8ECIgYkpniQ67vv",
+        "gap": 15.534598214291691,
+        "focus": -0.04642173430934024
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          156.90311345661485,
+          375.9244791666715
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 978,
+      "versionNonce": 175428312,
+      "isDeleted": false,
+      "id": "qpLieFLePbH6vHckqzIjK",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -2854.9090345890504,
+      "y": -20446.079872702605,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 358.12642521160336,
+      "height": 133.3642857142873,
+      "seed": 794264859,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "4WmFLTGP__mybw__t11_I",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470297091,
+      "link": null,
+      "locked": false,
+      "fontSize": 55.56845238095306,
+      "fontFamily": 3,
+      "text": "Ray Cluster\nDashboard",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Ray Cluster\nDashboard",
+      "lineHeight": 1.2,
+      "baseline": 119.99999999999994
+    },
+    {
+      "type": "arrow",
+      "version": 1677,
+      "versionNonce": 948719064,
+      "isDeleted": false,
+      "id": "4WmFLTGP__mybw__t11_I",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3115.2232767552346,
+      "y": -20391.256786296675,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 235.01444692460063,
+      "height": 0.6867437908804277,
+      "seed": 1217472251,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470297090,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "qpLieFLePbH6vHckqzIjK",
+        "focus": 0.19556432130235743,
+        "gap": 25.299795241583524
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          235.01444692460063,
+          -0.6867437908804277
+        ]
+      ]
+    },
+    {
+      "type": "image",
+      "version": 612,
+      "versionNonce": 163245272,
+      "isDeleted": false,
+      "id": "1RxsFSlWs1wEI3WaLVrg3",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -2434.7482643544427,
+      "y": -22161.385899488305,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "width": 115.86681547618994,
+      "height": 115.86681547618994,
+      "seed": 673778491,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "7727ea4b539cc346117a4be03d066944af8fc5c6",
+      "scale": [
+        1,
+        1
+      ]
+    },
+    {
+      "type": "image",
+      "version": 540,
+      "versionNonce": 895020200,
+      "isDeleted": false,
+      "id": "51IrG4GK5EWyuQX-7xA60",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1640.517423580632,
+      "y": -22535.328607821644,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "width": 208.76884514051656,
+      "height": 212.2483258928585,
+      "seed": 814928277,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "b14373482fe27fb621c05dd618ed293fe087395c",
+      "scale": [
+        1,
+        1
+      ]
+    },
+    {
+      "type": "image",
+      "version": 447,
+      "versionNonce": 811045800,
+      "isDeleted": false,
+      "id": "EuyXZZY0cJurPEEpFH6Cz",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1193.0285842949193,
+      "y": -21818.216256631167,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "width": 171.75781249999997,
+      "height": 171.75781249999997,
+      "seed": 1023638235,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "IjT7HPwtYblYJulX-Vz0Z",
+          "type": "arrow"
+        },
+        {
+          "id": "sswUPL_pfoM6wYQGmoNix",
+          "type": "arrow"
+        },
+        {
+          "id": "a5v_IJfOtYtLJ0rN_N7As",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470950879,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "30fb3952dfc0d0b1cff3d7aff756b93fc647a8dc",
+      "scale": [
+        1,
+        1
+      ]
+    },
+    {
+      "type": "image",
+      "version": 569,
+      "versionNonce": 798542808,
+      "isDeleted": false,
+      "id": "KwVSzA8ECIgYkpniQ67vv",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3299.043651259205,
+      "y": -20497.82209740497,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "width": 189.48704117063758,
+      "height": 184.36576978764734,
+      "seed": 164376955,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "TYyeNmkJSgCmCNaS2-wQ4",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470285754,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "48c11a4ac31ddea5e6f5a39963f8ee9aae7f345d",
+      "scale": [
+        1,
+        1
+      ]
+    },
+    {
+      "type": "text",
+      "version": 872,
+      "versionNonce": 1802773720,
+      "isDeleted": false,
+      "id": "SwNE31dLI--Ben-JvSTpL",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3312.885090642576,
+      "y": -20315.441554250203,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 328.0333251953125,
+      "height": 103.36428571428594,
+      "seed": 2005152213,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470263196,
+      "link": null,
+      "locked": false,
+      "fontSize": 43.06845238095248,
+      "fontFamily": 3,
+      "text": "Network \nLoad Balancer",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Network \nLoad Balancer",
+      "lineHeight": 1.2,
+      "baseline": 93
+    },
+    {
+      "type": "arrow",
+      "version": 2013,
+      "versionNonce": 1303634600,
+      "isDeleted": false,
+      "id": "EO16NQBT22qzb4wNesYS1",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 80,
+      "angle": 0,
+      "x": -4330.1528402472995,
+      "y": -21349.732811690694,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 346.23958333333167,
+      "height": 0.16833829292590963,
+      "seed": 38876955,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          346.23958333333167,
+          0.16833829292590963
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 747,
+      "versionNonce": 32439256,
+      "isDeleted": false,
+      "id": "KW4FpOIBMhIdu_4xZOiSo",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1350.584326104585,
+      "y": -22181.423362285925,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 497.3500061035156,
+      "height": 145.50401785714172,
+      "seed": 2047886261,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "sswUPL_pfoM6wYQGmoNix",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "fontSize": 40.41778273809493,
+      "fontFamily": 3,
+      "text": "Neuron\nDocker Image\nwith Inference script",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Neuron\nDocker Image\nwith Inference script",
+      "lineHeight": 1.2,
+      "baseline": 136
+    },
+    {
+      "type": "arrow",
+      "version": 1604,
+      "versionNonce": 359746984,
+      "isDeleted": false,
+      "id": "sswUPL_pfoM6wYQGmoNix",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1121.6426768872593,
+      "y": -22020.40807210735,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 3.5430175553334493,
+      "height": 192.98143601190895,
+      "seed": 24264635,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "KW4FpOIBMhIdu_4xZOiSo",
+        "focus": 0.08541159805074457,
+        "gap": 15.511272321429715
+      },
+      "endBinding": {
+        "elementId": "EuyXZZY0cJurPEEpFH6Cz",
+        "focus": -0.10524429649390349,
+        "gap": 9.21037946427532
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          3.5430175553334493,
+          192.98143601190895
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 757,
+      "versionNonce": 793886936,
+      "isDeleted": false,
+      "id": "lue3OYiDxHGr1f4whCwGO",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -2516.9114771540044,
+      "y": -22048.147432226404,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#69db7c",
+      "width": 206.57374216328284,
+      "height": 84.63684444309922,
+      "seed": 877974267,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "fontSize": 35.26535185129134,
+      "fontFamily": 3,
+      "text": "AWS Neuron\n",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "AWS Neuron\n",
+      "lineHeight": 1.2,
+      "baseline": 76
+    },
+    {
+      "type": "text",
+      "version": 953,
+      "versionNonce": 2045248424,
+      "isDeleted": false,
+      "id": "R-tbCPMPJOY3C_HPDXRnQ",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -4550.518429570801,
+      "y": -21253.33256367481,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 242.75,
+      "height": 63.766655961897044,
+      "seed": 692186235,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "fontSize": 51.01332476951764,
+      "fontFamily": 1,
+      "text": "Karpenter",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Karpenter",
+      "lineHeight": 1.25,
+      "baseline": 45
+    },
+    {
+      "type": "line",
+      "version": 2503,
+      "versionNonce": 2068409048,
+      "isDeleted": false,
+      "id": "pcA5TrbiBaRoiEiXNaQZ7",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4448.352124156683,
+      "y": -21484.871853491175,
+      "strokeColor": "#000000",
+      "backgroundColor": "#1971c2",
+      "width": 227.3371725270889,
+      "height": 222.51683597435553,
+      "seed": 1914914677,
+      "groupIds": [
+        "lVgmniEn3-VlBtsYBfaKx",
+        "sHa6Kp7623lZoHqBWBbq2",
+        "OE7_QLBQuHNWBHjf-s_dk",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -93.83704568139416,
+          44.8853703467584
+        ],
+        [
+          -113.18489015178474,
+          140.86366225844392
+        ],
+        [
+          -48.36961117597641,
+          222.51683597435553
+        ],
+        [
+          60.462013969970435,
+          222.03933203449637
+        ],
+        [
+          114.15228237530417,
+          134.65611104027505
+        ],
+        [
+          92.86965345787459,
+          40.11033094816709
+        ],
+        [
+          0,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 1777,
+      "versionNonce": 1215909544,
+      "isDeleted": false,
+      "id": "ZasAR2fj-loOHlhKH2G0L",
+      "fillStyle": "hachure",
+      "strokeWidth": 4,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4487.796997269444,
+      "y": -21320.918945158322,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 78.55000305175781,
+      "height": 55.03878161317595,
+      "seed": 1972670677,
+      "groupIds": [
+        "sHa6Kp7623lZoHqBWBbq2",
+        "OE7_QLBQuHNWBHjf-s_dk",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "fontSize": 44.03102529054076,
+      "fontFamily": 1,
+      "text": "Pod",
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Pod",
+      "lineHeight": 1.25,
+      "baseline": 39
+    },
+    {
+      "type": "arrow",
+      "version": 3751,
+      "versionNonce": 294014936,
+      "isDeleted": false,
+      "id": "8MWghFQb2XJz3YiTtJpFm",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4449.26015362281,
+      "y": -21405.334182940816,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 1.8625794619281744,
+      "height": 43.21713842068707,
+      "seed": 47558197,
+      "groupIds": [
+        "pDBTfHAefEFcUsDs9Qnzn",
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "pG5NrMoUaCVceiK7DUOXB",
+        "focus": 0.06357849557370095,
+        "gap": 2.7519390806605024
+      },
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.8625794619281744,
+          43.21713842068707
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1862,
+      "versionNonce": 1823029672,
+      "isDeleted": false,
+      "id": "-Ielwf-tNVhmKXqyDSQ7A",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4441.198654472309,
+      "y": -21350.819666848405,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 36.35046288980226,
+      "height": 17.15900888769132,
+      "seed": 2026643349,
+      "groupIds": [
+        "pDBTfHAefEFcUsDs9Qnzn",
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          36.35046288980226,
+          -17.15900888769132
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 3408,
+      "versionNonce": 2027853016,
+      "isDeleted": false,
+      "id": "fxKCO2xChEQwHEGwA_JHq",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4404.730015428128,
+      "y": -21421.203716571174,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 1.1022750421817886,
+      "height": 55.60685515099953,
+      "seed": 1034773749,
+      "groupIds": [
+        "pDBTfHAefEFcUsDs9Qnzn",
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "pG5NrMoUaCVceiK7DUOXB",
+        "focus": -0.9764089313008433,
+        "gap": 3.8820090724657774
+      },
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          1.1022750421817886,
+          55.60685515099953
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1721,
+      "versionNonce": 2040775848,
+      "isDeleted": false,
+      "id": "4kW6K3CIBBf747pXG4wFq",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4450.649480781981,
+      "y": -21348.049357722153,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 44.68514918542391,
+      "height": 27.645243309229667,
+      "seed": 1425997397,
+      "groupIds": [
+        "pDBTfHAefEFcUsDs9Qnzn",
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -44.68514918542391,
+          -27.645243309229667
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 3252,
+      "versionNonce": 921057752,
+      "isDeleted": false,
+      "id": "z_tdWtFZF4_ZTVpZNHM6C",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4485.3550665105795,
+      "y": -21371.226412785454,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 3.4250012809227046,
+      "height": 50.96140267351802,
+      "seed": 899050421,
+      "groupIds": [
+        "pDBTfHAefEFcUsDs9Qnzn",
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "pG5NrMoUaCVceiK7DUOXB",
+        "focus": 0.8589310764378185,
+        "gap": 1.0063108506771563
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          3.4250012809227046,
+          -50.96140267351802
+        ]
+      ]
+    },
+    {
+      "type": "diamond",
+      "version": 1740,
+      "versionNonce": 1024782248,
+      "isDeleted": false,
+      "id": "pG5NrMoUaCVceiK7DUOXB",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4487.5894195033925,
+      "y": -21445.02452328887,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 83.75461197742997,
+      "height": 38.286404528631834,
+      "seed": 1603874069,
+      "groupIds": [
+        "pDBTfHAefEFcUsDs9Qnzn",
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "8MWghFQb2XJz3YiTtJpFm",
+          "type": "arrow"
+        },
+        {
+          "id": "fxKCO2xChEQwHEGwA_JHq",
+          "type": "arrow"
+        },
+        {
+          "id": "z_tdWtFZF4_ZTVpZNHM6C",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "line",
+      "version": 1420,
+      "versionNonce": 2125545176,
+      "isDeleted": false,
+      "id": "mzVlIUktaS3t2W0MisncV",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4423.96160032099,
+      "y": -21407.53290422778,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 19.39288648637184,
+      "height": 35.413097062070236,
+      "seed": 847037045,
+      "groupIds": [
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -19.39288648637184,
+          35.413097062070236
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1423,
+      "versionNonce": 1864940200,
+      "isDeleted": false,
+      "id": "GxA_sfNFPKofuvkzx16a-",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4475.394907958758,
+      "y": -21416.807762982135,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 21.079224441708483,
+      "height": 32.883590129065176,
+      "seed": 50768853,
+      "groupIds": [
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          21.079224441708483,
+          32.883590129065176
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1454,
+      "versionNonce": 13870040,
+      "isDeleted": false,
+      "id": "u0o5EkErXqDawk9eLrDD6",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4410.049312189464,
+      "y": -21399.1012144511,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 19.39288648637184,
+      "height": 35.413097062070236,
+      "seed": 1900833077,
+      "groupIds": [
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -19.39288648637184,
+          35.413097062070236
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1462,
+      "versionNonce": 1653286312,
+      "isDeleted": false,
+      "id": "4vKzAdoDAoBBV-ODa9Pww",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -4480.032337335936,
+      "y": -21396.150123029263,
+      "strokeColor": "#fff",
+      "backgroundColor": "#1971c2",
+      "width": 21.079224441708483,
+      "height": 32.883590129065176,
+      "seed": 2125691541,
+      "groupIds": [
+        "l-heIug_I5g9pORkhz81t",
+        "kSisrTeSHslArJM_kEkN1"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          21.079224441708483,
+          32.883590129065176
+        ]
+      ]
+    },
+    {
+      "id": "1xAIoblY9tV0mvEphy56A",
+      "type": "rectangle",
+      "x": -3057.8684280449215,
+      "y": -21956.92607805972,
+      "width": 690,
+      "height": 843.3333333333323,
+      "angle": 0,
+      "strokeColor": "#000000",
+      "backgroundColor": "#99e9f2",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "seed": 1517018280,
+      "version": 272,
+      "versionNonce": 455045848,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "Ka7b9VKB1nYFVAnez9dnA",
+          "type": "arrow"
+        },
+        {
+          "id": "-IJ5a50c1h3DYHhmLZ42O",
+          "type": "arrow"
+        },
+        {
+          "id": "wjWYiFGryzK6C2AtP8i6X",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708471024293,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "dNbOfh0TOMIBQKofXwTbx",
+      "type": "rectangle",
+      "x": -2984.5350947115885,
+      "y": -21913.59274472639,
+      "width": 556.6666666666665,
+      "height": 106.66666666666788,
+      "angle": 0,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "seed": 900367064,
+      "version": 147,
+      "versionNonce": 879243432,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "QEsFQv-uUwGJRm-c_db_D"
+        }
+      ],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "QEsFQv-uUwGJRm-c_db_D",
+      "type": "text",
+      "x": -2777.8684255017906,
+      "y": -21882.759411393054,
+      "width": 143.3333282470703,
+      "height": 45,
+      "angle": 0,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 1973990616,
+      "version": 39,
+      "versionNonce": 1240370648,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "text": "Neuron 1",
+      "fontSize": 36,
+      "fontFamily": 1,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "baseline": 32,
+      "containerId": "dNbOfh0TOMIBQKofXwTbx",
+      "originalText": "Neuron 1",
+      "lineHeight": 1.25
+    },
+    {
+      "type": "rectangle",
+      "version": 170,
+      "versionNonce": 898568920,
+      "isDeleted": false,
+      "id": "SDo3WcjHX53xGqsLHHydm",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2982.8684280449215,
+      "y": -21763.592744726393,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 560.0000000000001,
+      "height": 100,
+      "seed": 515276968,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "12eU_mGLhqcBk-7MOPyZv"
+        }
+      ],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "12eU_mGLhqcBk-7MOPyZv",
+      "type": "text",
+      "x": -2782.4767578178707,
+      "y": -21736.092744726393,
+      "width": 159.21665954589844,
+      "height": 45,
+      "angle": 0,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 1698319016,
+      "version": 41,
+      "versionNonce": 2093098664,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "text": "Neuron 2",
+      "fontSize": 36,
+      "fontFamily": 1,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "baseline": 32,
+      "containerId": "SDo3WcjHX53xGqsLHHydm",
+      "originalText": "Neuron 2",
+      "lineHeight": 1.25
+    },
+    {
+      "type": "rectangle",
+      "version": 163,
+      "versionNonce": 182187224,
+      "isDeleted": false,
+      "id": "GRul5Wb7oEkNbNA0PbnPY",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2989.5350947115885,
+      "y": -21283.592744726393,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 556.6666666666665,
+      "height": 110,
+      "seed": 490751656,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "Ee0Ulec8bC_9z7UOc9wrR"
+        }
+      ],
+      "updated": 1708470345555,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "Ee0Ulec8bC_9z7UOc9wrR",
+      "type": "text",
+      "x": -2789.510095728841,
+      "y": -21251.092744726393,
+      "width": 156.61666870117188,
+      "height": 45,
+      "angle": 0,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "seed": 1991539112,
+      "version": 44,
+      "versionNonce": 1377243560,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "text": "Neuron 6",
+      "fontSize": 36,
+      "fontFamily": 1,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "baseline": 32,
+      "containerId": "GRul5Wb7oEkNbNA0PbnPY",
+      "originalText": "Neuron 6",
+      "lineHeight": 1.25
+    },
+    {
+      "id": "TFJ8RLnN4grpA3FqBwOTm",
+      "type": "line",
+      "x": -2974.5350947115885,
+      "y": -21566.926078059725,
+      "width": 536.6666666666665,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "seed": 2097308840,
+      "version": 169,
+      "versionNonce": 1272593624,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          536.6666666666665,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null
+    },
+    {
+      "type": "line",
+      "version": 162,
+      "versionNonce": 597073064,
+      "isDeleted": false,
+      "id": "0863oC0oo-vHbtpNbSlb4",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2972.868428044921,
+      "y": -21466.926078059725,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 536.6666666666665,
+      "height": 0,
+      "seed": 842302632,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          536.6666666666665,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "rectangle",
+      "version": 1503,
+      "versionNonce": 2083316184,
+      "isDeleted": false,
+      "id": "HGtzxLcau-L3hjsIpjcj9",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -2261.8960508127816,
+      "y": -22170.065028952573,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#ffec99",
+      "width": 801.3885788690491,
+      "height": 1346.2779017857113,
+      "seed": 14479320,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "line",
+      "version": 199,
+      "versionNonce": 1391249320,
+      "isDeleted": false,
+      "id": "eoDgl6zMIWc4NhnoAQFf2",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2969.535094711589,
+      "y": -21360.259411393054,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 536.6666666666665,
+      "height": 0,
+      "seed": 24539864,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          536.6666666666665,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "text",
+      "version": 1152,
+      "versionNonce": 887285464,
+      "isDeleted": false,
+      "id": "UVy8AW1XU6PFmaYGPnmWm",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -2146.1517735852867,
+      "y": -22165.274983246803,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 529.9000244140625,
+      "height": 103.36447704081654,
+      "seed": 1950223784,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "fontSize": 43.06853210034023,
+      "fontFamily": 3,
+      "text": "Karpenter Worker Node\ninf2.24xlarge",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Karpenter Worker Node\ninf2.24xlarge",
+      "lineHeight": 1.2,
+      "baseline": 93
+    },
+    {
+      "type": "image",
+      "version": 663,
+      "versionNonce": 742757032,
+      "isDeleted": false,
+      "id": "tGOnHII2xPbK0I1bZcvaa",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1589.1351691163504,
+      "y": -22168.192819131153,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "width": 115.86681547618994,
+      "height": 115.86681547618994,
+      "seed": 2023144664,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "7727ea4b539cc346117a4be03d066944af8fc5c6",
+      "scale": [
+        1,
+        1
+      ]
+    },
+    {
+      "type": "text",
+      "version": 816,
+      "versionNonce": 1385188312,
+      "isDeleted": false,
+      "id": "auwRLnhnkXmaNIv71KrxS",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1671.1552991265644,
+      "y": -22052.577833614607,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#69db7c",
+      "width": 206.57374216328284,
+      "height": 84.63684444309922,
+      "seed": 437637288,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070062,
+      "link": null,
+      "locked": false,
+      "fontSize": 35.26535185129134,
+      "fontFamily": 3,
+      "text": "AWS Neuron\n",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "AWS Neuron\n",
+      "lineHeight": 1.2,
+      "baseline": 76
+    },
+    {
+      "type": "rectangle",
+      "version": 333,
+      "versionNonce": 1800056488,
+      "isDeleted": false,
+      "id": "uZdC6baA001DAJ6RIa3Ik",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2205.2017613782555,
+      "y": -21953.926078059725,
+      "strokeColor": "#000000",
+      "backgroundColor": "#99e9f2",
+      "width": 690,
+      "height": 843.3333333333323,
+      "seed": 1643990952,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [
+        {
+          "id": "Wmaw46aDrhPAYH0iiPfkD",
+          "type": "arrow"
+        },
+        {
+          "id": "D7s4qRs1ntHBfYFm8H1gO",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708471001528,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "rectangle",
+      "version": 210,
+      "versionNonce": 2135494872,
+      "isDeleted": false,
+      "id": "lmDDGuIqWn8ub9Z49f_2Q",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2142.8684280449215,
+      "y": -21903.592744726397,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 556.6666666666665,
+      "height": 106.66666666666788,
+      "seed": 1028010408,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "7zleH7l7L4lZRjYSrvT0o"
+        }
+      ],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "text",
+      "version": 103,
+      "versionNonce": 1110378664,
+      "isDeleted": false,
+      "id": "7zleH7l7L4lZRjYSrvT0o",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -1936.2017588351234,
+      "y": -21872.75941139306,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 143.3333282470703,
+      "height": 45,
+      "seed": 467778728,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false,
+      "fontSize": 36,
+      "fontFamily": 1,
+      "text": "Neuron 1",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "lmDDGuIqWn8ub9Z49f_2Q",
+      "originalText": "Neuron 1",
+      "lineHeight": 1.25,
+      "baseline": 32
+    },
+    {
+      "type": "rectangle",
+      "version": 217,
+      "versionNonce": 44119512,
+      "isDeleted": false,
+      "id": "u7zvBjndJih8ubS_nyaSg",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2137.8684280449215,
+      "y": -21753.592744726397,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 560.0000000000001,
+      "height": 100,
+      "seed": 1577958104,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "mVfHQ3RhZIOflZ7Lwat46"
+        }
+      ],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "text",
+      "version": 88,
+      "versionNonce": 1536668584,
+      "isDeleted": false,
+      "id": "mVfHQ3RhZIOflZ7Lwat46",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -1937.4767578178707,
+      "y": -21726.092744726397,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 159.21665954589844,
+      "height": 45,
+      "seed": 926982104,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false,
+      "fontSize": 36,
+      "fontFamily": 1,
+      "text": "Neuron 2",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "u7zvBjndJih8ubS_nyaSg",
+      "originalText": "Neuron 2",
+      "lineHeight": 1.25,
+      "baseline": 32
+    },
+    {
+      "type": "line",
+      "version": 206,
+      "versionNonce": 296532696,
+      "isDeleted": false,
+      "id": "dRH_ceN0oIHaby8obANGW",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2122.8684280449215,
+      "y": -21563.592744726393,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 536.6666666666665,
+      "height": 0,
+      "seed": 1740547752,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          536.6666666666665,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 220,
+      "versionNonce": 951254696,
+      "isDeleted": false,
+      "id": "1wQKPvf_robEQDLj4_7CW",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2119.535094711589,
+      "y": -21463.592744726397,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 536.6666666666665,
+      "height": 0,
+      "seed": 709318104,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          536.6666666666665,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 243,
+      "versionNonce": 520069080,
+      "isDeleted": false,
+      "id": "7bqOlXmPWhAcsj-K3XrXJ",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2126.201761378255,
+      "y": -21363.592744726397,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 536.6666666666665,
+      "height": 0,
+      "seed": 872758440,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          536.6666666666665,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "rectangle",
+      "version": 194,
+      "versionNonce": 170715560,
+      "isDeleted": false,
+      "id": "hs4DjIfRffxiAaJt0nqj7",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -2139.5350947115885,
+      "y": -21285.25941139306,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 556.6666666666665,
+      "height": 110,
+      "seed": 1825982424,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 3
+      },
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "CWp6A_AmSP6qCZ9Nrql9Q"
+        }
+      ],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "text",
+      "version": 77,
+      "versionNonce": 716039384,
+      "isDeleted": false,
+      "id": "CWp6A_AmSP6qCZ9Nrql9Q",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 0,
+      "opacity": 80,
+      "angle": 0,
+      "x": -1939.5100957288414,
+      "y": -21252.75941139306,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f08c00",
+      "width": 156.61666870117188,
+      "height": 45,
+      "seed": 1466928344,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1708470070063,
+      "link": null,
+      "locked": false,
+      "fontSize": 36,
+      "fontFamily": 1,
+      "text": "Neuron 6",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "hs4DjIfRffxiAaJt0nqj7",
+      "originalText": "Neuron 6",
+      "lineHeight": 1.25,
+      "baseline": 32
+    },
+    {
+      "type": "text",
+      "version": 1271,
+      "versionNonce": 2143648168,
+      "isDeleted": false,
+      "id": "MBgbeDdbNLM6gzVIBsNu_",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -2043.7350967460936,
+      "y": -21073.374011026775,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 391.73333740234375,
+      "height": 219.56253260076136,
+      "seed": 678759592,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "Wmaw46aDrhPAYH0iiPfkD",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1708470552378,
+      "link": null,
+      "locked": false,
+      "fontSize": 58.550008693536356,
+      "fontFamily": 1,
+      "text": "Ray Cluster\nWorker Pod 2\n",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Ray Cluster\nWorker Pod 2\n",
+      "lineHeight": 1.25,
+      "baseline": 198
+    },
+    {
+      "type": "arrow",
+      "version": 1730,
+      "versionNonce": 2116059816,
+      "isDeleted": false,
+      "id": "V8JsmtNhH4fopTiMU_lPX",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -532.1259022471445,
+      "y": -21591.90328141703,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 567.4037504194794,
+      "height": 524.6498078673358,
+      "seed": 68818856,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470459103,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          339.8326062421329,
+          373.4482005302052
+        ],
+        [
+          567.4037504194794,
+          524.6498078673358
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 2587,
+      "versionNonce": 1610246360,
+      "isDeleted": false,
+      "id": "Wmaw46aDrhPAYH0iiPfkD",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -3475.4592355456116,
+      "y": -21515.23661475025,
+      "strokeColor": "#fff",
+      "backgroundColor": "transparent",
+      "width": 1527.403749922863,
+      "height": 495.13244720210787,
+      "seed": 499657944,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470634539,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "uZdC6baA001DAJ6RIa3Ik",
+        "focus": 0.9687729398492078,
+        "gap": 6.65044381653388
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          466.9229093467429,
+          -495.13244720210787
+        ],
+        [
+          1527.403749922863,
+          -445.3399071260101
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1760,
+      "versionNonce": 1102248408,
+      "isDeleted": false,
+      "id": "a5v_IJfOtYtLJ0rN_N7As",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1209.6661316390441,
+      "y": -21706.40011451014,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 309.7903157779997,
+      "height": 136.3147693452447,
+      "seed": 945674712,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708470963596,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "EuyXZZY0cJurPEEpFH6Cz",
+        "focus": 0.15503118250636186,
+        "gap": 16.63754734412487
+      },
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -309.7903157779997,
+          136.3147693452447
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 1847,
+      "versionNonce": 1824902616,
+      "isDeleted": false,
+      "id": "D7s4qRs1ntHBfYFm8H1gO",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 90,
+      "angle": 0,
+      "x": -1253.3291036356848,
+      "y": -21321.388030994247,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 259.7903157779997,
+      "height": 33.68523065475529,
+      "seed": 1453093080,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1708471013861,
+      "link": null,
+      "locked": false,
+      "startBinding": {
+        "elementId": "J0C_JCDLOc4ZamEDzkLfo",
+        "focus": -1.2247269157911924,
+        "gap": 18.22554706549272
+      },
+      "endBinding": {
+        "elementId": "uZdC6baA001DAJ6RIa3Ik",
+        "focus": 0.28340958731079136,
+        "gap": 2.0823419645710146
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -259.7903157779997,
+          -33.68523065475529
+        ]
+      ]
+    },
+    {
+      "id": "wjWYiFGryzK6C2AtP8i6X",
+      "type": "arrow",
+      "x": -2481.2017613782555,
+      "y": -21106.92607805972,
+      "width": 1356.666666666666,
+      "height": 406.66666666666424,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#99e9f2",
+      "fillStyle": "solid",
+      "strokeWidth": 4,
+      "strokeStyle": "dashed",
+      "roughness": 0,
+      "opacity": 80,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1080485544,
+      "version": 549,
+      "versionNonce": 1042357928,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1708471051695,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          846.666666666667,
+          256.66666666666424
+        ],
+        [
+          1356.666666666666,
+          -150
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": {
+        "elementId": "1xAIoblY9tV0mvEphy56A",
+        "focus": 0.6804777995286856,
+        "gap": 6.66666666666606
+      },
+      "endBinding": null,
+      "startArrowhead": "arrow",
+      "endArrowhead": "arrow"
+    }
+  ],
+  "appState": {
+    "gridSize": null,
+    "viewBackgroundColor": "#fdf8f6"
+  },
+  "files": {
+    "027ab987048fc220092d17805a94cf1f502bb875": {
+      "mimeType": "image/png",
+      "id": "027ab987048fc220092d17805a94cf1f502bb875",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOAAAAA8CAYAAAB/0ba1AAAAAXNSR0IArs4c6QAADFFJREFUeF7tnXuQl1UZxz8ryJ3YlZuIcTdAYVFLmXCE5TIRShrOONltbBqmLDPNLMvGqZmmizUJhWYlZZdxJqcpCwmksF12CwiQ2l1QNG7m4Cqmi8COXJfm8HJm331/73nPOe97ftc971/K73mf8zzf83zf55znXLbqzJkzZ/CPR8AjUBQEqjwBi4K7b9QjcBYBT0AfCB6BIiLgCVhE8H3THgFPQB8DHoEiIuAJWETwK77pl7bD/i0w7moYe2XFu5vGQU/ANKj5d+IRkITbtwn2/KZLZum2ZAJu+Ekg2wOJ6gnoyeQOAUHAle/J1ZdEwF/e2p2s4u1vdrqzqcQ1FY+A7a9AzUUlDo83zwqBNAS8/7zcJhb8GObcZtV0uQoXnoBtL0DTI1DVC6bfAFPmlCt23u4oArYEVMlP/Dh84lc9At/CEfDwa9D0M9j89QDY2i9Ax//ggnFQeyOM85P0so84WwIKh+MyoG7OWPZAdTmQfwKePgGNK6H+HjhzrKtlSUD5L6NnQO0HYOQlFQRvD3MlDQFFAWb9Z7uA6kHDT+F0fgm45Qlo+C4cac6NxCgBpcTE2VB7PQy5sIdFbwW4m4aA0m3xbg9cqsgPAXf+FRqWwatPq6NKRUD5xmWLoXYR9B1UXpHZQwPpbCdlIWB59bIza90ScN82aHwIdv9ab6COgELD+f1gxk0wbaFeX6EkRJDJJ/rFliV1F8OopHZUvobfETL5zChx9pUCAaVd+fTdYay5IeDBPdD4CDQ/qDdNEG/2Z2DkJHixCZr/GBRjkp7Bo+DyG2DiLL1+1xJijhJdWA63ISp2c+8Mdnzo5jJxa16y4icXscM6wu3EkVq8U//DQCq88B3FQLQx/r3ZSvtysVyFhWwjzv5oUSWu8BK22aYIo8PAhe+uYyqkLxsBO96Axkdh4316EwUQsz8HE67qLnumE1qfhuY/wOmTyXpGTIEZi2H0dH17LiSiBQJbnVHSqAgoyKEinmwzLih1geyKiFlxyAcBJfGSPjxR/12MTGxjQCOfjoCdp+Hvv4D6r8EpTfa6cCHMuUs/jHz7MLT8GZ5PmDdKZ8ZcHRBx6FjHcITU2Qa3SWfHEdDEA9W6WFp9NhkmbRtJGU2Hrc6+LB+EEiOhPQGf/T3Ufw/e2pocOoNqoe5emPnheLnjHdB3YO5v7QegZTXs26gPzckLYNxVMGqKXtZGImvQFYowqjmXia8m2710RDFpR8i4zIBZyCftLSES2hNQ2ym9Yd4yuHYp9O6b20WH2qDpp3DsCLz7ltwhqXzjlV3Q+hS07Yjv5pPH4NBumHYzLPqKaSjo5ZI6ONxxSUMgVQfriC3eE4/YlCweOb9T7QqRBJTz0Kh30XlpUlaKvqvDQcqHbVUNB6MElPNJocNkzhi2TRV/YQxEAUa2oRram3yA9NGSWcItAWd+A679NAwZmWvYibehaSU03Bn8Jqugo6YFC/CqLLZ3C7SsgkMvB+91dsKhPdC+Ofj/Wd92S0AVSVQdpgrUOPkkAubzq5xU/IkLoaTMmmSnCoukIaXNThiV/jQ2lch2NzcEnLwU5t0NFymGgv98HOq/Ax3PdXV3dBli/DXBAnzN6PivynPPQP0P4PVNcPqtLhnXBLQJCGGFKljjgkJFwHwHg8pG1UdFZadubpZmGcIG77Qbt9P6kzm/6RVkI2C/iVAzGQYMDTZWT78O+vTvanXHWqhfBgfX51qiWgecughqr4P+7wjpWRcs7L/2l1w9LgmYJoCERaaBUehACG8KMA30LBuk0+Bnalea7CejJY1deu44kUhHwPNHQc1lINbnwk+fQTBjCfQfDBsegr2Pq41MWojv1SfQM2gYND6cvMZV7gR0lf3C62ECdZPyfFxGyxKsad7NSkDTuZzpR9IJrcyV2BNweR1UK8r/x49A+27oUBROwnYlEfDEUWjfA0db9J6UKgHjgtt2Lqb3PhgCi2KNCeGi+uJstJnTRvUVmoA2H698YG/SPxoZewKK6mPrGmj5U5fqU8ehfS8c3qY36V2fhNm3w9grYMe6YAFe6BSPODkh9OiWOISs0DPndhhzhb5NGwnbL6VN0LkOAl1VVee36TzVNNBtsJC2mWbArNhlfV+HZcrf7QkoGzryOvx7FWx9DNq3AKeSTRixAObfC5fO7y53/Cg0r4F/rID2Z7sfWYrTOHweLPhqrp6UAOS8ZjPXSMo+plVQ0+COGpqv9bAsgZpPAtp+GKN42Va3XcWT8wwoFW59IliQP/Kv5CZ6D4PqaTDknTB1YVCoGVDd9c72J6Hh+13LCiptvYYH806h55K5QcV08HD3MCWV4OW+Qtmqzb5N8U6W4A57qiKftC/ucqO4tn0GLPrJe/sMuHM9bFgObWuSg7+qN1RfDTUToKqqu+wVNwfHjBpXwMtPakjUG2qEnvFQFbk/RJyknzKvO6FdUDJLdknKaK4IGJcNdJnUlIClOgfMip2p/y7ix0KHPQG1O2GAYXNg4Mj4nTDSuI6D8Oo6zbB1PvQfGq+n8yS074NLb3S7EC8tSktC2xvAdMSJQyiuD3TVQNMhXKkSMM4uG+xM/bcgjwtRtwSsvSs4ajRiErSuTT7hkETAaXcEesTumF0NwZGlt9u7/D30ErRvh86j7nfChFG1KXKY7GTJ+hUXtqUliGkA2syBoxGYzzlgGt26j6lJn7lgWYIONwQcfwvU3QUTzu1hlA2ePeGwBp5fm2tCHAHHfQjq7sg993f6VFB5bRKFmufgZFuXPpfLEFJr0u4WcR5OPuIYkXhML5TNFwF1mcCGVElzYF2WTUMS0ypolg0CJVqAEaGTjYB9RkPNVKgeD5cvgWnvj+d63AmHMAHFkLXui8ERo7hnzyZoWAH7f5v7az4ImK/5ggsCpgly2y1wSUUecfhYddq8nPaClkD2S0/AXkOg5nIYMqY7IQZdGJxcn3RNPJHadkHLuRMOkoCLHoNZtyrkz90h2vojdRJ3TcCkAJdWiFMG4olmQ10mzCcB405+6xbpVZlTd8wpXG0VOEg8VFVhV5uxRVuqGoQglMRf2C+epA0Kumye56GnVG+fAR+cBdUT4byYG42l1hGTgxMOFytOru/dCjuegvfdA/1Cez7l+4cPQtOjsPl+PQyuCZi2+CItlcdi4rKECwKKdmzmpkkIJg1ds+IQbtclAV3YVSLZL10G7HgzOLn+QswG62hnj7kKahfDsHF6IgkJMdcTR5bqvxwUWJKeiz8IdZ+HyXVmuk2ldF9/Uz2u19jC7aaxUZAtbrtaUjC6IrpLAgocspCwhMiXjoAyEN54CZpXw3/PDceSAnPyfJh+PQwaqpba+jtoeAAOh24di5OunglzvwRX3mRKBXu5LB0cbi06zHGVAW2DUGa6NKcxbLBQkdw1AW39F/JJIxP7CHH2hv0QNNr0gdaAiAd36Y0SVwyKuz7FaQf5PP83aFgOr6xOfl/sqJn7reCkfXRhX9+yvUT4dEE4c4iOjD6qjdCmlzJl+TsISQSJBp3wyeT2tqh/KiykXHhOaPvXkUyroKoeFP7rbq3LeiOcffQYv5GdgLKp3RuheRUcCS0RxJnRfwjULoGBNbDhYXjx53pjxTxv9qdg4AV62WJJmK6z5dM+WXwQbejuxZSyOrk4e23ayae/Sbal8avQtqZahtAZGT3hoJI32QkTvkNU124+fheBZtqRWXdq5MN+r7PkEXCXAcOuihMOLWthZ8KwMomAEz927g7RyMJ+IeGUhDKdtLuc3xXST99WURHIDwGlS2+9GlRM9zTmOhlHwJELoO5u9YJ+oaCKZrPojVthO5Ju39LdoVIof3w7JYtAfgko3X7tP8EC/IHQX0kKE3DAVJh3H8z8aPGBMinxq6p9UetLZLG3+KB6C1QIFIaAsvX924OT9G/uB0nAuuVBZbPPgNLoJZPTHiaW+uxnglKPlyksASXc4oTDMw/AR1aqryEsVtfotm+Z2OXJZ4KSl8lLFbRSYE1DRNOCTaVg5P3IjEBxMmBmswuoQK55iQXs8OZrYYI8jiT+e85tBTTKN1UpCHgCVkpPej/KEgFPwLLsNm90pSDgCVgpPen9KEsEPAHLstu80ZWCgCdgpfSk96MsEfAELMtu80ZXCgKegJXSk96PskTAE7Asu80bXSkIeAJWSk96P8oSAU/Asuw2b3SlIOAJWCk96f0oSwQ8Acuy27zRlYKAJ2Cl9KT3oywR+D9AriqnFFvEPgAAAABJRU5ErkJggg==",
+      "created": 1698433189156,
+      "lastRetrieved": 1708463794770
+    },
+    "3a34c550bc3d084ca26009ac81411d3e8bca6b08": {
+      "mimeType": "image/png",
+      "id": "3a34c550bc3d084ca26009ac81411d3e8bca6b08",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAToAAABCCAYAAADHRBpEAAAAAXNSR0IArs4c6QAAFzlJREFUeF7tXQeQFEXbfg4OELgjHAccIBKPJAgSCgH9FMWAnyiGUlRMmABFLTHnHEotEwoqPwii/OaAmLMiIAZEVFAkCh5BQLIccF89s9e3Pb09OzN7szN3S79VFudux6d7nn37DT1ZJSUlJTBiEDAIGAQyGIEsQ3QZvLpmagYBg4CFgCE6sxEMAgaBjEfAEF3GL7GZoEHAIGCIzuwBg4BBIOMRMESX8UtsJmgQMAgYojN7wCBgEMh4BAzRZfwSmwkaBAwChujMHjAIGAQyHgFDdBm/xGaCBgGDgCE6swcMAgaBjEfAEF3GL7GZoEHAIGCIzuwBg4BBIOMRyAyiK/ohtlAFB2b8gpkJGgQMAv4RqFxER0Ir+g4omgmsmpp8tt0fi33f7QL/qJgaBgGDQEYhUPGJjuQ2d4w7sSVblqanAwV9DOll1NY1kzEIeEeg4hJdMoJreChQNw/IrQoU/2mf7bZcIDsP2LgeWPNhIhLU9IyW532HmJIGgQxAoGIS3dzxwPeX2eFt0BdosgOoqRCb2yKsLQRqHQD8MtZe0hCeG3Lme4NAxiBQ8YjuvfPtx9S2g4H6X5cf8KotgI1dgAUT4m0Zsis/rqYFg0AlQKDiEB2Pqu/0i0PW4Twgd3rwEK5pDuxoBKx+N9a2IbvgMTYtGgQqGAIVg+jUo2rrI4EGP6YXqk0DgYWTYn3QWXHM/6W3P9O6QcAgEBkC0ROdqsl17gvUXBQOIBv6AYteN2QXDtqmF4NAZAhET3QTasUn37kfUPP3cMHY0AdY9KY5xoaLuunNIBAqAtESnXxk3a8L0Hh1qJMv6+yf/sBvLxqyiwb9QHvdvXs3vvvuO6xcuRL9+/dHvXr1Am3fNFY5EYiO6GSSa/NfIG9OtAgu7Qys/SQ2hmNnmHSyaFcjpd5//vlnHH744VizZk1Z/dGjR+PBBx9MqT1TKXMQiI7oxJG140gg55WKgeic0gfEOCcqxnr4HMWwYcMwceLEhFrffvstevTo4bM1UzyTEIiG6GRtrlejioOnbK8LSat7/fXXccUVVyRg8MYbb+DAA/WXFOzYsQPt27dPqHPqqafigQceqDh4hjySrKwsbY8vv/wyTjnllJBHk57unPaLl96OOOIITJggxZF6qZQhZaIhOqHNtTsTqKtJ05LAnfL+vhj7RsxhMWLwNgw92ntmxOjHW2PWL9n+6oas1U2ZMgVnnXVWwnaaNWsWevfurd1m27dvR61akhOntNS5556r1WgyZK+6TqNXr16g9qbKkiVL0LJlS9f6laGA037xMvaBAwfinXfe8VI048qET3SyNtf7QGDPSkdQZZIThQ7qtAsPjVrsuhC6up6IMmStzhCd61J6LvDxxx/j+OOPx7Zt28rqUFt++OGHPbdR0QsaoktthcInOpHi1WkEUPvVpKPWkRUrzBj7m+ts+41ol1DGG0lWBeb8FasbwvHVEJ3rUvoq8O+//+KLL77A+vXr0a9fP+y7776+6lf0woboUluh8IlOHFtbDQDy59lHvXALsGkb0KwO0HQfyEdPuWAgRLdqB7B5F5CbbfVlE+GBDcEpYYgutY27t9YyRJfayodLdMmcECSelZvis+jVCD/9UR/DH2xofTbuqrVl33Vps8F1ttQGu7bdapUTbdiOrsIWxwIdeOVTzJZnSclxwLelRtth8WOQa6cpFEg30c2fPx9btmyxjaxGjRoJjo7i4mIr/kyVDh06JI1F++eff/Drr7/ip59+wty5c1G9enWwTps2bZCTk5PQHh0GPXv2RNWqVRO+o5Pl999/t9r64YcfrHG3a9cOhYWFyM/P16Irj2/x4sW20BJW4Bg6d+5sq8txsi8hMh6Mw5sxY4alFS5fvhx16tRB165dQfsf+/IiQWKi9pfKfnEb86pVq0DsiD3XcuPGjRbu/I9zb9GihVsTtu85f5oRFi1ahGXLloFr3qVLF+y///7o1q2bdl/IDXB9uAZ//PEHNm3ahP32288aA22MjRql5ryMhugaHwvspxiNqV0tWB+fb6k3VhCWF3JzWg0SJsXWhkx0pRpkWf3tLYD5pXF9aT6+prJx/TgjGDT72Wef2aDhZlm92h6cvXbtWu0muummm3DnnXcmQEtCuP/++3HjjTf6eghY+L333sPRRx9tqzd9+nQcd9xxvtuSx3fNNddovc58cOvWrVvWNj3Wv/1mN3/s2rXLetjpueaDppOnn34aF154oeMYg8ZE11Eq+0XXDsdKMrrrrrvw5ZdfJsWdnvzLLrvM+hFLJoxfvPXWWzFu3DjHYnSiTZo0CSeddBKqVKliK8cft8svvzzpeK699lrcfvvt4I+THwmX6IR9ruNFQM4bieMUx0keJWUNy8+MvJZNdnRlG4II93Kiu/7663HPPffYUN2wYQPo4X3rrbe8om0rR88ff50pfODuvvtu6wFJReTxOREd7XX168d+7Cg6ouMDT9J0k+effx5nnHFGQrEgMUk2hiCI7quvvsLw4cPBAGuvwtCU999/X6uJsw2dIyhZ2yqOzz33HM4++2xPw+HeeeWVV7SRB04NREN0hacC9exahqcZhlloeW9g9bS0X+OUysYNU6NTiW7Pnj1W2IsujMPr8shEd/PNN1taRaoSFNF57Z/HOR7vZG0kaEzSTXQffvghjjrqKK9TLiv36quvWpqYKjR50BzhVViWZCu0sg8++CBBw3dri1rdLbfc4las7PtwiU44ItoMAvJmex5kJAWXdQfWvBcZ0dEukZubq5067Wnq0YsFdXF05T26qkT30Ucf4cgjj0wYF4/DV199tZVj+sgjjyRdMkF0TsdlVuYRhXmqDA2RU7rUhsMmOvavxjgGiYnbXk/lh1Fts6SkxFpDamF+hGu8YsUK2xGW2nLz5s1tIT1ubdJ2RxsupaioyPpbDgkS9XnM7dSpk+OP6tKlSz3bDyMiuoFAXqLhOxlA86fsi5Lmu9Dl0CI3HG3fs17nod6DjMsqL+sGrPkg7XfVlceLpgIRBtHRXqf7JZU3HW0wHIssNETTMSLLp59+auWmqvLiiy9atjLKwoULtU4APiCNGze2VS3P0VU0dN5551m2Qj6M1Bp0D+DUqVMxZMiQsr6DxMRtc6e6X9TsENrDunfvbnXHOXO9OnbsiLy8PMybNw/HHHOM9geG60GtVsjjjz9u2e90MmrUKFx00UUoKCiwfhzOP/98PProozbsaP/juqnC/GS2W61aNStU6OSTT06wNT/55JMYMWKEG2TW9xERnf8kfhEXNyK/GOi4G0PPWO44QTofJk5qgNlrY8bOcUM2+SZIRKzReVo9pVAYRHfJJZeAG0wWetL44AgpWl2EJgVNEqZAT6dsRH777bcxaNCghHJebGr0yvXt2zdQopMJlg3TBnnCCSdoH0JeFiAkSEzc1j1VolPnxn5oJ6MZom3btgndPvTQQ7jqqqsSPv/kk0+sW2EotK82bdpUS4j33nsvrrvuOlt9lpe97U716fCh40cW3V7xk+kRLtEJZ0ThKUC9L9zW1Pb96OFtMSvL7qURpNe12U5krcjG3L+r4fvl2Zi9zZ7zmBLRLe8FrJ4e2dHVFzilhcMgOjoN7rjjDtvwVG3tzz//tI4zqjBcpHbt2mUfOxEJPcIijIDHLKZvMdRDFmqDhx12WGBEp5I1G2ZohC51TL0RJUhM3NY9SKKT+/r7778tb/Ps2bOtfz///HMtgT377LM455xzrKpO+HDtlixdglo1E9MU5T7p5RZHWPlz2mzVteX41B8dXfSAE37REF1+P6CVvws2r7ylbZmG5rYZ1O+9BBgntCm8rml+p0SqG1eHQRhE50ROjHlq3bq1NSzeIMKbRGShvWXr1lhcoxAnze+FF17A6aefbhWj4Z92GlUWLFiQcLFBeY6uOqJjWIrsrRVj4JGKRzAhQWLitrdT3S86jY4hNdOmTbO86l6dS/fdd59lP6XMnDkzQavm59Rwx4wZ4zYVx/quFaUCdAQ5XeYgtxMN0TU6CmgxF2CIhxA1O0GZLW1tF89I/guhA4ha39A7l7hjJ8bCsBb+F3F4CR92Pnw64RFQ2Ffk78MgOicHAn9dqenQGfHYY48lDPvMM88EH1JVGMyrC3NgW7QXMfREtZORNHm8VWOpgia6zZs3WwHDqqhEFzQmyTarE9ER/332UTJ8pIaeeOIJW5wif0Boh1M1ZbcHhetxww03WMV4k4rOC8tj75VXXunWlGN914pSAZK1LvhcbSNcolPfD6GORmQoMHiY/ykkeOXoQtux9KCSPei+uwRPZsei7Efu2l32t6g6Y3QR0LY040ImVkFoaqAyK9YsALaXOj0qeWZE0F5XwvPUU09ZcVh+hDY8HXFTk2DWgR955plncMEFFyRUiYrogsYkFaJLdtuN2h4zIGSHgq4/fq/z7MtE52Rjlcskm4tTfT97gaYNLxI90RXkAkWb42OtUyuW7ypLaebCT58XYPj/x35hSWpnFhdbfz9frZr1r/z/JL8RHYox9PJSbU5NMWMFtS91LBmQ66ojOt0x0kkr0QUME7qhQ4daxmw3oabBTAinu/VYn3ek0SPnRZwCdlk3SqILGhMnLIIIL6HHmEdZVRhbRwx5GQLtpDr7pExiTj9STtq72p9T/T59+uDggw923Q70ustOoWQVwiM6anOUL0cDm2fF/m5VD8ivDuwuAb6P57KWDbhOdWDTztj/lmp7JLt5U2qXkZrT5OYP2BMPK9FpbWrF7g2BqlnAup3Ako2xb5sMAQ4cFfu7QH8JputquBRIZeP6CRhmqATTq1RRPaA8Pqo5oayjIzoGex5yyCFJZ0aCo/GYD0bDhrF8ZZ389ddfOOigg5IeoUjMJGy2xdxLJ4mS6ILEJBmwqewXuT3e7qI74jJ8g+QnjoFOjgaZ6HjsdcqD5Xc6h5Q8FienFZ1dDCQPUsIhOvW9rWIGguj4///uAeati89NEI+40YTaV3spSfzhZsCPiYnhOLXU7nds/L0BEG1QY2teM3YslvNqRV/M519SBVnrNLF6aUoFS2Xj+iG6Sy+9FLTPqPLaa6/hxBNPtD5mECij1XWBuSrR8ajAuCi5LMMBmPNKLxq9qjz2eH0pjRqawUDpr7/+2iI+BkYz9KFJkyaeDM5REV3QmKST6Jw8nWPHjrWZI958800MHjw4YSjqsdTJxsq9xbQu2ctO8qQ3V071oqavyy3+5ptvtCYNhqRw73FP+JFwiE5+paE6OolkygiImlz70rc3yQSo3jLCthZJxmJhi5P7kElN7ks4G+Q2nTRL0V4a7HXpJjom3qvxTGI6jENq2DAfkyc/57hnVKLTaX4kKwaOevF+yR1x09LYLzsbSJIMWPWbtM12oyK6IDFxe3hT2S9ymzyS8odKFeLO+Ej+QDFzxSm9SiW6ZPZahh0xSb9BgwYgcXEvUvhDxuMpZeLECRg2TG+2YF/UNHk6ILnNmTPHumCCmiADxp0yh3QYpp/oZAdEz/5A1s/AtlrAilXxY6n83gihfcmfCVJStTq3XcHvVW1O1GGbQsPjZyrJtT8EqLMQKBkIfDspVisNWl0qG9ePRpdKHqEMq0p03LC6K965GXkVj3ws4hVJDM/gph4wYIAVXCqL0zGKR1W+zEb2eLJdPoTUIJi+xJATlVijIrogMXHb0qnsF7VNalm6jA+3vvm9SnS8kumAAw7w5b0lAdI5xawHhhxxP/m5YIDj0AUkJxt/yER3DpD1bnw8q7YCK7faCUdocLKmJWtlOq3OaYZO2pz4XNbwVmyPOUWa1QaaxoNaKzvRUWtifJvfMAIBqUp0tO3VrFnTyzORUIaEx7AZ2cjtZEN064BH3PHjx9vybqMiuqAxSTb3IIiOt7SQsFIRnUeVR89kziZdP3L6llOan9v4eI+e1yNs+omOoxUZEfy7pweyEw4BmdQEEbENL2Qnk5ysuYnP5c+8kFyaPLCpbFw/Gh3h4q0Tbm/BYroPiYhHhWQaHb9jes7FF1/stg+135Og+GvOGDlKKuElcsM8zoibM6IiuqAxSTfRMT6Qts9klyVQQz/00EPBHFlZnEJHqNUynS9Zm6Idauz8wZMzHajRMSZPF9Kiw4NrTg+8W5iMqJt+otM5InrcANRYABR/FRvH9hxg/mK7ZieOq+IIKx8tvRxhxZGV7QvNTW5DfCZITibPagcDO3PjR1aBVhqyJOgUUMmF3f3444/WkUAnTkSXLCLd6QjL2DYGwDKxW2dr0nldnQzVXpmPr3IUm1z30mmv7bCcnI4VNNE54awGDHMcQWKSbP6p7BddeyQkOqpUImNZxkjyaMigYjWfOFmMHNO0aLNj1ogT4fGiBNrt5ItQxfiYIsgUM9p7nQiP9+JxT/IyCD824fQTnXBEtBwE5G8BSvoA35Ve5NjleGCf0lCT7bWA5auAlnWAGlViXlgK/xYiOyaSkZ2O5EQbJDuGkVCo3a2vBuQVxy/6lG1y1D6xHFiXAyydlvabTPw84KmUZRQ5U7X4+r/s7GzruEFDsR956aWXcNppp9mqMCODhmEe4ZiSU1y8E7/88qtjWtFtt91mXbTJNC7emCELNzIJnjYkjpftcbzUGHR2Jf6yU6uLUoLEJMx50FvMTBYGENNW1qpVKyutjnujPMJ1Y5s8WpK8aKulBskXFXnJYuCa0zvM+rxKnXVofqHJIxUnFecSHtF1+A+QuyCO354LYoRHD2vTHO83CrvZ69y+d1pBuZ56vF7bOyOIrjybl3V1YRTJbpBwsr3Qo8dfdl6xo167rSb+izFTu+JGVzWFqIkuaEzKu0amvh6B9BNdMvscj4j/dogRnuoESLZiwoan0+qcvKzJ2hMkpxKc9XRLXtc02ekqy+akNqhe6ZPsim2nIGSRYK7z/vFKcl0MHhPs6Z1TjzQjR47UxgmGhWnQmIQ17r2tn/QTnWqjowbXrl8szERIyf7A7m1Atofke9aRj7ByGIqTl9VtVbO6Anua2j3CMsGJ+mmw0bkNrSJ97xQtT7JjgChDPni04KWVvNlC95IUGqKZDcHQEabwqBoanRW0NTIEgW/+4vGFVwfxRhSd3YfODIaiRCVBYxLVPDK93/QTndDo6ICoMh4gqQk7HT/LLQK2vu0PZ9mpEATRyb0LgrPsczzcvxvX6vZyjS7ZRYteF5DXAom3fdHoTeN1qsLrgnhtUJQSNCZRziWT+w6P6OiMaCi9J4KERyP/zhygmb+76x01Oq6ULuPB6wrSFpcfC3uwxfsZG10ZgnzfKcMO/AptadTwZO2L0e1sy2tIgeiTWuHkyZMtLVJ9ZZ7fcQVRPkhMghiPaSMRgfQTnZwZoTu2prAqZfmo6vtY2Zaw0XXoDORK+a4p9GOzz7F+GjIjUhlW1HV4FxxfWuPl7V08ijJJm7ed6DxuO3futOKhGOrgFq1PgmM4CWP+dPfERYlLkJhEOY9M7Tv9REfknOx0Oa38H1tFNoW8Io353oEsYLXynlE/Dg65PWOf87TfGTfFl+Iw95AXA9CGRgJq0CAPDRs2ssJXmjVr5qktkhwN+wx3YHv8l/Y+ppAxBIapX4WFhZ7CEzx1mKZCQWKSpiHulc2GQ3SC7Pjv98obg2iny5oJVK8fDyB2WopN7YGFyd8qnlBVjtVzalcECK9bHwsjkYUOiIIeabumaa/cdWbSBoGQEQiP6MTEqN3pCE98T1sepUEXIGslsGUJsKOunYDoFOh2KVCkeWUiScki1jHAqqlxOEW7wgZHUqOoxCZqkOAo3RJvsg15jUx3BgGDQDkRCJ/o5AG7kZ5ucn5CPOQYPi9AGXLzgpIpYxCodAhES3QqXHRcyFpa0cx4CWpwFL83/YqbjanhCSmI3YUVa88cSyvdrjUDNgj4RKBiEZ3PwZviBgGDgEHACwKG6LygZMoYBAwClRoBQ3SVevnM4A0CBgEvCBii84KSKWMQMAhUagT+BwzE6v7W5zVwAAAAAElFTkSuQmCC",
+      "created": 1698433385292,
+      "lastRetrieved": 1708463794770
+    },
+    "7727ea4b539cc346117a4be03d066944af8fc5c6": {
+      "mimeType": "image/png",
+      "id": "7727ea4b539cc346117a4be03d066944af8fc5c6",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAAEH9JREFUeF7tXXlcFdUXP2zigqC4gIqmyBJLCIKiiKJCmIp7ppmfFs0ylyzTrF/1y/bFtCy3stJ+HzPMPVGLxAQEVwSRJVFBDRdUUBFXBH6fc3kzDeO8WR7zYJh371/w5s6dO+c759xzz3atrGIXVgFtuqWAFQVYt9iSF6MA6xtfCrDO8aUAU4D1TgGdvx9dgynAOqeAzl+PcjAFWOcU0PnrUQ6mAOucAjp/PcrBFGCdU0Dnr0c5mAKscwro/PUoB1OAdU4Bnb+exXDw05194W3fUALnhzkH4H+nc3QObfXr6R7gvm06wJeB/aG7s0sNQI+UFMGrGXsg+fI5XQOtW4DdmznB54H9YLSbpyiAmwpPwOsZSZB/87ougdYdwE529kQUz/QMgkY2Nixot+6XwxfHD5P/53iHQFNbO/bavYoK+OZEOhHd18vv6gpo3QBsY2UFL3QNgPf8w6C1fRMWpKqqKvj5TC68mbkXzt0uI793aOIAnwSEw1MP+YCVlRXb98rd2/BuVip8dyoTKqr0EWyqC4Afc+0MC4MiwMexVQ3u23v5HMzO2AOHS4oEuTLE2QUWBfaH8DYdalzPLS2G19IT4feLpxs8NzdogH0dW8GioAiIdu1cA4iCsuswLzMZNvyTJwugxzt6wWcBfaGLg1ON/vEXT8Ps9ETIKS2WNY4WOzVIgFEEv+8fBlPcHwEba2uWrqXld+GjnAOwOC8d7lVWKKJ3I2sbmOUVBG/5hoKjnT17b0VlJazMPwb/zUoFFOENrTUogMVA+D7/GLyjAgj48XzgHwbPq/jx1OdH0WAAHuPmCZ9361dnYlRM/L9+NAk2Fp6oT9xkP1vzAAe3dIEvg4QVoTkZSbDzQoHslzWl4+B2XeCLwH6CCtyr6Xsg7aqwAmfKs8xxj2YBxq3MxwHhMFFgKzM/KxW+rcOtDG7BXuwaAPMFtmBrzuTCfzhbMHOAVJsxNQdwUxtbeN2nhyaNEVJGlM9zD8Gtivu1wUP1ezUF8DOdfeGjgHBo38ShxovW1pyIytmAth3Bz6l6n5x9vRh2XzoL5ZWVJhEUzaALAvvBKJ4Z9PztMsLNWnJkaALgfm3cYFFghFkcAmM7epE1nP/RIBi4hq6XuVcW+hIagiOjXgE25hBA4r+VuRd+qqVLb4ZnIHzdfaAol758ZDcsOZFhEiczN5lL8tRqUoab6wXguljL/J1aQ3r0RNYQUnjrBqCox4YeJremzcnfaMgIil8DWdev1IqeWtUd6hTgutRGV/ccBE938SOgoU16cNImuHm/nPzfzNYOdvYbzdqgfyrIhucO/lErgJmbtaT945zqDGBTHQKmUv3ssCkslwbHr4H0q5dqDBXUsi2kRU8kvyF3d9q20tRHCd6nFUeG2QHu0swJlodE1tohoJT6d8fOAjvran+w/fqvHtCY7ayt4e7YV8j18soKsF+/WOkjZPU35sj448JpmJaWAAVmDjQwO8Anh04Cd4cWLDFq4xCQRVFDp8LhL7CasxAHd2/ZFg4bOBiVOrffvlMyvKK+xmzop8qugef2HxWNpbSz2QGuHDebndOKk0frzCuzLDgSpnp0k7UG47yQm8zdGC8YMy98nvW6RWZ9bJ0CbO6X4VIKHRNzHg5hfzKmRWOHBX8fgnlHk81KaO7g3I/e3DTRHcAOtnawqucgGNPRSxFgG//JI5p0mUHTVnSzws4UYIUEY7qji29jn2Hg7ejMjnC45CK0a9wMOhj2vcyFc7duwIU7NyHE2ZXte7y0BMakbDN7BAcF2ASAx3Xyhu97RJM9LtO+zjsC6FLEtiR4IAnKw4ZBdTPSdpO/0RX4sld39h7cKz9/KB7WnT1uwizk3UIBlkcn0svWypoY/mfxQJpyKB5iOSC969cb3vXvTe55L2sfvJe9j33K+E7esJL3cSzOOwJzM5LgfpVpDgmxV6AAywQYRe+vYTHQhxMVaUzMigGMj0Pxvil8OHg1b8k+PeXyOXgiNY6IcjUbBVgGNdEDtS5sKLg0bsb2Rlvzswd+F1SUpADGQVBBWx36WI1siKI7N2Fc6nZIulwoY1byulCAJej0mncwfBrQl3UkoMMAA9uZzAWh2+UAzNyHmQ8YGM9EbOL4b2Qmw8LjafIQlOhl8QCjJ2iOdzAMdOkELo2bwuW7t2HXxTOw4lQm2dty842kOAzX6Enu/jDbO5gVv3k3rsKi42nwY36W0TU2oo0bxPIkBG6lEOSpXQMgyvUhaGPfBIru3IKEorPk48JAAjnNogFGHy5mA3LjnY0RLfXKeRibss3oGokfR1zfURDMyyxkxksrKYKY5M0EJKGGa/z6PsMgrHV7SdyQyzFbUY5v2WIBxuiLdWExksTEDswWyJiWi86E/VETAL1GYg29TKF/rjXKySgB+FspsfHGpcZJRolYJMBokM+Pmcw6CNCHOyv9L+KIR5G9OGgA67+9YHAOiKWHcaM5MHsQY5mZWClMBkdTJpN9KBXVgelp6LxoZ4gVE5sbOi66xH0vGu9lkQAPcu0MOyNGE+ZAu7HPztWsgx5/QwNG7uBnWR9v9J4NsKvorFFm2h/1JPRs1Y5cf+XIX/D1ifQafV/2DIKvug8gvx0svgC9dv1idKwol04Q3/9x2XMbnLgJ/hBJXLNIgFEJ+iIwghARxe8r6XseIPhXQf1Zq9O8o0mw4O/qfF+hVjZmJpsD7LxpKVzj5f22sLOHktHTya2YO+yw8RujY819OAQ+69ZP9tzmZCQSJc5Ys0iAceuzQCcAz81IFN1SWSTAGNKzQ0URfSBqAvRoVe1IqGsRPSRxk2husUUCjEpWQcxkWYoM7n3bb/0W6lLJOj/iRdZqJqUAdon7QTR91SIBRk57oqMXxMrcJq0uyIbpaQlw20iqCEZPXBwxFaw5JRqE1sTKqipw3brCaO5vExtbWBocCc8aIjTFtkh4bXxqHPwqEUxvsQAjgbB4ysLACLDlJHYbI2rO9WIYm7oNcktLHuiCiWtv+PSUwoNc/yTnALx1LOWBvj6OzrA+bBj4GlJexAa7X1kJr2UkkmIuUs2iAUbiPOLUGlDpGunmwWbbYxTim5nJxC34DIebUAPGeCpuPhDGJucNeQ6aGHzD6P/1c2xF9tPYcG+dXVrM+odv3y8Hzx2rAPewTMO9MsZ1cavxYPw0brc+fiQcBrWrLhuBQYRbCk8SpeqYzOB5iweYIfJ8/97wX79qH+7KU5nw4uFd5G9MFUGxySU+V2T/0CMannP3J30xoqPnn2sFmergoxPYiI5V+Vkw+VA8CIlk/IhwOWBSab4NiYIphuCB97P3wfysf33LUtyL1ynABiqhDXhv5Hjy3+mb18E97geWfkLiE0U2OvJ/6T2UXXsH/rUe9lz6R5Du/dt2hN0DxpJruBY/uW87oNeJK5KFloGCmOfhoWaO5L7whFhAm7iSRgE2UAtTXYpHTWPFtNf2H+Fk2TWWlshtKEa5IptL6B3n8yEmeYso7eP6joQh7d0F+6BIRvHPVeQ8HFpA3tBJrHhutXmZ4ppaFGAOuTeHD4cRHTzILzPSEmDZyaMPgCEksrFTrz/XwsGSi6IA93R2hf2PTqjRR2hdZzpM8+gGS4Ijyb9bz52EUXt/U8K81dKCEytu8WGzL3l0I+sttt/OnYKRe7cKEhRDbo5ET6xRvlBMy8ZBhMQ8Oia6x68xGlm5JXwEDO/QlcwB1+XlAh+cFOIUYA6Fujq0gBMGkXij/B44b14qKBIxqhLXXn4zxo1CWjJzL67FQlGVuGSUjJoOze0aka6YdoLpJ0obBZhHMXQjdm5WXYWub0IspPCUGvT9oqeJyYHC6A9U0IS0bByDb7jAjwAVJYzSwJZfdo14s/glHvq0bg/JBqUPq+l13f6v0qcEZAowj1orQqLYPesH2ftJwVBu47r+iu/eJoTHvTDfSIEiG5uQloyFSk8NnQytDIVMhezXWOj0Hb9eZAzcW081bNuUgEvXYAFqYQzWhj7DyJUDxRegN8d362jXyCgwUmZGvrlT6EMpLb/Hzmhf1JMQavAxP56yja0YQAE2UMBUjRF9t5dHvkTitDD2qc2W5ax/l2uSFBKtCHJK5HgI5IXuZFy9BH0SYmtsgfii/tPcg6RqDjb+HFpvWW5ybWkqogVYIjVyPPQyBL8x3MM3SfKVIylbspCWzVXW0ITptWMVqTPNlSL7r5yHsIRYpYzL9qcAC5BOaP0TM0kKackokrFxPUNCWraQCVNKD1CCNgVYgFpcDfbynVvEg4SFvBl3ICZxY5AeRkEKaclch4Qx8HFfi1GaGODHJGmjCRP9vygN2jRualSTpwDXMpudvwcVIijGOeOaK2VLxnuN2bLRLGksjhrvQ++RKeZJ7nwpBwughwDnDZn0QDlhMc6RCgqQsmULjY2KnPeOVYrtzxRgCRmH6SLLQqJIL6k4ZzFbstBj+LZsqfGnHd5F0mhMbZSDBSjH3YNKBdFh2mff3esU0R/dkkyKitT4/L24ogdRZ4MwuW6Mmclm70vFOZeV3wPHTUsU0b109AxwMNiYpcbHKgDNReKopR5MOViAQkoAQKeEkxkBNmV8ugZLfPZKRLQpItTc41sEwLUphDbdIxC+Ca4uDSylBM1M2w1LTyorEWzu8XHeuiyEplYpQ7QTY7YC36bMZ3y0MYfuWqu4mrs5x9d1KUMs+r3MSDFSpcfTYNV2jKEyBjKCizFY3PBXKYWHe90c44sdB/TSYR0UI2UIqFY5YeS0F9wDYGJnHxLrjA1jnNeczoXv8jMVcy7/A1BrfIspJ8wlYF0WBFfCuWr2tdiC4FwiipX0x5xfLA6qteNppD4CLOk/9+EegLnEWjqb2OzFSMUI05COpxF7D/ROYeAB/2SXzYUnSLW8+jxdvF4BZohmzmN1pDivNtfFjtWZnZGoavE0U+epCYCZyWv5eBougc19HJCpYArdpymAcYJSx9N8kLMfuIFwahJDaiwM8HvHtxdJcWUq9OA96L3CQmj0aDspCnKuozaK5QSfEjicEsNmMWy1okosx1/BwyS6ovaPpYgxbAitUUyrqqqCn8/kkjKKGLelxaY5DuYTqb73k2rt3+sLfM0DzBBG7HgazKzPKZVXJ1IuoTHXCSsNMInezH2Y0TAvMxk21OLMQ7lzUKNfgwEYX1bsiPeV+cdUOdGFcQhMoUe8q/F9mTaGGAgfZh8gZRbuVVYoGhw/HsxseNsvlM1HxgEw0F6tj0fRhFTq3KA4mP/OeB4witFo1+p6GVwxqsSRIeYQQPEvt0ywSpioOkyDBpihxOB2XUhFWB+D84H5HeOZ8YzgtKtFgkQLbulCzhbG+Gpuyy0tJod57LxQoCqx62MwXQCMhFPiyNCaQ8CcwOsGYIZIUmcTYz8s2a8lhwAF2AQKGHNk8IfSgkPAhNeTfYvuOJj/5mKODK04BGSjZUJH3QOMNMGK7ejSm+8fRkg0PyuVLWpmAs0a1C0WAXCDQkTlyVKAVSao1oajAGsNEZXnQwFWmaBaG44CrDVEVJ4PBVhlgmptOAqw1hBReT4UYJUJqrXhKMBaQ0Tl+VCAVSao1oajAGsNEZXnQwFWmaBaG44CrDVEVJ4PBVhlgmptOAqw1hBReT4UYJUJqrXhKMBaQ0Tl+VCAVSao1ob7P5cAvOeQLalRAAAAAElFTkSuQmCC",
+      "created": 1698433798363,
+      "lastRetrieved": 1708463794770
+    },
+    "b14373482fe27fb621c05dd618ed293fe087395c": {
+      "mimeType": "image/png",
+      "id": "b14373482fe27fb621c05dd618ed293fe087395c",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB6CAYAAAB0rJfZAAAAAXNSR0IArs4c6QAAEXNJREFUeF7tnXmcFMUVx389R8+xwAoKKKioiAqKBkQUZVeU+4xAYjRGTUw8wyFCFBSVQw5lVUDQGM1hDjUeCwKCICCnR4IgIKCiIhGQQ67dnavn6Hxezc7s1O7MTs9292zPbM9fsF3Hq/ftqq6qV/WeAPOX1xoQjo6BnNctbOCNMwHn+QtgAjYB57kG8rx5Zg82Aee5BvK8eWYPNgHnuQbyvHlmDzYB57kG8rx5Zg82Aee5BvK8eWYPNgHnuQbyvHlmDzYB57kG8rx5Zg82Aee5BvK8eXndg8XOt8A1YBoQCaH8j30QOfYth9PVbyqcPcZC2r4A3iUPQj65P+9w5yVga6vL4B42D/bzuseBeZdOhH/lNA5g01lBCFYb+5sc8MD3/hPwr30GCEt5AzqvAAuupnD1nwrH1fdAsFg5SL7lk+FbPon7W7Nnah5HCx/ZDe+C0Qh+sSwvIOcHYMECx5W/g2vgdFgKTk0KRingWGbp80XwLhxTY1jPNeo5D9jWphvcw+fBdmZnTvfSF8shVxyBo8uv2N/TAfaUjmS93+I6JV6OHArAv3oWfKtmAEFvrrFl8uYsYKHx6XAPmgmxy20QBCGu/PDRPfC+8wCCny+Eq+8kuPo+rgjwsQcECAXN2Sjg6HoHBIulqszj30fL3PZWzkHOPcAWGxzdR8LdbxIEZ5Oq3ib54Fs9E/7VTwEhP/t7poBjhVnP7IICGhXaXMkBDe5eDW/pKIQP7cgZ0DkF2NauFwqGzYW1ZXt+ON5WynpY5PhefhmUYQ/mqQkQu/4a7oEzYWncoupFCocQ2DCPTdhk/0nDg84JwJambeAe8jTEy4ZzCg0f2gVP6SiEdq9Mqui69uDEwgRnIVz9JsNxze/jSyp6Hik/BO+S8ZD++wotsgwL2tiAbU44r/sDXD0nQBBdVb3IXwbfiinwr5sLRIIplasF4Piw3fJiuIfNhb3d9Vx9ob2fwPP2CIT3bTIkZMMCtl/8U7hveBbWU8+tAivLkDb9A94lD0EuP5hWoVoCjlUmXvZzuIY8DWvTs6rkikQQ+OTP8C19GLLnx7RyZTOB4QBbml8A99C5EC/qy/eUfZvhfXsEQns/UqwfPQCzyu1uuHo9DOd14yDYHHF5It7j8L33GAIbXwDksGI59UxoHMBiI7j6PApn8f0QbGKV0jxH4Vv6CAIfvwTIkYx0oRvgSiksp7Zlo4x48WD+ZTywDd7SkQh9uy4jefVIbAjAYudfwj14FiyFrRKGvTACH74I33uPQvYeq1Pb9QYcE8p+UX+4h86BtXk7Ts7A5tfgXfyHejVi1CvgZEYB0lDw2w3wlo5A+MDWOoGNZcoWYFafVYTz2gfg6j0RgqOg6kWtZyNGvQCOGgWegOPquzmjQOTkAXgXPwhp879Uga0XwJWVCoWt4R5cAkfnm7g21JcRI7uAUxgF5HAQ/rWz2dIHUoUmcKmQrPbgalLbziuGe9hzsLW6lHsi7VgM74L7s2bEyBrg2owCZJ6LHPlSM7D12YO5RghWOK65t16NGLoDjhoFnoTY5daaRoGFYxDc8Y7mYGMFuofNh7P7fey/6axJxyefBfnkPl1kqc2I4Vs0FtLWN3WplwrVFbCjaDTc/aekNQpo3Tr6DhYMnw/xkp/Gi6ZtRf/qJ7mquBMdkpeZBf0flMSNFVrLVZsRw/PGXYgc/UbrKvUDLF5+Kxrd8nf++7P1bXgXja1hFNCuVQIbEt0DZ3AvVeTEfpTNK0Lk2B6uKjqvRRsWiT9mblw0FsHtC7QTix+3kxoxwj9+g5PTz9e8Tt16cOIEh2aQnrfuS2kU0KJVlpYdUHDjS7Cfe3W8OFmWEfjoT/DR1mYKy4/t3CK2x2xr/RNOjOBXq9jRHb1Mg8yI0XcSnNfeH6+XbNJa/7ICONn3T7OGWB3RbcOe47kdsPChL0DDXmjP+vRV0ez+qjvZ0s3S6LSqF4RMgxufh++9xyH7T6Qvpw4pEs+FmYCrKZB6X8GNf4K15UVVUEIS/KtmwrdyOhAOZKRytj4n0+DV9/KmwYof4Vs2sU7bpekEMAEn0RAb3gY9CUe3u7iZeXDPh/C8cScih3am02utz61kGhw6B/YLenLpQvs/Yyc6FI0KCiUwAVdTlL3jMHacxtLkjKpe6y+D990JUSuOhsZ3e8eh7KBBosmSKg1sfr1yj1n9ssoEXIkx2dKHHknbF8JTOkK/DX126GBc5aEDd9VLpdGyygSMFEufsh9AR12D295WOBiqSyYUnsksXjX2mFUuqxo0YMtp56Pg5lcyXvqoQ1l77tqWVZ437854s6JBAy4c/wWsLS6Mazy69LkToT0b9GSYvuwUy6rw0W9xclrb9PkTUjRowImN9y2fktHSJxPFCe5mcP/sBQj26DdW9h2H58170t5mEJynsGWVs3hUHFmma9lM5MzozYnNXfRyCJ7OVKdEWDWNV5zX7kaTe1fBds5VUbghCeUv9kXomzVKRGRpFNeVpEQ1eZUIaOidLDWNV5TXYkOjO96B2GFAXFcVr94OaRO/h55OkYrqSlGImrzp5KLnDRiwgIJfvgJHl1vjeqrrlqoaSGrymoArNZDsu+gaXALXdWPjOgps+ic8r1bBVqK8WBo1kNTkVSJjg+zBzh7j4B4yK66f4NdrUf5inzrf7FcDSU1eE3CSHkzXTQtu/lt8Dzt8+EuUzenGZs51/amBpCavEnkbVA+2tx/AJlUxvxyRiiMMrtqTFGogqclrAk7owXTor/G9KyGIlWvdoB/lz1+f0VWYVApVA0lNXhNwpQZOzOyAJiM3wFLQLLrWlWV4/n4TpK1vKNFR2jRqIKnJm1awhrJMCh//nrsNmOwAnhJlmT04QQNG2slKBOP/6CV437xLDc8aedX0QjV5lTSiQUyyEhVR/tfhCG4vVaIbxWnUQFKTV4mADQIwHZu1nNI6+v0NeFA2rxjh/ZuV6EdRGjWQ1ORVIlyDAHyypBOajFwPwdGI6YQuuZ2cfaVmNxnUQFKT1wScsEyydxgUXQNX+r8K7d+Ksue6a3LZTQ0kNXlNwAmA6Z/kX4vcMMV+0s6lqPjzENXuFtRAUpPXBFwNMP2X/H84i0bGdePfMJ9dNlfzS4Tk++Bp+FZMBgLlioo0ASeBpERzKRUnWNHot2QDHhgvxrNwDALrZispNmmawoe/hvW0qqM67CL7onGQtryWtkwTsNaAqTyxEZt0xe4jyZEIKv46FMEdi9ICSZaAnLEU/OJl2M/vwT0Ofr2GeQaq7X6TCVgPwLSFV9gahaM/0XT5JHa6Ge4hJbwzmXAI/nVzUg7bJmCdAFOx1tad0GQELZ+iTlM0WT45GsPV53E4i0fz95tSDNsmYB0BU9FJl0/zihRPklKN6ew66/D5aYdtE7DOgNnyqWgUCobOqVo+7VqGipcHq14+sc99mmG72YyyeL2ZHrlVMmHImZ0sMvlFDu9S0iaWJtOe4R76HJxFVcultMsnix2Oq37HorZAlpkLw5Sz5lqG7UTnbw0OMOdDIxKB9Ok/mZ/m6q4YklEna1bsVz0YR9K3RLDCenoH7lH44M6avViwQrziNrj6PAZrs3MymjWnGrZjhTQ4wCyuUe9HuDvA5FMr8PHLLASOXHZAcY9Wn1CA2OkXcPWdDGuLC1IWJ6eZNacatunvDQ5wdKbbGa4BT0Bs359Tqhz0g4ZR/+qZurvwtV9yA1z9psDWqiMnA53pIm8CQpNWimfN8QKqDds57YSlrgfKE7VpO+caFsXMfv61PGh/OfzrZsO/5mnNXezbL+zLXi7bWV14sL4TLBqLf/3cuLFC6ay5ete3tGjPXl5pWykix79TP9BUK8HQk6xkrbVd0AduUvrZV/BK9xyD/4On4F//XNpLY+m0aGt7LXPIkhg5jfLIgQrmcjH6MiV3ypJu1qx0jzqdjEqf5xzgWMPYsNl/KmxnXMKDLjvIbiEGPnox44Ps1rO7wk1gL+zNjxKSD/6Nzyv/HGS42aEUVl3S5Sxg1ljBArHTTdGJT3PeiVj4+P+Y+0IWNCON93Vya0wvS3XH3nTTkByR+96fBrn8h4z1y5y5DJ+XdrMj44IzyJDbgGMNpVhKXX8DZ+9HudOT9Dh8+Cv4lj8Oacu/azhosbS4iN3vpTgMicG1aCZMNwzJ+231UD0Z6DaetD6H7awADmz6Bzyv38HCvOr6szpYYEpyjJYY64jqDB3YBt+yR5nFyNLsPBYRTbz8Fs5fNVmVpC2vR9faP+7WVtRUw/aJfeyMmJK1fV0E0g2ws9cjbDIU+5E7Q9/SiZWeVXWOMyQWwFk0mnnHsbibcnqhzQtL83YQrHbu79K2BWw3Knzw87roUXEe2vkii1Piz7v4ITZB1OOnG2DqJY3vWw1rszac3CGKnrJkAkJfrdCjPVyZ5GKBIDPLTuWBu+qVSruWsZ4d3veprvKw8AWDZ9WYwNFcoXz+dbo5CNcNMNOW3RXtSdc/WKMnsTiA705A+H//0VWxbC5GQSd7TYi6KLQ7WX1kjKcRJfTdRl3rZy7++02FeMXtXMBLWnL5PpgVdV+sY2RTfQFXqo71pJ4PwVk0Kn75K6ZVWuBTdO5MDAl1JUK+rsRLhyG8/zP9Q97QN7fneDiLx/BR2yLh6FYrOTitOFTXpijOlxXAMWmExmewyY3jyt9yxnA5EmbLGTa5OfG9YuENmZBm9OS5tu+kGhM9accSFnQkGy9zXOd6edmpTfnk4Ix2isSf3MgvTygg8/p58K+aAdl71JD8ahOKheMb/CTn24vSh77/lB3Cy8Rzj1aNz2oPri40HZlxDZxRI4ydTMEn6fu0drYmB9O1UlaqctgO2JAS2M8r4pKEj+1lUdukza9q6iQ1k/bUK+CYoLa2PZgb/pivqtjfI+WH4Xt/KvPajrCUSbuyktbS7Fy4BkxnZsTEjZIIGSNWTo9GR83QZ7XWghsCcKxRtL/sHjCtpuH96J7oiQnqCRnGL9RaYWxW7moKWufTAfrEOIvMVk0e4ldMNcwnxlCAGQzaX+5yG9tCtDY9m+MTOrCdhXAN7lyiB7f0ZVpFFiiagmhW30CRtr7FAkar9feRXojMUhgPcEx+2na85r7otmNCHAV6HNyzEb4l47PolFRgE0KaL1R3Dk6y0AQqvPfjzDSfpdTGBRxTAK0ne4yDs8cDNXajpJ3vwvfuwwj/sE03dTH3wUNKYGvTlZ9AHdnNNmqy5a+6rg00PuDKlrHdqN4TmTGB++4xA8Fr8C17TNPtPhaomiK2dbyB022EAnSsmILAh3+sNbx8XYFonS9nAMcabmnahp2PEi//Fb/1RxMcijdMh/FU7BCxF4k2Y7rdzW/G0BmwdXOia/QUMZi0hqNFeTkHOP6JbnkxXAOnQ7xkCKcHctHgX/ss/GtKMgNB++bFY+Dq+RAfik+Wo8d1lz6Sk7tsOQs4voZu0w2uQTNhb1vMD6Weo6y30clLhPypOwPN2i+/lZk2LaecyaVjBhGaQO3fokVnqpcych5wTGsUZp16dPUQdZET++BdPgnSf/5W4+iOrV2v6ASq9WX8cuzgDvgWP4jgrqX1AkXLSvMGcFQpdDj9Jna+KvFCNj2heA/eZRPZrNd6Rke4Bj0FsX0/vtfTgb33HkPgk7+kPcelJQQ9y8ozwJWqqrw3RNdLLE1O55c3h78CGTtizljoIfturylh+9+QPHrqO+tl5yfg+LjthrP4/uiBA1dhDeWSmZJ6K/Vaufxg1pWfjQrzG3ClBimqivP68XB2HxE3vpOHHfrO6hU+NhvwlNTRIADHFEHHZ8SOdKJjSxa3OZVg0C9NgwKsnxqNW7IJ2LhsNJHMBKyJGo1biAnYuGw0kcwErIkajVuICdi4bDSRzASsiRqNW4gJ2LhsNJHMBKyJGo1biAnYuGw0kcwErIkajVuICdi4bDSRzASsiRqNW4gJ2LhsNJHMBKyJGo1biAnYuGw0kUzQpBSzEMNq4P9n/CWp0vLj/wAAAABJRU5ErkJggg==",
+      "created": 1698433832678,
+      "lastRetrieved": 1708463794770
+    },
+    "30fb3952dfc0d0b1cff3d7aff756b93fc647a8dc": {
+      "mimeType": "image/png",
+      "id": "30fb3952dfc0d0b1cff3d7aff756b93fc647a8dc",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAAEABJREFUeF7tnXl8FEUWx389d0+CQJRjBRZQFMGLQ/FEXO5bcFEUUVdZ1/VCFAhBbkHkFlAX3RVdj3UVZQW5UREQFDwQXFFhFURRuWQIJD09Z++nqpOZqUwm6Z7pniRt9Z9JXe99p6qrX716T/j1ISjgj2U1IHDAlmVLBeOArc2XA7Y4Xw6YA7a6BiwuH38Hc8AW14DFxeMzmAO2uAYsLh6fwRywxTVgcfH4DOaALa4Bi4vHZzAHbHENWFw8PoM5YItrwOLi/WZmsJBbH2LPR+FufwuiRUcgf/AkAh89C4T8lkZsfcA2JzwdH4Cn+0TYxNoMzOjJQ/BvmFUCWrIkaEsDdp7XC94B82Gvf26F8KKnjkB+fxbkD58BgsWWAm1JwLZ6LeEd8ARcrXoxsCKHv4H09ijY8ppB7FIAW53G7IwuOgr5/dmQty4CgkWWAG0pwIKnNjzdJsBzzXAIdmcMUNR/Av51jyKw5SkgGlL/bnfBfdkweLoUwF7392VAH4O8cS7krU8DgVM1GrQ1AAs2uDvcCbHPdNhy68WAKNEoAtufg3/1eCjFR8sHRUB3uAOeLmNhz2vKgi4+roImP4zAyRoJusYDdjTvCO/ABXA0bssACH23GdJbDyLy805tYGxOuC+9HZ6uj8B+enMWtOSDvOkJBD5YCEUu1NZeNSlVYwHb6jSB2HcW3O1uYt+zvh/gf3s0gruWpKdimwOuS26DSECfcTYL2n8C8qb5CGxeAEU+kV77Wa5V8wA7RXj+kA+x8xgILjG+HAcl+slDdsOGfNsS0O1ugdhtHOz1zikDupBCljfPh+L3ZRmZvu5qFGDXxTdC7D87aVMU2PEa/CvzET3xoz7ptZQW7HC1GwKx2/ikzy1FPkkNJvKmeVCk41pay3qZGgHY3qgtfc86z+rIKCh8cAd9z4b3bzFfcYINrrY3q6AbnMf0p8in6EaMgi4+Zv5YdPRQrQELOfUg9p4G92V/hmCzxcQihgn/6nEIfPw8oER1iGtAUQK6zY0Qu02AvWFrFnSgCPKWp+nOO+Wu3YAh6GmiegImO9qr74fYYxJjXlQiIXVJXP9o1e9mCeiLBsHTfQIcv7ugDOhiyB8uokYTpeiIHh6Gl612gFXz4hOw12/JCBv8eg2kZQ8henSP4UrIrEEBzov+CJGAPvMiFnRQouZPCvrUocy6SbN2tQFsq3cuvNfNg6t1H0aUyJE9kJY/jNDXq9MUMVvVBDgvHACx+0Q4GrUpA9qPwLa/w//eTCinfsnWgGg/VQ/YfRpVSrJ5sRDyO1Mhb14YNy9mVTXpd+Y8/zqIPSbC0bgdCzokI7DtH/BvmAml8Kf0O9BRs+oAk3dYhzvg7T0dtlr1Y0Om5sWPn6ebqKp+f+nQY7lFna370n2Eo8klLOhwAIGtiyCtLAAigUy7qbB+lQB2NL+6xLzI/sJD+7ao5sWfdpgqdLYbd7bqDbH7JDiadmC6JquTtOxBU4eTVcCqeXEm3O1uZt+zvh+poSL4+WumClvVjZPNWO7QVyE4XHQoZH9ROIP9pjZ6jNkBTM2Lo0vMi974chz00x0meSchZE2PClVYgVrDvH1nwlanUUz+4K6lKHpxkNFMmfZMB+y6+AaI/WYnHcUFdi6hhwLREz+YKmBVN25vcqlqhWt2BTOU8IHtOPXC9VBO/mzqEM0DbHMg909L4bqgPyvYTztV8+K+zaYKVtWNC7UawtvncbguvR2CIMSGQ/zApFVjEfzkRSALEaxMA0xOYnKHvhIXrOgoPXgnB/BZNy9mk7bdBc81I6jNWvDUir+OwkF6+uR/Z1pWvURMA+zpPgnenpOpgMGvVqH4laE15gw13d+Ds3U/aqyx12vBNBHcvYIaa6LHvk236bTrmQZY7DGZfgOSR1o7GfL6KWkPsrpXtNVvhZyB8+Fs2Z0ZauTw1yh+awTCe9dXmQgccAaqFzx1IPacDPdV90GwO+KvI+Lkt3YyAsRpLxouvwfiC3bF3XCe0xmRn3eVfEkY74TPAacDmDj5XX4XxF7TYMs9I/6ejUZUU+SaCRWeC5e3lAc+fQXFr96azmgqrMMB61Sp4+xO8A5YAEeji5maoW83UasUmY2pHrKUU3/t83okFVFCMnxj4i5IOoeVsjgHrFGTtrpN4e03G642N7Dv2eMH4F9BnPzeSK3kCpZym1gnVu/4w/HPKY3DqrQYB1yZipxeaoHzdM6H4PTEl2Pi5PfeDGqJQ1guv5VKl/KJqDtVdQhQFAW+kXGvlcqGpfX/HHAFmiI+WN5+s5KuuAR2/BvSinwohQdT1k69lG+EtGxEyVIuIG+e6nLEAWv9yRpQzt64vWpebH4V01r4x89UK9z3W1O/ZytYysm9qNAXbybU5YANwKW9CXKHmJxPk3Nq1snvMKTV4xD8+IXUVjiylHcpoIcq2pfyBMDRKHyj7NoHq7EkX6KJosgd4muGU88SwXNa/D1LnPw2L4B//dQK7yalXMo/exXSyjGpl3LBhry5EXWJ5oA1/mR1FnO26qOaF8vcISbmVWpePLo3dYt2N3KHLU/67NGylNNGOWCdtHQUV+8Qz4erVU+mFr1DvPwhhL5ZW2lrrg53IvemxbFy0VOHIa16BMFP/qntQIUBHIFvVNwaVmnnGgv85pZocoeY2MiJ3zV7h7gQ/nVT2DvElSiR3EX29nqUliIzvujlIfqumQp25M1VTZlKlAPW+JtNUYx8k142DGLvx8q5Q7xYdfJLdYc4RZMk7oe3p3qIQi6Y+9ephyuaHw5Ys6oqLGg7owVyb1uSfId43weQ/jNc+x3iMr2wgKfAv049HtX8JAKOhOEbHY9KoLmNSgr+Jpbo0x7czng0Rsgd4hX5CO58PSM9Jp55k+VdN2CbA3lz1JASCgecJgvBjrpzQtRthliLCAij7hBnfObNAacJNbGazYm8OcGSWRKCb7TqsmrEwwKeRC/F6XoYwMaOrXQc1l+iTQU8hV5RIY+0lgPW9eM2rHC2AK+ZSO9S6XpMHBufwbpIlF+YxL4k10bpDOaAq8jpzsRZIvacCrH7+BLAEyATl1g9T+LYwkH48t16amsqy9/BmtSUagYnAF49HvK7j+lrze5C3mz1dqHCAevTXay0mTO41zQaZoku0RywBZfo3o/RgGkU8KpxkN+bru9XyMzgAHz5cZcgfQ2lLs2X6Aw0SezaccCPQH7vcX2t2d3Im636cylhDlif8kpLm7lE954OsevYkhnMAacHKNNa2QK8cizkDTP0jTZxBnO/aH26y8omq8/j1A+LvoPTAezwIG+Wel2FO76nyZf4W5lmi+4zA2KXMSWACyCTSAV6Hg5Yj7ZSlM0W4BVj1FMqPU8i4KAfvoJ4eAs9zVRUlu+i09QkuUCWc8MzsNU+U53BK/LVWw56HqeIvJlqbBKFA9ajuYSyBs9g6js9cCHcbQczAyp6+Wb9UYI44DShJlYzELCr/a30dqAt5/RYDyTyrfTW8PS8QxjAEnwFOQYIzDbBl2gNKqU3C294Nsn/OfDJS9TFNu1g4BywBu1XViSTGUw8Ma+6D94+0yG4c2M9RY4fgPTG3QjtWVdZ7xX/3+lF3kw1EZcS5DM4PWWmCdjWoDVyBj/HxLeicTS3PAVp9SPGZEjjgNNjytTSC5jcU+o6FmLXcbGQg6S9yKGvUPT6MEQObDNgUCVNJAIOFMM3Nr5KGNUJfwcnaNL++w7IGbyYieBOzmnJIYL/3elARHXeM+xx5SBvhppCT+GA01Srlhns9MJLckN0fJC5NkrCDRa/NgyRw7vT7LySajUZMBMI7cvlKPrXrVmN8BZTbSWAyV2lWg9sYWdtoBjSmvE005mZUfnsjdqh9sjPSmZwEXxj45HxjPpFmbZEk+xhuUNIPEb1ITfv/GsnIbCNhDJU78Rm5akEsLvjcOQMXBAbSmjPOyhe8hdEfd+bNzxXDo0f7ek0InYBjtxqLJzZyvA+TQNMsnvWumsVnOd2ZQYdPrSbRpkNfbPGcGHKbbASwGLCmS5JKystvdfUcTkvHEjDMNnrNon1Q97zRS8NRujLZYb3bR5gOlQBrvZD6Y2+RIHIf0J71tNcvpFf/mu4UEyDOgCndeSncfS2vObwXv9kUtIRmkTzzXtNe8+bDLhEehIQvNPDakDwxAispfkZSGQ4s9LOVDVgEn322lFq9NmEXIvRoqOQSBLNT+OvMY2/FV3FsgO4ZEhCbgOIvabCfdmdEGzxgCNKoIjGapQ3zjM+8nsVAna06IycQX9jckDFchqvLMhKYsusAi796dkbXgCx/5wk2270xEE1ms2nLxsXLLsKANNg4P3nwt1+CLv/OPg5it+8B5EftuuahZkUrhLApQN2tuxBQZdNDUeTTi4fifB3GzORTa2bTcDEdn3lPWoUAbF2fBMln4S0ZgICW57O7hdEtUiMJdjpkk3u+dhOa8gADX75Nj1IzyidXZYAk9wMOYMWwdGkPSMDSX1LovVkO+NZ6SCqdAYzmnDlqjEhrx3JJn6OhBH48Bl6e16RftU/o00GTGNG95lOYz8nBk+LHNmL4qX3Ify/d/WP2cAa1Qdw6UasdmN6PEc+r5hkFn6S6m4azT6qK1uYiYCpA0D/OWzmtpBM7dbyhln6xmkg1MSmqh3g2EasUTsaoMzZohMjeuTX/fCvLEBw1xJtKjEBMA3hP2hR0thohtSl9yN6fJ+2sWWhVLUFHNuInX8djfhaNhJd6PuP4CcbsQMfVawmIwGTeJTdJ6ivEXs8Ig7Z/RcvG4HQF0uzgExfF9UecOlO2H3lX9WE0Qn+UOR/NMHWygJEj+8vX3KDADvP70+d7ex5TeO740hYjWVJwicF1WO/6vbUDMCl72dPHXi6jYen4wPMYTy5uEUSPZL7uYpcyOo4Q8DUH2vgwqQEX6H9WyGRb1qzTa0Z/mJqFOBSWaldt+/MpPD60aJj8K+fQnfdsWwn6QImnh3XjqRLsuCKO6STPkgEWRpaOAuZyzLkWw0SRGcggaPZldRi5Gh2ObsRI1nDV+QjtPvttAwdjrOvVU2MDeLHdyTGVmD7YvhJeGDpeAajzm7VGjmDy6rI1WYwxL4zYM9rxvwr9O1GmoS59gjVj0qJJMeiYo4LN82HkHM63Jew6W3CP+2iy3GlG7rsstPUmyUAU0ntbhrU29N1HGsmVJTY93RlgMtqTJFPQVo7EQHy7Z1NJwVN6LQVsg7g0o1YzhkgEeioZSkhGxn5N/EqOTGJNYe6r34AOdcvTNIW2Z1Lyx4yPf2rNkzpl7Ic4NhGjAT87j8brvP7xbRDluuyVzzL+mRFjn6rmhirMN9g+jiTa1oWcKmoZCPmOKsjwgc/Tw3N7oazZTfqYBfa+67x7rFGEtPZluUB69SH5YpzwJZDygrEAXPAFteAxcXjM5gDtrgGLC4en8EcsMU1YHHx+AzmgC2uAYuLx2cwB2xxDVhcPD6DOWCLa8Di4vEZzAFbXAMWF+//n+x1mC2t7cAAAAAASUVORK5CYII=",
+      "created": 1698433843748,
+      "lastRetrieved": 1708463794770
+    },
+    "48c11a4ac31ddea5e6f5a39963f8ee9aae7f345d": {
+      "mimeType": "image/png",
+      "id": "48c11a4ac31ddea5e6f5a39963f8ee9aae7f345d",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEoAAABICAYAAABRGGN6AAAAAXNSR0IArs4c6QAADMBJREFUeF7tnHmQHHUVxz+vZ3dDIAnIJQlBQIUAVqklWHKES84c28tRlCBQoIilKERgejcJBJcIht0ZFLCCdxWUWAgRcHo3HIlgIOFSkLLKkgBRxMh9muwmbDbdz/r1dg89szM7PbMz2aQqv6r9Y6ff7/r2+73fe9/f+7WwvSRCQBJJbRdiO1AJlWBMgLputu7dAtPF4mBgGnCgCLsqTGToz5T1AutVeU+El1RZDawe8Fl5da+8mnB+dRPbQkCpdNkcZ8FZIpxggBnlDF70lUdEWdLfw4pOxB9lexWrNxQoozk7pLgEOB/Yp+JoahNYq8odAz6LG6lpDQEq06r7izBXhQsFWkrMfyPKKpRnfXhBYbU/yBs6yPpNr7PeyLdMZqI0M9FqZq+UMA3lIIRDEaYD44vbVNgkym2DHl3zlsq/asO8fK26ApU5WXdiPAsErgCa492q8jbKnSLc07eGpzr/IZtqmUznIdoy4dMcrsqZCOeIsEdRO4MoP9YPWegsk/5a+ihVp25AdbfqbMvi1mFLTFnlQWbjOu7vXCGb6zVw007ncdo0fhIzU+CEmhZvfq16fMfplZ569DlqoMwb3unTdInwvQINgpXqs6C9Rx6tx0ArtZG19RiFH4hwTIGscnPfGtpr1eCorVEB1WXrFAv+IMIX84NT3kRx0j3ym0qTa8TzjK3nCWQRPh61r8pfBnxOH42xrxmoLlunWcJDAvvGBnTfZo+L5i2V9xsBQtI2O4/TXXaaxK9FOCM/NnjFV07pcOWFpO3E5WoCKjtLDyXFgwi7h40NKqSdnNxSyyAaVSfTppcF2hVtLMo7eJyaXirPVttn1UAZTUrBqhhIfZ5yRocry6vtfEvId9l6Ukq4F5gQ9Ke848H0ajWrKqACmyQ8kV9uQ53O6HDlmS0x6Vr76LL1sBQ8EL1chVcGPI6qxmYlBirc3VbFDLfRpOO3dpAicAOwhD9FmmUMfP8apifdDRMDlbX1JoQ5kU3ylFljudy6bf22NeSSlPL8h1aZsgHhaicn95n/zTK0hN58tKDcnHalwK0pp7WJgAqdybzjpjBnrA13xtZ+EXastBwVnndyckgk192ql1oW+U1HPewkTmlFoExYIuN5PvK4VbnPcSW/7VYaaLXPL52h43bbSHPnCukbqW62TTVJ28YeOTnZLy6bsfWemOuwVjdycKVwpyJQWVu7ENrDHePNQY+DG+kndbXqaSmLu1V5UmC557NsYy/PFFMpcaAGB9g/DkSqhb0tYdXQJjccKONnTZjE6rxTqnSnXekYCfgRgVo0Sz/Z3BQQZkGAq8r5jit3JHmTtcpk2nSxEFAz+aKKcWAfRsg6OXnaPIgDlc5JwTyyM3Vfmvl3OaDM74EHL0TRw+DgZg4aiXUYEaisrT9H+GYI0mOOK8fWCkDSehlb7xU4DRlOUyu85eQkCE1GC1QI1qNRbKjKLx1XgrmWKmWBMqTbuBT/iu0Qx6ZdeSzphEcjl2nVL4twV8ypHWpOeTXtytR6AWUCaYQgaDd8lr+JT3U8IP+tCqiMrT8UYV44wFVpV44ezeST1DWEH8JChK8KWMV1VLndceXCegEVaFWbPiYQzE2VRY4r8xMD1YlaE9qCNR7Qt57S1uGKm2Sytch0z9S9pDkg/C6OE34KPoovQlM4jvM6XPltMVAj9VnKmMflM7O1VVJEc1vbl2O/Uhx8yaUXqL7FwyHKb/evY0q9STfTdhjlmx11TrFPpNCDxyJSrAiWv6IDMPkqV94MNWGgDM1cgJsqLzmulD3MMOTfTjvzqsCewXx9TnB65JFi8EsC1W3rTy3hW2HFW5weiTzyWhRmWJ3OVt1xR4vLLDBb8i5xAVUe9Tzmz10qT2RsnSVCb7j8/5Z25fORrDENCFdWAGsjPul0jxjmtWyJRx2+8rN2V76dCKhsmxrOZugtKAVG3LyBatGKtPGbh2rzgVO4WIUFIuxV+Op5zof57a48GP3eZaudgoXAZ1W40cmJU23fSeQLjHoZDRymUV0zdGqqhbXhstvQv4aPmcDR+FRNKf4oUujcJRmI2a0UZnrC5CbIAxHWfdFQxk4PS0BKetvX2/pxBrCuekheT9RflUJhwP9+tPy9TexTvPsNAypj69ki3Blq0/K0KycHNsFWR4TuKsfwkbjPDekemZex1TAQRyn8Vz2u3dDHbY2wf9WOM2vrMoSTQgU5x3Hld/E2hgHV3arXWhbXhBXy22WmTa8SuC4EUBEqns4qGJc52OZV+ZHjypU3zNIjm1Ic0beOxZ0r5MORJnT5ETp+zz04aJ4rzxXLGW5MoG0k9kBgQ/86lnSukA8qARd3h3yfhe098v0Rgcq2qUHyKyEgF6ZduT3QqBhQ6nO90yNXJ+j8ChFujANVqU703IA0ZQ9cEQ7f7DFjbq8EsVtUsrb+HeEzldpTuN/JyaxKcllbL0C4LZS7K52Ts0cEKmPrsyJ8wQh5Pkd09MhTYwFU1tY7EM4NB9tXDNZo2INSoHW16uEpiydDBXku7UqAQVSGLb1sm74MBLSEicrnPShBcLmlNSrg5ocYycmlwCoASrk5PilVJonF1wJNLsEelAKqUiA93Ji36TsCu5nGNvWx+/yH5d16A9Vt6xwp8p9KDV5MSpBwTuxZn6+c2u7K4/UIiuN9dp6iu07YgWCuwHvpnAQYlNWoTJvmPd6+lxgXccr11Ki41pYCaKTfDIPQn2PyhDa8SK4WmqW4j8DHm0qUDzGYzkkBxVxKo7YDBYmAavjSy7Tq95DC0KWMFk0TIb775I36mC+9rcWY/3CmHtjSzIokxlyVm4rsySSErzfWmG93D8xWmcg92O5wQmWHM0kIYwg14aNdp9wupZAqFcKkUhzev45b6xHCiDKuXP8mhOlbz90NCWEaHRRnbV0ZZsetVZ9r/9zDbUuQ/FZfrbtQL/lMm5oUpoAAUKVyUFyOZumeoZ+SZpbXQrOo8howoxTNohokuy5od/l9OZolc7LuuUlIbVU0i0F0JOLOOGbVvsVfPCuDpo7hfXY8gItFubqYuFPlr54wf25OHoraN3w2KRaK8rlGEnfds/Roq4nghKkcdVyRCqaKRIakAJpjeh3HHMvCMJbDqGB85jm98mT3bJ1ppVgatKsUUMHZNr0e5UqkvI0ySRomwa3dlZ+ONLaaqeCCwwUTMvyPvRtBri2apR9raqID5dJhCReK6ymLLItHt+ThgudxYkevBAcrI8Z6wRLZwsdV15+ik1vGBTz6N8byuMqwrv059k18XGXAGosD0CDXIcVCNYn2VR2AGhb1I7590am6X/M4DF1UkWaJH4AS0tWlluk2daRu3riTk+BQth6xXoERr/VIPRjM2CRp3CNw+jaTpGGA2lrSfoAP1KT9QKZeaT9dtp6bEqIUptGl/YRaVZBI1reOg5KEBEldhWK5fCIZPIWyHGHZn3M8U+y9F1DBg0PUdVQ2C3s3NfF4ORtVnEimSsZxZShZrkypmHFXIjXxXseVM2sFolI9k5o4tZmWDleC62jlymgOFxqSmhjsgIUZH/g+l7X3yE8qTbqRz7e6ZNdosnHvNUi6UmaPZfp0tlUvUZM+LeXTp4ENJlxKu2JuLpiTpBOBpVFih/okTkCpuPQioLb1hPzg/k5TwJgGVz1UeaZ/DUfVPSHfNB6mKz6+rV3xKL7kpMp/BnyObMgVj0izSl0aUjjdyckfG2mTam3bLDcBc3NhSJPg3UGf6fN7xGQ7Jy6Jl168xWFvCDapT3qsDXzxrDO2fhfhxrxNgnfNAWot93dqAsoMKLjYCMtE+EQ0QFXu7V/HRY30s5KoQJDyuDO/Esi7MWa5DSqnVKtJUX81A5W3WRb3FV+VDS45NjhxvxxgxuO2IBsnBo3hHvA5rRqbVNz+qIAyjYXX67tjN6+CPlQxackLtlRuuglwJRVcvi64NGBcgP5/4iTd3cq9gFEDFTUcOqWLi6/zK6zEI9PfxwP1Jv+CjN4JzCCFE+WKxya61lO+W6+077oBFTh05ibWDlyDcPmwD0TAW6Lc6Xvcs+Flnq71DQe8+/58SVKcESbuB2nPsTIYnBx/yLWVbkwlsXd1sVHlOgoTY+ciXFAqvTm8cBh8ckSF1QIvyCBv9Hmsf+2doU+OTNmdiRNSTNRm9lIwG8c0hcNQppe6p2eiBZTbN3vcsNV/cqQYOHP0ZTVzCcL5AsEdlnoXQ+aJzx3eZhaXu8dSjz7ruvTKDchw8ONnc7yV4iwUcyHogNEM3hwpITzieyzZ2MuftvnPIpXdwmfoVGniaJGhD20JHKDCrlL0oS01H9tS3lN4CfNVIOV53czKRmpOw3e90WjItlB3iyy9bQGISmPcDlQlhMLn/weJZ0Oyco1JHAAAAABJRU5ErkJggg==",
+      "created": 1698433910223,
+      "lastRetrieved": 1708463794770
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Adds excalidraw architecture diagram for the stable diffusion blueprint on Inf2. 

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
Adds excalidraw architecture diagram for the stable diffusion blueprint on Inf2. 

### Motivation

<!-- What inspired you to submit this pull request? -->
Currently, there's no folder to store the excalidraw projects. This PR adds a folder in the gen-ai section of the doc website to store excalidraw project files for the stable-diffusion-inf2 blueprint. Similarly, we can add other excalidraw projects to this folder.

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
