### PR TITLE
feat: Use unique name for the spark job execution IRSA policy

### DIFF
--- a/analytics/terraform/spark-eks-ipv6/spark-team.tf
+++ b/analytics/terraform/spark-eks-ipv6/spark-team.tf
@@ -66,7 +66,7 @@ module "spark_team_a_irsa" {
 #---------------------------------------------------------------
 resource "aws_iam_policy" "spark" {
   description = "IAM role policy for Spark Job execution"
-  name        = "${local.name}-spark-irsa"
+  name_prefix        = "${local.name}-spark-irsa"
   policy      = data.aws_iam_policy_document.spark_operator.json
 }
 

--- a/analytics/terraform/spark-k8s-operator/spark-team.tf
+++ b/analytics/terraform/spark-k8s-operator/spark-team.tf
@@ -65,7 +65,7 @@ module "spark_team_irsa" {
 
 resource "aws_iam_policy" "spark" {
   description = "IAM role policy for Spark Job execution"
-  name_prefix        = "${local.name}-spark-irsa"
+  name_prefix = "${local.name}-spark-irsa"
   policy      = data.aws_iam_policy_document.spark_operator.json
 }
 

--- a/analytics/terraform/spark-k8s-operator/spark-team.tf
+++ b/analytics/terraform/spark-k8s-operator/spark-team.tf
@@ -65,7 +65,7 @@ module "spark_team_irsa" {
 
 resource "aws_iam_policy" "spark" {
   description = "IAM role policy for Spark Job execution"
-  name        = "${local.name}-spark-irsa"
+  name_prefix        = "${local.name}-spark-irsa"
   policy      = data.aws_iam_policy_document.spark_operator.json
 }
 


### PR DESCRIPTION
### What does this PR do?

Create a unique name for the spark job execution IRSA policy by using `name_prefix` instead of `name`. 
solves https://github.com/awslabs/data-on-eks/issues/668

### Motivation
If you deploy the solution with the same name and account but different regions, the name of this policy conflicts and blocks the creation.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

this could just as easily be avoided by not using the same name in the variables for the solution. 