### PR TITLE
fix: RayServe script name mismatch in Dockerfile

### DIFF
--- a/gen-ai/inference/stable-diffusion-rayserve-gpu/Dockerfile
+++ b/gen-ai/inference/stable-diffusion-rayserve-gpu/Dockerfile
@@ -20,7 +20,7 @@ RUN pip install --no-cache-dir requests torch "diffusers==0.12.1" "transformers=
 WORKDIR /serve_app
 
 # Copy your Ray Serve script into the container
-COPY ray_serve_sd.py /serve_app/ray_serve_sd.py
+COPY ray_serve_stablediffusion.py /serve_app/ray_serve_stablediffusion.py
 
 # Set the PYTHONPATH environment variable
 ENV PYTHONPATH=/serve_app:$PYTHONPATH


### PR DESCRIPTION
### What does this PR do?
In Inference module, within Stable diffusion on GPU blueprint, RayServe FastAPI function is of different name than that of what's in pre-built image. So either file name for RayServe script has to be changed to that of what's in Docker image in Public ECR DoEKS repository or Dockerfile needs to be changed to reference right script name. This PR is intended to take latter approach in modifying Dockerfile, so users using blueprint will be able to build own image that references correct script 

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
Encountered error while following blueprint and hence identified the change necessary

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [x] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
