### PR TITLE
chore: Clean up pre-commit warnings and delays

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,go.sum,package-lock.json,*.css,.codespellrc,*.sql,website/package-lock.json
+skip = .git,*.pdf,*.svg,go.sum,package-lock.json,*.css,.codespellrc,*.sql,website/package-lock.json,*.excalidraw
 check-hidden = true
 # some embedded images and known typoed outputs
 ignore-regex = ^\s*"image/\S+": ".*|.*loopback adddress.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,6 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-      - id: terraform_validate
-        exclude: docs
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
### What does this PR do?

Added excalidraw to codespell ignore
Remove terraform validate from pre-commit, developers should run this themselves.

### Motivation

Terraform validate in the precommit takes absolutely forever on the root of the project. Everyone is skipping it or aborting it. So let's remove it.

Finally, excalidraw always comes up in spelling check output. Let's add that to ignore.

### More

- [x ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
