### PR TITLE
feat: Neuron scheduler update for trainium-inferentia blueprints

### DIFF
--- a/gen-ai/inference/llama2-13b-chat-rayserve-inf2/ray-service-llama2.yaml
+++ b/gen-ai/inference/llama2-13b-chat-rayserve-inf2/ray-service-llama2.yaml
@@ -49,83 +49,85 @@ spec:
       rayStartParams:
         dashboard-host: '0.0.0.0'
       template:
+        schedulerName: my-scheduler
         spec:
           containers:
-            - name: head
-              image: public.ecr.aws/data-on-eks/ray2.22.0-py310-llama2-13b-neuron:latest # Image created using the Dockerfile attached in the folder
-              imagePullPolicy: Always # Ensure the image is always pulled when updated
-              lifecycle:
-                preStop:
-                  exec:
-                    command: ["/bin/sh", "-c", "ray stop"]
-              ports:
-                - containerPort: 6379
-                  name: gcs
-                - containerPort: 8265
-                  name: dashboard
-                - containerPort: 10001
-                  name: client
-                - containerPort: 8000
-                  name: serve
-              volumeMounts:
-                - mountPath: /tmp/ray
-                  name: ray-logs
-              resources:
-                limits:
-                  cpu: 4
-                  memory: 20Gi
-                requests:
-                  cpu: 4
-                  memory: 20Gi
-              env:
-                - name: LD_LIBRARY_PATH
-                  value: "/home/ray/anaconda3/lib:$LD_LIBRARY_PATH"
+          - name: head
+            image: public.ecr.aws/data-on-eks/ray2.22.0-py310-llama2-13b-neuron:latest # Image created using the Dockerfile attached in the folder
+            imagePullPolicy: Always # Ensure the image is always pulled when updated
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh", "-c", "ray stop"]
+            ports:
+            - containerPort: 6379
+              name: gcs
+            - containerPort: 8265
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+            volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+            resources:
+              limits:
+                cpu: 4
+                memory: 20Gi
+              requests:
+                cpu: 4
+                memory: 20Gi
+            env:
+            - name: LD_LIBRARY_PATH
+              value: "/home/ray/anaconda3/lib:$LD_LIBRARY_PATH"
           nodeSelector: # This is using Karpenter Nodes with the provisioner label
             instanceType: mixed-x86
             provisionerType: Karpenter
             workload: rayhead
           volumes:
-            - name: ray-logs
-              emptyDir: {}
+          - name: ray-logs
+            emptyDir: {}
     workerGroupSpecs:
-      - groupName: inf2
-        replicas: 1
-        minReplicas: 1
-        maxReplicas: 1
-        rayStartParams: {}
-        template:
-          spec:
-            containers:
-              - name: worker
-                image: public.ecr.aws/data-on-eks/ray2.22.0-py310-llama2-13b-neuron:latest
-                imagePullPolicy: Always # Ensure the image is always pulled when updated
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh", "-c", "ray stop"]
-                resources:
-                  limits:
-                    cpu: "180"
-                    memory: "700G"
-                    aws.amazon.com/neuron: "12"
-                  requests:
-                    cpu: "180"
-                    memory: "700G"
-                    aws.amazon.com/neuron: "12"
-                env:
-                  - name: LD_LIBRARY_PATH
-                    value: "/home/ray/anaconda3/lib:$LD_LIBRARY_PATH"
-            nodeSelector:
-              instanceType: inferentia-inf2
-              provisionerType: Karpenter
-            tolerations:
-              - key: "aws.amazon.com/neuron"
-                operator: "Exists"
-                effect: "NoSchedule"
-              - key: "hub.jupyter.org/dedicated"
-                operator: "Equal"
-                value: "user"
-                effect: "NoSchedule"
+    - groupName: inf2
+      replicas: 1
+      minReplicas: 1
+      maxReplicas: 1
+      rayStartParams: {}
+      template:
+        spec:
+          schedulerName: my-scheduler
+          containers:
+          - name: worker
+            image: public.ecr.aws/data-on-eks/ray2.22.0-py310-llama2-13b-neuron:latest
+            imagePullPolicy: Always # Ensure the image is always pulled when updated
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh", "-c", "ray stop"]
+            resources:
+              limits:
+                cpu: "180"
+                memory: "700G"
+                aws.amazon.com/neuron: "12"
+              requests:
+                cpu: "180"
+                memory: "700G"
+                aws.amazon.com/neuron: "12"
+            env:
+            - name: LD_LIBRARY_PATH
+              value: "/home/ray/anaconda3/lib:$LD_LIBRARY_PATH"
+          nodeSelector:
+            instanceType: inferentia-inf2
+            provisionerType: Karpenter
+          tolerations:
+          - key: "aws.amazon.com/neuron"
+            operator: "Exists"
+            effect: "NoSchedule"
+          - key: "hub.jupyter.org/dedicated"
+            operator: "Equal"
+            value: "user"
+            effect: "NoSchedule"
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -137,21 +139,21 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - http:
-        paths:
-          # Ray Dashboard
-          - path: /dashboard/(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: llama2
-                port:
-                  number: 8265
-          # Ray Serve
-          - path: /serve/(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: llama2
-                port:
-                  number: 8000
+  - http:
+      paths:
+      # Ray Dashboard
+      - path: /dashboard/(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: llama2
+            port:
+              number: 8265
+      # Ray Serve
+      - path: /serve/(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: llama2
+            port:
+              number: 8000

--- a/gen-ai/inference/llama3-8b-instruct-rayserve-inf2/ray-service-llama3.yaml
+++ b/gen-ai/inference/llama3-8b-instruct-rayserve-inf2/ray-service-llama3.yaml
@@ -37,6 +37,7 @@ spec:
         dashboard-host: '0.0.0.0'
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: head
             image: public.ecr.aws/data-on-eks/ray-serve-inf2-llama3:latest # Image created using the Dockerfile attached in the folder
@@ -65,13 +66,13 @@ spec:
                 cpu: 4
                 memory: 20Gi
             env:
-              - name: HUGGING_FACE_HUB_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: hf-token
-                    key: hf-token
-              - name: LD_LIBRARY_PATH
-                value: "/home/ray/anaconda3/lib"
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: hf-token
+            - name: LD_LIBRARY_PATH
+              value: "/home/ray/anaconda3/lib"
           nodeSelector: # This is using Karpenter Nodes with the provisioner label
             instanceType: mixed-x86
             provisionerType: Karpenter
@@ -87,6 +88,7 @@ spec:
       rayStartParams: {}
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: worker
             image: public.ecr.aws/data-on-eks/ray-serve-inf2-llama3:latest
@@ -105,13 +107,13 @@ spec:
                 memory: "700G"
                 aws.amazon.com/neuron: "12"
             env:
-              - name: LD_LIBRARY_PATH
-                value: /home/ray/anaconda3/lib
-              - name: HUGGING_FACE_HUB_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: hf-token
-                    key: hf-token
+            - name: LD_LIBRARY_PATH
+              value: /home/ray/anaconda3/lib
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: hf-token
           nodeSelector:
             instanceType: inferentia-inf2
             provisionerType: Karpenter

--- a/gen-ai/inference/mistral-7b-rayserve-inf2/ray-service-mistral-ft.yaml
+++ b/gen-ai/inference/mistral-7b-rayserve-inf2/ray-service-mistral-ft.yaml
@@ -66,6 +66,7 @@ spec:
         num-cpus: "0" # this is to ensure no tasks or actors are scheduled on the head Pod
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: head
             image: public.ecr.aws/data-on-eks/ray2.22.0-py310-mistral7b-neuron:latest
@@ -118,6 +119,7 @@ spec:
       rayStartParams: {}
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: worker
             image: public.ecr.aws/data-on-eks/ray2.22.0-py310-mistral7b-neuron:latest

--- a/gen-ai/inference/mistral-7b-rayserve-inf2/ray-service-mistral.yaml
+++ b/gen-ai/inference/mistral-7b-rayserve-inf2/ray-service-mistral.yaml
@@ -64,6 +64,7 @@ spec:
         num-cpus: "0" # this is to ensure no tasks or actors are scheduled on the head Pod
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: head
             image: public.ecr.aws/data-on-eks/ray2.22.0-py310-mistral7b-neuron:latest
@@ -114,6 +115,7 @@ spec:
       rayStartParams: {}
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: worker
             image: public.ecr.aws/data-on-eks/ray2.22.0-py310-mistral7b-neuron:latest

--- a/gen-ai/inference/stable-diffusion-xl-base-rayserve-inf2/ray-service-stablediffusion.yaml
+++ b/gen-ai/inference/stable-diffusion-xl-base-rayserve-inf2/ray-service-stablediffusion.yaml
@@ -50,6 +50,7 @@ spec:
         dashboard-host: '0.0.0.0'
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: head
             image: public.ecr.aws/data-on-eks/ray2.9.0-py310-stablediffusion-neuron:latest
@@ -91,6 +92,7 @@ spec:
       rayStartParams: {}
       template:
         spec:
+          schedulerName: my-scheduler
           containers:
           - name: worker
             image: public.ecr.aws/data-on-eks/ray2.9.0-py310-stablediffusion-neuron:latest

--- a/website/docs/gen-ai/inference/Mistral-7b-inf2.md
+++ b/website/docs/gen-ai/inference/Mistral-7b-inf2.md
@@ -117,7 +117,7 @@ To deploy the Mistral-7B-Instruct-v0.2 model, it's essential to configure your H
 
 export HUGGING_FACE_HUB_TOKEN=$(echo -n "Your-Hugging-Face-Hub-Token-Value" | base64)
 
-cd ./../gen-ai/inference/mistral-7b-rayserve-inf2
+cd ../../gen-ai/inference/mistral-7b-rayserve-inf2
 envsubst < ray-service-mistral.yaml| kubectl apply -f -
 ```
 


### PR DESCRIPTION
### What does this PR do?
Adds neuron-scheduler for Ray head and worker Pods in AWS Neuron gen ai patterns
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
We're deploying [my-scheduler.yml](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/_downloads/e739253083129abeaf6f6ad1db7ccb21/my-scheduler.yml) and [k8s-neuron-scheduler-eks.yml](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/_downloads/e518187532701b6660dcd70ea28c2562/k8s-neuron-scheduler-eks.yml) in our trainium-inferentia blueprint.
As part of this PR, we are updating the Ray Service yamls to set `scheduler` to `my-scheduler` for Ray head and worker pod specs.

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
