### PR TITLE
fix: Incorrect command to provide Linux permission on the AWS Trainium on EKS Blueprint #533

### DIFF
--- a/website/docs/blueprints/ai-ml/trainium.md
+++ b/website/docs/blueprints/ai-ml/trainium.md
@@ -160,13 +160,13 @@ Login to AWS Console and verify the ECR repo(`<YOUR_ACCOUNT_ID>.dkr.ecr.<REGION>
 
 #### Step2: Copy WikiCorpus pre-training dataset for BERT model to FSx for Lustre filesystem
 
-In this step, we make it easy to transfer the WikiCorpus pre-training dataset, which is crucial for training the BERT model in distributed mode by multiple Trainium instances, to the FSx for Lustre filesystem. To achieve this, we will login to `aws-cli-cmd-shell` pod which includes an AWS CLI container, providing access to the filesystem.
+In this step, we make it easy to transfer the WikiCorpus pre-training dataset, which is crucial for training the BERT model in distributed mode by multiple Trainium instances, to the FSx for Lustre filesystem. To achieve this, we will login to `cmd-shell` pod which includes an AWS CLI container, providing access to the filesystem.
 
 Once you're inside the container, Copy the WikiCorpus dataset from S3 bucket (`s3://neuron-s3/training_datasets/bert_pretrain_wikicorpus_tokenized_hdf5/bert_pretrain_wikicorpus_tokenized_hdf5_seqlen128.tar`). The dataset is then unpacked, giving you access to its contents, ready for use in the subsequent BERT model pre-training process.
 
 
 ```bash
-kubectl exec -i -t -n default aws-cli-cmd-shell -c app -- sh -c "clear; (bash || ash || sh)"
+kubectl exec -i -t -n default cmd-shell -c app -- sh -c "clear; (bash || ash || sh)"
 
 # Once logged into the container
 yum install tar

--- a/website/docs/blueprints/ai-ml/trainium.md
+++ b/website/docs/blueprints/ai-ml/trainium.md
@@ -134,7 +134,7 @@ If you are executing this script on a Cloud9 IDE/EC2 instance different from the
 
 ```bash
 cd ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain
-chomd +x 1-bert-pretrain-build-image.sh
+chmod +x 1-bert-pretrain-build-image.sh
 ./1-bert-pretrain-build-image.sh
 ```
 
@@ -184,7 +184,7 @@ Execute the following commands.This script prompts the user to configure their k
 
 ```bash
 cd ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain
-chomd +x 2-bert-pretrain-precompile.sh
+chmod +x 2-bert-pretrain-precompile.sh
 ./2-bert-pretrain-precompile.sh
 ```
 
@@ -215,7 +215,7 @@ We are now in the final step of training the BERT-large model with WikiCorpus da
 
 ```bash
 cd ai-ml/trainium-inferentia/examples/dp-bert-large-pretrain
-chomd +x 3-bert-pretrain.sh
+chmod +x 3-bert-pretrain.sh
 ./3-bert-pretrain.sh
 ```
 


### PR DESCRIPTION
… Trainium on EKS Blueprint #533

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
There is a typo in the following commands on the Blueprint for AWS Trainium on EKS:

https://awslabs.github.io/data-on-eks/docs/blueprints/ai-ml/trainium
The wrong commands are:
chomd +x 1-bert-pretrain-build-image.sh
chomd +x 2-bert-pretrain-precompile.sh

The correct version should be:
chmod +x 1-bert-pretrain-build-image.sh
chmod +x 2-bert-pretrain-precompile.sh

### Motivation

<!-- What inspired you to submit this pull request? -->
I'm part of the AWS Container TFC and a Solution Architect working with customers promoting this blueprint.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?
Yes

### Additional Notes

<!-- Anything else we should know when reviewing? -->
