### PR TITLE
feat: Upgrade Spark operator blueprint to EKS 1.30 and fluent-bt changes

### DIFF
--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -32,7 +32,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | ~> 1.2 |
 | <a name="module_eks_data_addons"></a> [eks\_data\_addons](#module\_eks\_data\_addons) | aws-ia/eks-data-addons/aws | ~> 1.30 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
-| <a name="module_spark_team_a_irsa"></a> [spark\_team\_a\_irsa](#module\_spark\_team\_a\_irsa) | aws-ia/eks-blueprints-addon/aws | ~> 1.0 |
+| <a name="module_spark_team_irsa"></a> [spark\_team\_irsa](#module\_spark\_team\_irsa) | aws-ia/eks-blueprints-addon/aws | ~> 1.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.0 |
 | <a name="module_vpc_endpoints_sg"></a> [vpc\_endpoints\_sg](#module\_vpc\_endpoints\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
@@ -49,9 +49,9 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | [aws_secretsmanager_secret_version.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [kubernetes_cluster_role.spark_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role_binding.spark_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
-| [kubernetes_namespace_v1.spark_team_a](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
-| [kubernetes_secret_v1.spark_team_a](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
-| [kubernetes_service_account_v1.spark_team_a](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
+| [kubernetes_namespace_v1.spark_team](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [kubernetes_secret_v1.spark_team](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_service_account_v1.spark_team](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
 | [random_password.grafana](https://registry.terraform.io/providers/hashicorp/random/3.3.2/docs/resources/password) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -67,7 +67,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | EKS Cluster version | `string` | `"1.28"` | no |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | EKS Cluster version | `string` | `"1.30"` | no |
 | <a name="input_eks_data_plane_subnet_secondary_cidr"></a> [eks\_data\_plane\_subnet\_secondary\_cidr](#input\_eks\_data\_plane\_subnet\_secondary\_cidr) | Secondary CIDR blocks. 32766 IPs per Subnet per Subnet/AZ for EKS Node and Pods | `list(string)` | <pre>[<br>  "100.64.0.0/17",<br>  "100.64.128.0/17"<br>]</pre> | no |
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `true` | no |
 | <a name="input_enable_vpc_endpoints"></a> [enable\_vpc\_endpoints](#input\_enable\_vpc\_endpoints) | Enable VPC Endpoints | `bool` | `false` | no |

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -301,10 +301,8 @@ module "eks_data_addons" {
   #---------------------------------------------------------------
   enable_spark_operator = true
   spark_operator_helm_config = {
-    name      = "spark-operator-team-a-release"
-    namespace = "spark-operator-team-a-ns"
-    version   = "1.4.2"
-    values    = [templatefile("${path.module}/helm-values/spark-operator-values.yaml", {})]
+    version = "1.4.2"
+    values  = [templatefile("${path.module}/helm-values/spark-operator-values.yaml", {})]
   }
 
   #---------------------------------------------------------------
@@ -390,21 +388,6 @@ module "eks_blueprints_addons" {
   }
 
   #---------------------------------------
-  # Kubernetes Add-ons
-  #---------------------------------------
-  #---------------------------------------------------------------
-  # CoreDNS Autoscaler helps to scale for large EKS Clusters
-  #   Further tuning for CoreDNS is to leverage NodeLocal DNSCache -> https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/
-  #---------------------------------------------------------------
-  enable_cluster_proportional_autoscaler = true
-  cluster_proportional_autoscaler = {
-    values = [templatefile("${path.module}/helm-values/coredns-autoscaler-values.yaml", {
-      target = "deployment/coredns"
-    })]
-    description = "Cluster Proportional Autoscaler for CoreDNS Service"
-  }
-
-  #---------------------------------------
   # Metrics Server
   #---------------------------------------
   enable_metrics_server = true
@@ -472,6 +455,10 @@ module "eks_blueprints_addons" {
   enable_aws_load_balancer_controller = true
   aws_load_balancer_controller = {
     chart_version = "1.5.4"
+    set = [{
+      name  = "enableServiceMutatorWebhook"
+      value = "false"
+    }]
   }
 
   enable_ingress_nginx = true

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -1,174 +1,4 @@
 #---------------------------------------------------------------
-# IRSA for EBS CSI Driver
-#---------------------------------------------------------------
-module "ebs_csi_driver_irsa" {
-  source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version               = "~> 5.34"
-  role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
-  attach_ebs_csi_policy = true
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
-  }
-  tags = local.tags
-}
-
-#---------------------------------------------------------------
-# EKS Blueprints Addons
-#---------------------------------------------------------------
-module "eks_blueprints_addons" {
-  source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.2"
-
-  cluster_name      = module.eks.cluster_name
-  cluster_endpoint  = module.eks.cluster_endpoint
-  cluster_version   = module.eks.cluster_version
-  oidc_provider_arn = module.eks.oidc_provider_arn
-
-  #---------------------------------------
-  # Amazon EKS Managed Add-ons
-  #---------------------------------------
-  eks_addons = {
-    aws-ebs-csi-driver = {
-      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
-    }
-    coredns = {
-      preserve = true
-    }
-    vpc-cni = {
-      preserve = true
-    }
-    kube-proxy = {
-      preserve = true
-    }
-  }
-
-  #---------------------------------------
-  # Kubernetes Add-ons
-  #---------------------------------------
-  #---------------------------------------------------------------
-  # CoreDNS Autoscaler helps to scale for large EKS Clusters
-  #   Further tuning for CoreDNS is to leverage NodeLocal DNSCache -> https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/
-  #---------------------------------------------------------------
-  enable_cluster_proportional_autoscaler = true
-  cluster_proportional_autoscaler = {
-    values = [templatefile("${path.module}/helm-values/coredns-autoscaler-values.yaml", {
-      target = "deployment/coredns"
-    })]
-    description = "Cluster Proportional Autoscaler for CoreDNS Service"
-  }
-
-  #---------------------------------------
-  # Metrics Server
-  #---------------------------------------
-  enable_metrics_server = true
-  metrics_server = {
-    values = [templatefile("${path.module}/helm-values/metrics-server-values.yaml", {})]
-  }
-
-  #---------------------------------------
-  # Cluster Autoscaler
-  #---------------------------------------
-  enable_cluster_autoscaler = true
-  cluster_autoscaler = {
-    values = [templatefile("${path.module}/helm-values/cluster-autoscaler-values.yaml", {
-      aws_region     = var.region,
-      eks_cluster_id = module.eks.cluster_name
-    })]
-  }
-
-  #---------------------------------------
-  # Karpenter Autoscaler for EKS Cluster
-  #---------------------------------------
-  enable_karpenter                  = true
-  karpenter_enable_spot_termination = true
-  karpenter_node = {
-    iam_role_additional_policies = {
-      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-    }
-  }
-  karpenter = {
-    chart_version       = "v0.34.0"
-    repository_username = data.aws_ecrpublic_authorization_token.token.user_name
-    repository_password = data.aws_ecrpublic_authorization_token.token.password
-  }
-
-  #---------------------------------------
-  # CloudWatch metrics for EKS
-  #---------------------------------------
-  enable_aws_cloudwatch_metrics = true
-  aws_cloudwatch_metrics = {
-    values = [templatefile("${path.module}/helm-values/aws-cloudwatch-metrics-values.yaml", {})]
-  }
-
-  #---------------------------------------
-  # AWS for FluentBit - DaemonSet
-  #---------------------------------------
-  enable_aws_for_fluentbit = true
-  aws_for_fluentbit_cw_log_group = {
-    use_name_prefix   = false
-    name              = "/${local.name}/aws-fluentbit-logs" # Add-on creates this log group
-    retention_in_days = 30
-  }
-  aws_for_fluentbit = {
-    s3_bucket_arns = [
-      module.s3_bucket.s3_bucket_arn,
-      "${module.s3_bucket.s3_bucket_arn}/*"
-    ]
-    values = [templatefile("${path.module}/helm-values/aws-for-fluentbit-values.yaml", {
-      region               = local.region,
-      cloudwatch_log_group = "/${local.name}/aws-fluentbit-logs"
-      s3_bucket_name       = module.s3_bucket.s3_bucket_id
-      cluster_name         = module.eks.cluster_name
-    })]
-  }
-
-  enable_aws_load_balancer_controller = true
-  aws_load_balancer_controller = {
-    chart_version = "1.5.4"
-  }
-
-  enable_ingress_nginx = true
-  ingress_nginx = {
-    version = "4.5.2"
-    values  = [templatefile("${path.module}/helm-values/nginx-values.yaml", {})]
-  }
-
-  #---------------------------------------
-  # Prommetheus and Grafana stack
-  #---------------------------------------
-  #---------------------------------------------------------------
-  # Install Kafka Monitoring Stack with Prometheus and Grafana
-  # 1- Grafana port-forward `kubectl port-forward svc/kube-prometheus-stack-grafana 8080:80 -n kube-prometheus-stack`
-  # 2- Grafana Admin user: admin
-  # 3- Get admin user password: `aws secretsmanager get-secret-value --secret-id <output.grafana_secret_name> --region $AWS_REGION --query "SecretString" --output text`
-  #---------------------------------------------------------------
-  enable_kube_prometheus_stack = true
-  kube_prometheus_stack = {
-    values = [
-      var.enable_amazon_prometheus ? templatefile("${path.module}/helm-values/kube-prometheus-amp-enable.yaml", {
-        region              = local.region
-        amp_sa              = local.amp_ingest_service_account
-        amp_irsa            = module.amp_ingest_irsa[0].iam_role_arn
-        amp_remotewrite_url = "https://aps-workspaces.${local.region}.amazonaws.com/workspaces/${aws_prometheus_workspace.amp[0].id}/api/v1/remote_write"
-        amp_url             = "https://aps-workspaces.${local.region}.amazonaws.com/workspaces/${aws_prometheus_workspace.amp[0].id}"
-      }) : templatefile("${path.module}/helm-values/kube-prometheus.yaml", {})
-    ]
-    chart_version = "48.1.1"
-    set_sensitive = [
-      {
-        name  = "grafana.adminPassword"
-        value = data.aws_secretsmanager_secret_version.admin_password_version.secret_string
-      }
-    ],
-  }
-
-  tags = local.tags
-}
-
-#---------------------------------------------------------------
 # Data on EKS Kubernetes Addons
 #---------------------------------------------------------------
 module "eks_data_addons" {
@@ -471,7 +301,10 @@ module "eks_data_addons" {
   #---------------------------------------------------------------
   enable_spark_operator = true
   spark_operator_helm_config = {
-    values = [templatefile("${path.module}/helm-values/spark-operator-values.yaml", {})]
+    name      = "spark-operator-team-a-release"
+    namespace = "spark-operator-team-a-ns"
+    version   = "1.4.2"
+    values    = [templatefile("${path.module}/helm-values/spark-operator-values.yaml", {})]
   }
 
   #---------------------------------------------------------------
@@ -507,6 +340,176 @@ module "eks_data_addons" {
     repository_password = data.aws_ecrpublic_authorization_token.token.password
   }
 
+}
+
+#---------------------------------------------------------------
+# IRSA for EBS CSI Driver
+#---------------------------------------------------------------
+module "ebs_csi_driver_irsa" {
+  source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version               = "~> 5.34"
+  role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
+  attach_ebs_csi_policy = true
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+  tags = local.tags
+}
+
+#---------------------------------------------------------------
+# EKS Blueprints Addons
+#---------------------------------------------------------------
+module "eks_blueprints_addons" {
+  source  = "aws-ia/eks-blueprints-addons/aws"
+  version = "~> 1.2"
+
+  cluster_name      = module.eks.cluster_name
+  cluster_endpoint  = module.eks.cluster_endpoint
+  cluster_version   = module.eks.cluster_version
+  oidc_provider_arn = module.eks.oidc_provider_arn
+
+  #---------------------------------------
+  # Amazon EKS Managed Add-ons
+  #---------------------------------------
+  eks_addons = {
+    aws-ebs-csi-driver = {
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+    }
+    coredns = {
+      preserve = true
+    }
+    vpc-cni = {
+      preserve = true
+    }
+    kube-proxy = {
+      preserve = true
+    }
+  }
+
+  #---------------------------------------
+  # Kubernetes Add-ons
+  #---------------------------------------
+  #---------------------------------------------------------------
+  # CoreDNS Autoscaler helps to scale for large EKS Clusters
+  #   Further tuning for CoreDNS is to leverage NodeLocal DNSCache -> https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/
+  #---------------------------------------------------------------
+  enable_cluster_proportional_autoscaler = true
+  cluster_proportional_autoscaler = {
+    values = [templatefile("${path.module}/helm-values/coredns-autoscaler-values.yaml", {
+      target = "deployment/coredns"
+    })]
+    description = "Cluster Proportional Autoscaler for CoreDNS Service"
+  }
+
+  #---------------------------------------
+  # Metrics Server
+  #---------------------------------------
+  enable_metrics_server = true
+  metrics_server = {
+    values = [templatefile("${path.module}/helm-values/metrics-server-values.yaml", {})]
+  }
+
+  #---------------------------------------
+  # Cluster Autoscaler
+  #---------------------------------------
+  enable_cluster_autoscaler = true
+  cluster_autoscaler = {
+    values = [templatefile("${path.module}/helm-values/cluster-autoscaler-values.yaml", {
+      aws_region     = var.region,
+      eks_cluster_id = module.eks.cluster_name
+    })]
+  }
+
+  #---------------------------------------
+  # Karpenter Autoscaler for EKS Cluster
+  #---------------------------------------
+  enable_karpenter                  = true
+  karpenter_enable_spot_termination = true
+  karpenter_node = {
+    iam_role_additional_policies = {
+      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    }
+  }
+  karpenter = {
+    chart_version       = "v0.34.0"
+    repository_username = data.aws_ecrpublic_authorization_token.token.user_name
+    repository_password = data.aws_ecrpublic_authorization_token.token.password
+  }
+
+  #---------------------------------------
+  # CloudWatch metrics for EKS
+  #---------------------------------------
+  enable_aws_cloudwatch_metrics = true
+  aws_cloudwatch_metrics = {
+    values = [templatefile("${path.module}/helm-values/aws-cloudwatch-metrics-values.yaml", {})]
+  }
+
+  #---------------------------------------
+  # AWS for FluentBit - DaemonSet
+  #---------------------------------------
+  enable_aws_for_fluentbit = true
+  aws_for_fluentbit_cw_log_group = {
+    use_name_prefix   = false
+    name              = "/${local.name}/aws-fluentbit-logs" # Add-on creates this log group
+    retention_in_days = 30
+  }
+  aws_for_fluentbit = {
+    s3_bucket_arns = [
+      module.s3_bucket.s3_bucket_arn,
+      "${module.s3_bucket.s3_bucket_arn}/*"
+    ]
+    values = [templatefile("${path.module}/helm-values/aws-for-fluentbit-values.yaml", {
+      region               = local.region,
+      cloudwatch_log_group = "/${local.name}/aws-fluentbit-logs"
+      s3_bucket_name       = module.s3_bucket.s3_bucket_id
+      cluster_name         = module.eks.cluster_name
+    })]
+  }
+
+  enable_aws_load_balancer_controller = true
+  aws_load_balancer_controller = {
+    chart_version = "1.5.4"
+  }
+
+  enable_ingress_nginx = true
+  ingress_nginx = {
+    version = "4.5.2"
+    values  = [templatefile("${path.module}/helm-values/nginx-values.yaml", {})]
+  }
+
+  #---------------------------------------
+  # Prommetheus and Grafana stack
+  #---------------------------------------
+  #---------------------------------------------------------------
+  # Install Kafka Monitoring Stack with Prometheus and Grafana
+  # 1- Grafana port-forward `kubectl port-forward svc/kube-prometheus-stack-grafana 8080:80 -n kube-prometheus-stack`
+  # 2- Grafana Admin user: admin
+  # 3- Get admin user password: `aws secretsmanager get-secret-value --secret-id <output.grafana_secret_name> --region $AWS_REGION --query "SecretString" --output text`
+  #---------------------------------------------------------------
+  enable_kube_prometheus_stack = true
+  kube_prometheus_stack = {
+    values = [
+      var.enable_amazon_prometheus ? templatefile("${path.module}/helm-values/kube-prometheus-amp-enable.yaml", {
+        region              = local.region
+        amp_sa              = local.amp_ingest_service_account
+        amp_irsa            = module.amp_ingest_irsa[0].iam_role_arn
+        amp_remotewrite_url = "https://aps-workspaces.${local.region}.amazonaws.com/workspaces/${aws_prometheus_workspace.amp[0].id}/api/v1/remote_write"
+        amp_url             = "https://aps-workspaces.${local.region}.amazonaws.com/workspaces/${aws_prometheus_workspace.amp[0].id}"
+      }) : templatefile("${path.module}/helm-values/kube-prometheus.yaml", {})
+    ]
+    chart_version = "48.1.1"
+    set_sensitive = [
+      {
+        name  = "grafana.adminPassword"
+        value = data.aws_secretsmanager_secret_version.admin_password_version.secret_string
+      }
+    ],
+  }
+
+  tags = local.tags
 }
 
 #---------------------------------------------------------------

--- a/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
@@ -18,7 +18,7 @@ input:
   name: "tail"
   enabled: true
   tag: "systempods.<namespace_name>.<container_name>.<pod_name>.<docker_id>-"
-  path: "/var/log/containers/*.log"
+  path: "/var/log/containers/aws-node*,/var/log/containers/kube-proxy*,/var/log/containers/aws-for-fluent-bit*,/var/log/containers/spark-history-server*,/var/log/containers/spark-operator*,/var/log/containers/*_yunikorn_*"
   db: "/var/log/flb_kube.db"
   memBufLimit: 5MB
   skipLongLines: "On"
@@ -27,8 +27,31 @@ input:
     multiline.parser  docker, cri
     Tag_Regex         (?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$
 
+additionalInputs: |
+  [INPUT]
+      Name                tail
+      Tag                 spark.<namespace_name>.<container_name>.<spark_app_id>.<driver_or_executor>.<docker_id>-
+      Path                /var/log/containers/*_default_*
+      DB                  /var/log/flb_spark.db
+      multiline.parser    docker, cri
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Tag_Regex           (?<spark_app_id>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)-(?<driver_or_executor>(?:driver|exec-[\d]+))_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log
 
-# NOTE: extraFilters config for using Kubelet to get the Metadata instead of talking to API server for large clusters
+  [INPUT]
+      Name                tail
+      Tag                 sel.<spark_internal_app_id>
+      Path                /var/log/containers/eventlogs/*\.inprogress
+      DB                  /var/log/sel_spark.db
+      multiline.parser    docker, cri
+      Mem_Buf_Limit       10MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Tag_Regex           (?<spark_internal_app_id>spark-[a-z0-9]+)
+      Buffer_Chunk_Size   1MB
+      Buffer_Max_Size     5MB
+
 filter:
   name: "kubernetes"
   match: "systempods.*"
@@ -49,19 +72,52 @@ filter:
     Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
 
-# CATION: Do not use `cloudwatch` plugin. This Golang Plugin is not recommended by AWS anymore instead use C plugin(`cloudWatchLogs`) for better performance.
+additionalFilters: |
+  [FILTER]
+      Name                rewrite_tag
+      Match               systempods.*
+      Rule                $log ^.+\s(YK_APP_SUMMARY:).*$ yuni.$TAG.log false
+
+  [FILTER]
+      Name                kubernetes
+      Match               spark.*
+      Kube_URL            https://kubernetes.default.svc.cluster.local:443
+      Merge_Log           On
+      Merge_Log_Key       log_processed
+      Keep_Log            On
+      K8S-Logging.Parser  On
+      K8S-Logging.Exclude On
+      Labels              On
+      Buffer_Size         0
+      Kube_Tag_Prefix     spark.
+      Regex_Parser        kubernetes
+      Use_Kubelet         true
+      Kubelet_Port        10250
+      Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+      Annotations         Off
+
+  [FILTER]
+      Name                rewrite_tag
+      Match               sel.*
+      Rule                $log ^(\{\"Event\":\"SparkListenerLogStart\").+$ app.$TAG.log true
+
+
+# CAUTION: Do not use `cloudwatch` plugin. This Golang Plugin is not recommended by AWS anymore instead use C plugin(`cloudWatchLogs`) for better performance.
 # cloudWatch:
 #   enabled: false
 
-# This is a new high performance C Plugin for CloudWatchLogs. See docs here https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch
-cloudWatchLogs:
-  enabled: true
-  match: "systempods.*"
-  region: ${region}
-  logGroupName: ${cloudwatch_log_group}
-  autoCreateGroup: false
-  extraOutputs: |
-    log_key               log
+# This is a new high performance C Plugin for CloudWatchLogs. See docs here https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch
+
+#cloudWatchLogs:
+#  enabled: true
+#  match: "systempods.*"
+#  region: ${region}
+#  logGroupName: ${cloudwatch_log_group}
+#  autoCreateGroup: false
+#  extraOutputs: |
+#    log_key               log
+
 
 #----------------------------------------------------------#
 # OUTPUT logs to S3
@@ -78,25 +134,57 @@ additionalOutputs: |
       region                          ${region}
       bucket                          ${s3_bucket_name}
       total_file_size                 100M
-      s3_key_format                   /${cluster_name}/system-pod-logs/$TAG[1]/$TAG[2]/$TAG[3]/$TAG[3]_%H%M%S_$UUID.log
+      s3_key_format                   /${cluster_name}/system-pod-logs/$TAG[1]/$TAG[3]/$TAG[2]_%H%M%S_$UUID.log
       s3_key_format_tag_delimiters    ..
       store_dir                       /home/ec2-user/buffer
-      upload_timeout                  10m
+      upload_timeout                  5m
       log_key                         log
 
+  [OUTPUT]
+      Name                            s3
+      Match                           spark.*
+      region                          ${region}
+      bucket                          ${s3_bucket_name}
+      total_file_size                 5M
+      s3_key_format                   /${cluster_name}/spark-application-logs/$TAG[3]/$TAG[4]/%H%M%S_$UUID.log
+      s3_key_format_tag_delimiters    ..
+      store_dir                       /home/ec2-user/buffer
+      upload_timeout                  5m
+      log_key                         log
 
-# Resource config for large clusters
-resources:
-  limits:
-    cpu: 1000m
-    memory: 1500Mi
-  requests:
-    cpu: 500m
-    memory: 500Mi
+  [OUTPUT]
+      Name                            s3
+      Match                           yuni.*
+      region                          ${region}
+      bucket                          ${s3_bucket_name}
+      total_file_size                 5M
+      s3_key_format                   /${cluster_name}/yunikorn-app-summary/%Y/%m/%d/%H/%H%M%S_${cluster_name}_$UUID.log
+      s3_key_format_tag_delimiters    ..
+      store_dir                       /home/ec2-user/buffer
+      upload_timeout                  5m
+      log_key                         log
 
-## Assign a PriorityClassName to pods if set
-priorityClassName: system-node-critical
+  [OUTPUT]
+      Name                            s3
+      Match                           sel.*
+      region                          ${region}
+      bucket                          ${s3_bucket_name}
+      total_file_size                 10M
+      s3_key_format                   /${cluster_name}/spark-event-logs/eventlog_v2_$TAG[1]/events_$INDEX_$TAG[1]_$UUID
+      s3_key_format_tag_delimiters    ..
+      store_dir                       /home/ec2-user/buffer
+      upload_timeout                  7m
+      log_key                         log
 
-# This toleration allows Daemonset pod to be scheduled on any node, regardless of their Taints.
-tolerations:
-  - operator: Exists
+  [OUTPUT]
+      Name                            s3
+      Match                           app.*
+      region                          ${region}
+      bucket                          ${s3_bucket_name}
+      total_file_size                 1M
+      static_file_path                true
+      s3_key_format                   /${cluster_name}/spark-event-logs/eventlog_v2_$TAG[2]/appstatus_$TAG[2]
+      s3_key_format_tag_delimiters    ..
+      store_dir                       /home/ec2-user/buffer
+      upload_timeout                  5m
+      log_key                         log

--- a/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
@@ -27,30 +27,18 @@ input:
     multiline.parser  docker, cri
     Tag_Regex         (?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$
 
+# Filtering the Spark job logs by using the namesapce in the path `spark-team-`
 additionalInputs: |
   [INPUT]
       Name                tail
       Tag                 spark.<namespace_name>.<container_name>.<spark_app_id>.<driver_or_executor>.<docker_id>-
-      Path                /var/log/containers/*_default_*
+      Path                /var/log/containers/*spark-team-*
       DB                  /var/log/flb_spark.db
       multiline.parser    docker, cri
       Mem_Buf_Limit       5MB
       Skip_Long_Lines     On
       Refresh_Interval    10
       Tag_Regex           (?<spark_app_id>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)-(?<driver_or_executor>(?:driver|exec-[\d]+))_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log
-
-  [INPUT]
-      Name                tail
-      Tag                 sel.<spark_internal_app_id>
-      Path                /var/log/containers/eventlogs/*\.inprogress
-      DB                  /var/log/sel_spark.db
-      multiline.parser    docker, cri
-      Mem_Buf_Limit       10MB
-      Skip_Long_Lines     On
-      Refresh_Interval    10
-      Tag_Regex           (?<spark_internal_app_id>spark-[a-z0-9]+)
-      Buffer_Chunk_Size   1MB
-      Buffer_Max_Size     5MB
 
 filter:
   name: "kubernetes"
@@ -74,11 +62,6 @@ filter:
 
 additionalFilters: |
   [FILTER]
-      Name                rewrite_tag
-      Match               systempods.*
-      Rule                $log ^.+\s(YK_APP_SUMMARY:).*$ yuni.$TAG.log false
-
-  [FILTER]
       Name                kubernetes
       Match               spark.*
       Kube_URL            https://kubernetes.default.svc.cluster.local:443
@@ -97,26 +80,20 @@ additionalFilters: |
       Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
       Annotations         Off
 
-  [FILTER]
-      Name                rewrite_tag
-      Match               sel.*
-      Rule                $log ^(\{\"Event\":\"SparkListenerLogStart\").+$ app.$TAG.log true
-
 
 # CAUTION: Do not use `cloudwatch` plugin. This Golang Plugin is not recommended by AWS anymore instead use C plugin(`cloudWatchLogs`) for better performance.
 # cloudWatch:
 #   enabled: false
 
 # This is a new high performance C Plugin for CloudWatchLogs. See docs here https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch
-
-#cloudWatchLogs:
-#  enabled: true
-#  match: "systempods.*"
-#  region: ${region}
-#  logGroupName: ${cloudwatch_log_group}
-#  autoCreateGroup: false
-#  extraOutputs: |
-#    log_key               log
+cloudWatchLogs:
+ enabled: true
+ match: "systempods.*"
+ region: ${region}
+ logGroupName: ${cloudwatch_log_group}
+ autoCreateGroup: false
+ extraOutputs: |
+   log_key               log
 
 
 #----------------------------------------------------------#
@@ -147,43 +124,6 @@ additionalOutputs: |
       bucket                          ${s3_bucket_name}
       total_file_size                 5M
       s3_key_format                   /${cluster_name}/spark-application-logs/$TAG[3]/$TAG[4]/%H%M%S_$UUID.log
-      s3_key_format_tag_delimiters    ..
-      store_dir                       /home/ec2-user/buffer
-      upload_timeout                  5m
-      log_key                         log
-
-  [OUTPUT]
-      Name                            s3
-      Match                           yuni.*
-      region                          ${region}
-      bucket                          ${s3_bucket_name}
-      total_file_size                 5M
-      s3_key_format                   /${cluster_name}/yunikorn-app-summary/%Y/%m/%d/%H/%H%M%S_${cluster_name}_$UUID.log
-      s3_key_format_tag_delimiters    ..
-      store_dir                       /home/ec2-user/buffer
-      upload_timeout                  5m
-      log_key                         log
-
-  [OUTPUT]
-      Name                            s3
-      Match                           sel.*
-      region                          ${region}
-      bucket                          ${s3_bucket_name}
-      total_file_size                 10M
-      s3_key_format                   /${cluster_name}/spark-event-logs/eventlog_v2_$TAG[1]/events_$INDEX_$TAG[1]_$UUID
-      s3_key_format_tag_delimiters    ..
-      store_dir                       /home/ec2-user/buffer
-      upload_timeout                  7m
-      log_key                         log
-
-  [OUTPUT]
-      Name                            s3
-      Match                           app.*
-      region                          ${region}
-      bucket                          ${s3_bucket_name}
-      total_file_size                 1M
-      static_file_path                true
-      s3_key_format                   /${cluster_name}/spark-event-logs/eventlog_v2_$TAG[2]/appstatus_$TAG[2]
       s3_key_format_tag_delimiters    ..
       store_dir                       /home/ec2-user/buffer
       upload_timeout                  5m

--- a/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/aws-for-fluentbit-values.yaml
@@ -27,7 +27,7 @@ input:
     multiline.parser  docker, cri
     Tag_Regex         (?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$
 
-# Filtering the Spark job logs by using the namesapce in the path `spark-team-`
+# Filtering the Spark job logs by using the namespace in the path `spark-team-`
 additionalInputs: |
   [INPUT]
       Name                tail

--- a/analytics/terraform/spark-k8s-operator/helm-values/spark-operator-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/spark-operator-values.yaml
@@ -22,10 +22,12 @@ serviceAccounts:
     # -- Optional annotations for the operator service account
     annotations: {}
 
-# -- Set this if running spark jobs in a different namespace than the operator
-# -- List of namespaces where to run spark jobs
-sparkJobNamespaces:
-  - "spark-team-a"
+# Enable this to monitor only one namespace with this Spark Operator.
+# By default, this operator monitors all namespaces for submitting Spark jobs.
+# Currently, it does not support selecting multiple namespaces to be monitored by each Spark Operator. You can select either one or all namespaces.
+# sparkJobNamespaces:
+#   - "spark-team-a"
+
 
 # -- Operator concurrency, higher values might increase memory usage
 controllerThreads: 10

--- a/analytics/terraform/spark-k8s-operator/helm-values/spark-operator-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/spark-operator-values.yaml
@@ -6,8 +6,26 @@ webhook:
   # -- Webhook service port
   port: 8080
 
+serviceAccounts:
+  spark:
+    # -- Create a service account for spark apps
+    create: true
+    # -- Optional name for the spark service account
+    name: ""
+    # -- Optional annotations for the spark service account
+    annotations: {}
+  sparkoperator:
+    # -- Create a service account for the operator
+    create: true
+    # -- Optional name for the operator service account
+    name: ""
+    # -- Optional annotations for the operator service account
+    annotations: {}
+
 # -- Set this if running spark jobs in a different namespace than the operator
-#sparkJobNamespace: "spark-team-a"
+# -- List of namespaces where to run spark jobs
+sparkJobNamespaces:
+  - "spark-team-a"
 
 # -- Operator concurrency, higher values might increase memory usage
 controllerThreads: 10
@@ -28,15 +46,18 @@ batchScheduler:
   # -- Enable batch scheduler for spark jobs scheduling. If enabled, users can specify batch scheduler name in spark application
   enable: true
 
+
 #------------------------------------
 # THIS WILL CREATE SERVICE AND INGRESS OBJECT FOR EACH SPARK APPLICATION
 #------------------------------------
-#uiService:
-##  # -- Enable UI service creation for Spark application
-#  enable: true
-### -- Ingress URL format.
-### Requires the UI service to be enabled by setting `uiService.enable` to true.
-### 1/ Enable ingressUrlFormat to create an Ingress object for each Spark Job submitted using Spark Operator
-### 2/ This setup also requires ingres-nginx to be deployed with NLB as LB with IP based routing.
-### 3. Enter the NLB DNS name or enter Custom Domain name from route53 below which points to the NLB
-#ingressUrlFormat: '<ENTER_NLB_DNS_NAME/CUSTOM_DOMAIN_NAME>/{{$appName}}'
+uiService:
+  # -- Enable UI service creation for Spark application
+  enable: true
+
+  # -- Ingress URL format.
+  # Requires the UI service to be enabled by setting `uiService.enable` to true.
+  # 1/ Enable ingressUrlFormat to create an Ingress object for each Spark Job submitted using Spark Operator
+  # 2/ This setup also requires ingres-nginx to be deployed with NLB as LB with IP based routing.
+  # 3. Enter the NLB DNS name or enter Custom Domain name from route53 below which points to the NLB
+
+  # ingressUrlFormat: '<ENTER_NLB_DNS_NAME/CUSTOM_DOMAIN_NAME>/{{$appName}}'

--- a/analytics/terraform/spark-k8s-operator/spark-team.tf
+++ b/analytics/terraform/spark-k8s-operator/spark-team.tf
@@ -1,78 +1,74 @@
 locals {
-  spark_team = "spark-team-a"
+  teams = ["spark-team-a", "spark-team-b", "spark-team-c"] # Add more team names as needed
 }
 
-resource "kubernetes_namespace_v1" "spark_team_a" {
+resource "kubernetes_namespace_v1" "spark_team" {
+  for_each = toset(local.teams)
+
   metadata {
-    name = local.spark_team
+    name = each.value
   }
   timeouts {
     delete = "15m"
   }
 }
 
-resource "kubernetes_service_account_v1" "spark_team_a" {
+resource "kubernetes_service_account_v1" "spark_team" {
+  for_each = toset(local.teams)
+
   metadata {
-    name        = local.spark_team
-    namespace   = kubernetes_namespace_v1.spark_team_a.metadata[0].name
-    annotations = { "eks.amazonaws.com/role-arn" : module.spark_team_a_irsa.iam_role_arn }
+    name        = each.value
+    namespace   = kubernetes_namespace_v1.spark_team[each.key].metadata[0].name
+    annotations = { "eks.amazonaws.com/role-arn" : module.spark_team_irsa[each.key].iam_role_arn }
   }
 
   automount_service_account_token = true
 }
 
-resource "kubernetes_secret_v1" "spark_team_a" {
+resource "kubernetes_secret_v1" "spark_team" {
+  for_each = toset(local.teams)
+
   metadata {
-    name      = "${local.spark_team}-secret"
-    namespace = kubernetes_namespace_v1.spark_team_a.metadata[0].name
+    name      = "${each.value}-secret"
+    namespace = kubernetes_namespace_v1.spark_team[each.key].metadata[0].name
     annotations = {
-      "kubernetes.io/service-account.name"      = kubernetes_service_account_v1.spark_team_a.metadata[0].name
-      "kubernetes.io/service-account.namespace" = kubernetes_namespace_v1.spark_team_a.metadata[0].name
+      "kubernetes.io/service-account.name"      = kubernetes_service_account_v1.spark_team[each.key].metadata[0].name
+      "kubernetes.io/service-account.namespace" = kubernetes_namespace_v1.spark_team[each.key].metadata[0].name
     }
   }
 
   type = "kubernetes.io/service-account-token"
 }
 
-#---------------------------------------------------------------
-# IRSA for Spark driver/executor pods for "spark-team-a"
-#---------------------------------------------------------------
-module "spark_team_a_irsa" {
+module "spark_team_irsa" {
+  for_each = toset(local.teams)
+
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "~> 1.0"
 
-  # Disable helm release
   create_release = false
-
-  # IAM role for service account (IRSA)
-  create_role   = true
-  role_name     = "${local.name}-${local.spark_team}"
-  create_policy = false
+  create_role    = true
+  role_name      = "${local.name}-${each.value}"
+  create_policy  = false
   role_policies = {
-    spark_team_a_policy = aws_iam_policy.spark.arn
+    spark_team_policy = aws_iam_policy.spark.arn
   }
 
   oidc_providers = {
     this = {
       provider_arn    = module.eks.oidc_provider_arn
-      namespace       = local.spark_team
-      service_account = local.spark_team
+      namespace       = each.value
+      service_account = each.value
     }
   }
 }
 
-#---------------------------------------------------------------
-# Creates IAM policy for IRSA. Provides IAM permissions for Spark driver/executor pods
-#---------------------------------------------------------------
 resource "aws_iam_policy" "spark" {
   description = "IAM role policy for Spark Job execution"
   name        = "${local.name}-spark-irsa"
   policy      = data.aws_iam_policy_document.spark_operator.json
 }
 
-#---------------------------------------------------------------
-# Kubernetes Cluster role for service Account analytics-k8s-data-team-a
-#---------------------------------------------------------------
 resource "kubernetes_cluster_role" "spark_role" {
   metadata {
     name = "spark-cluster-role"
@@ -89,6 +85,7 @@ resource "kubernetes_cluster_role" "spark_role" {
     api_groups = ["storage.k8s.io"]
     resources  = ["storageclasses"]
   }
+
   rule {
     verbs      = ["get", "list", "watch", "describe", "create", "edit", "delete", "deletecollection", "annotate", "patch", "label"]
     api_groups = [""]
@@ -125,20 +122,20 @@ resource "kubernetes_cluster_role" "spark_role" {
     resources  = ["roles", "rolebindings"]
   }
 
-  depends_on = [module.spark_team_a_irsa]
+  depends_on = [module.spark_team_irsa]
 }
-#---------------------------------------------------------------
-# Kubernetes Cluster Role binding role for service Account analytics-k8s-data-team-a
-#---------------------------------------------------------------
+
 resource "kubernetes_cluster_role_binding" "spark_role_binding" {
+  for_each = toset(local.teams)
+
   metadata {
-    name = "spark-cluster-role-bind"
+    name = "spark-cluster-role-bind-${each.value}"
   }
 
   subject {
     kind      = "ServiceAccount"
-    name      = local.spark_team
-    namespace = local.spark_team
+    name      = each.value
+    namespace = each.value
   }
 
   role_ref {
@@ -147,5 +144,5 @@ resource "kubernetes_cluster_role_binding" "spark_role_binding" {
     name      = kubernetes_cluster_role.spark_role.id
   }
 
-  depends_on = [module.spark_team_a_irsa]
+  depends_on = [module.spark_team_irsa]
 }

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -12,7 +12,7 @@ variable "region" {
 
 variable "eks_cluster_version" {
   description = "EKS Cluster version"
-  default     = "1.28"
+  default     = "1.30"
   type        = string
 }
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

- Added support for creating multiple teams. By default, it creates spark-team-a, spark-team-b, and spark-team-c, all of which use the same IAM policies. However, you can modify the code to customize the policies if needed.
- Updated Fluent Bit configuration to write Spark logs to a dedicated folder structure in the S3 bucket.
<img width="461" alt="image" src="https://github.com/awslabs/data-on-eks/assets/19464259/10eb25a0-1881-44fd-bdc5-04e599253cf6">

- Upgraded the blueprint to use EKS version 1.30.
- Upgraded the Spark Operator to the latest version.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
