### PR TITLE
chore: Add access entry for workshop

### DIFF
--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -222,10 +222,33 @@ module "eks_blueprints_addons" {
   tags = local.tags
 }
 
-resource "aws_eks_access_entry" "karpenter_node_access_entry" {
-  cluster_name  = module.eks.cluster_name
-  principal_arn = module.eks_blueprints_addons.karpenter.node_iam_role_arn
-  type          = "EC2_LINUX"
+# Access Entries
+locals {
+  # Default access entry
+  karpenter_access_entry = {
+    karpenter = {
+      principal_arn = module.eks_blueprints_addons.karpenter.node_iam_role_arn
+      type          = "EC2_LINUX"
+    }
+  }
+
+  # Merge var.access_entries with the karpenter_access_entry
+  merged_access_entries = merge(
+    local.karpenter_access_entry,
+    var.access_entries
+  )
+}
+
+resource "aws_eks_access_entry" "this" {
+  for_each = local.merged_access_entries
+
+  cluster_name      = module.eks.cluster_name
+  kubernetes_groups = try(each.value.kubernetes_groups, null)
+  principal_arn     = each.value.principal_arn
+  type              = try(each.value.type, "STANDARD")
+  user_name         = try(each.value.user_name, null)
+
+  tags = merge(try(each.value.tags, {}))
 }
 
 #---------------------------------------------------------------

--- a/ai-ml/trainium-inferentia/variables.tf
+++ b/ai-ml/trainium-inferentia/variables.tf
@@ -128,3 +128,10 @@ variable "enable_rayserve_ha_elastic_cache_redis" {
   type        = bool
   default     = false
 }
+
+
+variable "access_entries" {
+  description = "Map of access entries to add to the cluster"
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Add a variable to accept and configure access_entries for the cluster.

### Motivation

<!-- What inspired you to submit this pull request? -->
Mainly used for the workshop. We need a way to add IDE access to EKS cluster.


### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [x] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
