### PR TITLE
feat: Override eks_data_addons jupyterhub chart version default

### DIFF
--- a/ai-ml/jupyterhub/addons.tf
+++ b/ai-ml/jupyterhub/addons.tf
@@ -302,6 +302,7 @@ module "eks_data_addons" {
       jupyter_single_user_sa_name = kubernetes_service_account_v1.jupyterhub_single_user_sa.metadata[0].name
       region                      = var.region
     })]
+    version                     = "3.2.1"
   }
 
   #---------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

I had an old version of https://github.com/jupyterhub/oauthenticator that broke my custom auth. On closer inspection we aren't even using a GA release of the jhub helm chart.
```
 $ helm list --namespace jupyterhub
NAME      	NAMESPACE 	REVISION	UPDATED                                	STATUS  	CHART                  	APP VERSION
efs       	jupyterhub	1       	2024-03-15 16:26:51.545097674 -0400 EDT	deployed	efs-0.0.1              	0.0.1      
efs-shared	jupyterhub	1       	2024-03-15 16:26:51.544946007 -0400 EDT	deployed	efs-0.0.1              	0.0.1      
jupyterhub	jupyterhub	1       	2024-03-15 16:36:12.27339005 -0400 EDT 	deployed	jupyterhub-3.0.0-beta.1	4.0.1  
```

We pick up this default from eks-data-addons:

https://github.com/aws-ia/terraform-aws-eks-data-addons/blob/main/jupyterhub.tf#L10

It might be best to make this change over there-- but IMO data-on-eks jupyterhub should make it very clear how to bump the jupyterhub helm chart version, so explicitly putting this into addons.tf makes sense to me.

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
