### PR TITLE
fix: Add yaml code block in documentation prometheus section

### DIFF
--- a/website/docs/blueprints/data-analytics/observability-spark-on-eks.md
+++ b/website/docs/blueprints/data-analytics/observability-spark-on-eks.md
@@ -74,6 +74,7 @@ Then open browser and enter localhost:18085. You can view your spark history ser
 ## Prometheus
 Spark users must add the following config to spark application yaml file to extract the metrics from Spark Driver and Executors. In the example, they are added into nvme-ephemeral-storage.yaml already.
 
+```yaml
     "spark.ui.prometheus.enabled": "true"
     "spark.executor.processTreeMetrics.enabled": "true"
     "spark.kubernetes.driver.annotation.prometheus.io/scrape": "true"
@@ -86,6 +87,7 @@ Spark users must add the following config to spark application yaml file to extr
     "spark.metrics.conf.*.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
     "spark.metrics.conf.master.sink.prometheusServlet.path": "/metrics/master/prometheus/"
     "spark.metrics.conf.applications.sink.prometheusServlet.path": "/metrics/applications/prometheus/"
+```
 
 Run port forward command to expose prometheus service.
 ```bash


### PR DESCRIPTION


### What does this PR do?

Fix code block for config spark application yaml

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Improve documentation
<img width="986" alt="image" src="https://github.com/awslabs/data-on-eks/assets/6713233/78a35387-c386-487a-8d50-72a29b371fe7">


### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
