### PR TITLE
chore: Revert "chore: Clean up pre-commit warnings and delays"

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,go.sum,package-lock.json,*.css,.codespellrc,*.sql,website/package-lock.json,*.excalidraw
+skip = .git,*.pdf,*.svg,go.sum,package-lock.json,*.css,.codespellrc,*.sql,website/package-lock.json
 check-hidden = true
 # some embedded images and known typoed outputs
 ignore-regex = ^\s*"image/\S+": ".*|.*loopback adddress.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,8 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
+      - id: terraform_validate
+        exclude: docs
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
Reverts awslabs/data-on-eks#491

reverting this PR as the pre-commit validate is failing and looking for this hook

Check the results here

https://github.com/awslabs/data-on-eks/actions/runs/8835984927/job/24271524130?pr=485