### PR TITLE
fix: Use eks module for access_entries for trn-inf blueprint

### DIFF
--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -222,33 +222,10 @@ module "eks_blueprints_addons" {
   tags = local.tags
 }
 
-# Access Entries
-locals {
-  # Default access entry
-  karpenter_access_entry = {
-    karpenter = {
-      principal_arn = module.eks_blueprints_addons.karpenter.node_iam_role_arn
-      type          = "EC2_LINUX"
-    }
-  }
-
-  # Merge var.access_entries with the karpenter_access_entry
-  merged_access_entries = merge(
-    local.karpenter_access_entry,
-    var.access_entries
-  )
-}
-
 resource "aws_eks_access_entry" "this" {
-  for_each = local.merged_access_entries
-
-  cluster_name      = module.eks.cluster_name
-  kubernetes_groups = try(each.value.kubernetes_groups, null)
-  principal_arn     = each.value.principal_arn
-  type              = try(each.value.type, "STANDARD")
-  user_name         = try(each.value.user_name, null)
-
-  tags = merge(try(each.value.tags, {}))
+  cluster_name  = module.eks.cluster_name
+  principal_arn = module.eks_blueprints_addons.karpenter.node_iam_role_arn
+  type          = "EC2_LINUX"
 }
 
 #---------------------------------------------------------------

--- a/ai-ml/trainium-inferentia/eks.tf
+++ b/ai-ml/trainium-inferentia/eks.tf
@@ -16,6 +16,8 @@ module "eks" {
   # allow deploying resources (Karpenter) into the cluster
   enable_cluster_creator_admin_permissions = true
 
+  access_entries = var.access_entries
+
   vpc_id = module.vpc.vpc_id
   # Filtering only Secondary CIDR private subnets starting with "100.". Subnet IDs where the EKS Control Plane ENIs will be created
   subnet_ids = compact([for subnet_id, cidr_block in zipmap(module.vpc.private_subnets, module.vpc.private_subnets_cidr_blocks) :


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

This PR fixes an issue where we need to provision access entry policies. I reverted the karpenter access entry to what it was before and instead now just pass the `var.access_entries` params to the EKS module as is. The EKS module has a way to accept both entries and policies in one single block. 

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
