### PR TITLE
fix: Add implicit dependecy for karpenter resources

### DIFF
--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -295,6 +295,7 @@ module "eks_data_addons" {
           - instanceType: trainium-trn1
           - provisionerType: Karpenter
           - hub.jupyter.org/node-purpose: user
+          - karpenterVersion: ${resource.helm_release.karpenter.version}
         taints:
           - key: aws.amazon.com/neuron
             value: "true"
@@ -349,6 +350,7 @@ module "eks_data_addons" {
           - instanceType: inferentia-inf2
           - provisionerType: Karpenter
           - hub.jupyter.org/node-purpose: user
+          - karpenterVersion: ${resource.helm_release.karpenter.version}
         taints:
           - key: aws.amazon.com/neuron
             value: "true"
@@ -402,6 +404,7 @@ module "eks_data_addons" {
           - instanceType: mixed-x86
           - provisionerType: Karpenter
           - workload: rayhead
+          - karpenterVersion: ${resource.helm_release.karpenter.version}
         requirements:
           - key: "karpenter.k8s.aws/instance-family"
             operator: In


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Fixes a bug in the trainium-inferentia blueprint where it fails to cleanly install due to karpenter-resources being applied before karpenter helm chart is deployed by adding an implicit dependency.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
