### PR TITLE
Fix nvidia crash backoff loop

### DIFF
--- a/ai-ml/jupyterhub/addons.tf
+++ b/ai-ml/jupyterhub/addons.tf
@@ -282,6 +282,10 @@ module "eks_data_addons" {
   enable_nvidia_gpu_operator = true
   nvidia_gpu_operator_helm_config = {
     values = [templatefile("${path.module}/helm/nvidia-gpu-operator/values.yaml", {})]
+    set = [{
+      name  = "toolkit.version",
+      value = "v1.14.6-ubi8",
+    }]
   }
 
   #---------------------------------------------------------------


### PR DESCRIPTION
In nvidia pod logs:
version `GLIBC_2.27' not found (required by /usr/local/nvidia/toolkit

It looks to me like those pods were based on Ubuntu, not Centos but the fix described below fixed the issue:
https://github.com/NVIDIA/gpu-operator/issues/72

I'm really not sure if this is the appropriate thing to do, but it fixed the error ;)

```
Name:             nvidia-gpu-operator-node-feature-discovery-worker-x7x4q
Namespace:        gpu-operator
Priority:         0
Service Account:  node-feature-discovery
Node:             ip-100-64-143-96.us-west-1.compute.internal/100.64.143.96
Start Time:       Fri, 22 Mar 2024 17:40:16 -0400
Labels:           app.kubernetes.io/instance=nvidia-gpu-operator
                  app.kubernetes.io/name=node-feature-discovery
                  controller-revision-hash=6b47dcc669
                  pod-template-generation=3
                  role=worker
Annotations:      <none>
Status:           Running
IP:               100.64.208.54
IPs:
  IP:           100.64.208.54
Controlled By:  DaemonSet/nvidia-gpu-operator-node-feature-discovery-worker
Containers:
  worker:
    Container ID:  containerd://ddd2aacbba26932ffa91f34b1fe2e71d634901fbf4ab53a44009ac59afd6e02c
    Image:         registry.k8s.io/nfd/node-feature-discovery:v0.12.1
    Image ID:      registry.k8s.io/nfd/node-feature-discovery@sha256:445ed7b7c8580825c23a6f3835c1f13718fcf72b393f51e852aa5bdda04657e7
    Port:          <none>
    Host Port:     <none>
    Command:
      nfd-worker
    Args:
      --server=nvidia-gpu-operator-node-feature-discovery-master:8080
      -enable-nodefeature-api
    State:          Running
      Started:      Fri, 22 Mar 2024 17:40:16 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      NODE_NAME:   (v1:spec.nodeName)
    Mounts:
      /etc/kubernetes/node-feature-discovery from nfd-worker-conf (ro)
      /etc/kubernetes/node-feature-discovery/features.d/ from features-d (ro)
      /etc/kubernetes/node-feature-discovery/source.d/ from source-d (ro)
      /host-boot from host-boot (ro)
      /host-etc/os-release from host-os-release (ro)
      /host-sys from host-sys (ro)
      /host-usr/lib from host-usr-lib (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-8dtk6 (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  host-boot:
    Type:          HostPath (bare host directory volume)
    Path:          /boot
    HostPathType:  
  host-os-release:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/os-release
    HostPathType:  
  host-sys:
    Type:          HostPath (bare host directory volume)
    Path:          /sys
    HostPathType:  
  host-usr-lib:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/lib
    HostPathType:  
  source-d:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/kubernetes/node-feature-discovery/source.d/
    HostPathType:  
  features-d:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/kubernetes/node-feature-discovery/features.d/
    HostPathType:  
  nfd-worker-conf:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      nvidia-gpu-operator-node-feature-discovery-worker-conf
    Optional:  false
  kube-api-access-8dtk6:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 op=Exists
                             node-role.kubernetes.io/master:NoSchedule
                             node.kubernetes.io/disk-pressure:NoSchedule op=Exists
                             node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists
                             node.kubernetes.io/pid-pressure:NoSchedule op=Exists
                             node.kubernetes.io/unreachable:NoExecute op=Exists
                             node.kubernetes.io/unschedulable:NoSchedule op=Exists
                             nvidia.com/gpu:NoSchedule op=Exists
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  28s   default-scheduler  Successfully assigned gpu-operator/nvidia-gpu-operator-node-feature-discovery-worker-x7x4q to ip-100-64-143-96.us-west-1.compute.internal
  Normal  Pulled     28s   kubelet            Container image "registry.k8s.io/nfd/node-feature-discovery:v0.12.1" already present on machine
  Normal  Created    28s   kubelet            Created container worker
  Normal  Started    28s   kubelet            Started container worker


Pod 'nvidia-operator-validator-v999m': error 'pods "nvidia-operator-validator-v999m" not found', but found events.
Events:
  Type     Reason                  Age                    From               Message
  ----     ------                  ----                   ----               -------
  Normal   Scheduled               34m                    default-scheduler  Successfully assigned gpu-operator/nvidia-operator-validator-v999m to ip-100-64-95-180.us-west-1.compute.internal
  Warning  FailedCreatePodSandBox  33m (x2 over 34m)      kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to get sandbox runtime: no runtime for "nvidia" is configured
  Normal   Pulled                  33m                    kubelet            Container image "nvcr.io/nvidia/cloud-native/gpu-operator-validator:v23.9.2" already present on machine
  Normal   Created                 33m                    kubelet            Created container driver-validation
  Normal   Started                 33m                    kubelet            Started container driver-validation
  Normal   Pulled                  33m (x2 over 33m)      kubelet            Container image "nvcr.io/nvidia/cloud-native/gpu-operator-validator:v23.9.2" already present on machine
  Normal   Created                 33m (x2 over 33m)      kubelet            Created container toolkit-validation
  Warning  Failed                  33m (x2 over 33m)      kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: /usr/local/nvidia/toolkit/nvidia-container-cli.real: /lib64/libc.so.6: version `GLIBC_2.27' not found (required by /usr/local/nvidia/toolkit/libnvidia-container.so.1): unknown
  Warning  BackOff                 33m                    kubelet            Back-off restarting failed container toolkit-validation in pod nvidia-operator-validator-v999m_gpu-operator(7e6a37cb-0696-4a75-96dd-6360f3fb4866)
  Normal   Pulled                  33m                    kubelet            Container image "nvcr.io/nvidia/cloud-native/gpu-operator-validator:v23.9.2" already present on machine
  Warning  Failed                  33m                    kubelet            Error: failed to get sandbox runtime: no runtime for "nvidia" is configured
  Normal   Pulled                  31m (x4 over 33m)      kubelet            Container image "nvcr.io/nvidia/cloud-native/gpu-operator-validator:v23.9.2" already present on machine
  Normal   Created                 31m (x4 over 33m)      kubelet            Created container toolkit-validation
  Warning  Failed                  31m (x4 over 33m)      kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running hook #0: error running hook: exit status 1, stdout: , stderr: /usr/local/nvidia/toolkit/nvidia-container-cli.real: /lib64/libc.so.6: version `GLIBC_2.27' not found (required by /usr/local/nvidia/toolkit/libnvidia-container.so.1): unknown
  Warning  BackOff                 3m14s (x136 over 33m)  kubelet            Back-off restarting failed container toolkit-validation in pod nvidia-operator-validator-v999m_gpu-operator(7e6a37cb-0696-4a75-96dd-6360f3fb4866)

```