### PR TITLE
feat: tags + security group and karpenter helm config updates

### DIFF
--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -308,6 +308,7 @@ module "eks_data_addons" {
         subnetSelectorTerms:
           id: ${module.vpc.private_subnets[2]}
         securityGroupSelectorTerms:
+          id: ${module.eks.node_security_group_id}
           tags:
             Name: ${module.eks.cluster_name}-node
         blockDevice:
@@ -358,6 +359,7 @@ module "eks_data_addons" {
         subnetSelectorTerms:
           id: ${module.vpc.private_subnets[2]}
         securityGroupSelectorTerms:
+          id: ${module.eks.node_security_group_id}
           tags:
             Name: ${module.eks.cluster_name}-node
           blockDevice:

--- a/ai-ml/trainium-inferentia/eks.tf
+++ b/ai-ml/trainium-inferentia/eks.tf
@@ -22,7 +22,6 @@ module "eks" {
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"],
     var.kms_key_admin_roles,
     [data.aws_iam_session_context.current.issuer_arn]
-
   ))
 
   manage_aws_auth_configmap = true
@@ -135,7 +134,6 @@ module "eks" {
 
       tags = merge(local.tags, {
         Name                     = "core-node-grp",
-        "karpenter.sh/discovery" = local.name
       })
     }
 
@@ -279,7 +277,6 @@ module "eks" {
 
       tags = merge(local.tags, {
         Name                     = "trn1-32xl-ng1",
-        "karpenter.sh/discovery" = local.name
       })
     }
     #--------------------------------------------------
@@ -488,7 +485,6 @@ module "eks" {
 
       tags = merge(local.tags, {
         Name                     = "trn1n-32xl-ng1",
-        "karpenter.sh/discovery" = local.name
       })
     }
 
@@ -595,7 +591,6 @@ module "eks" {
 
       tags = merge(local.tags, {
         Name                     = "inf2-48xl-ng",
-        "karpenter.sh/discovery" = local.name
       })
     }
   }

--- a/ai-ml/trainium-inferentia/eks.tf
+++ b/ai-ml/trainium-inferentia/eks.tf
@@ -133,7 +133,7 @@ module "eks" {
       }
 
       tags = merge(local.tags, {
-        Name                     = "core-node-grp",
+        Name                     = "core-node-grp"
       })
     }
 


### PR DESCRIPTION
### What does this PR do?

1. In MNGs we were adding karpenter tags which was not necessary
2. Security group IDs were missing in karpenter helm config
3. Removed karpenter tags for 100.x subnets
4. Default Nodepool and Inferentia-inf2 nodepools were not getting created before the above fixes resolved the issue.

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [Yes ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ Yes] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [Yes ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ Yes] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
