### PR TITLE
feat: Spark benchmark observability

### DIFF
--- a/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-1t-ebs.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-1t-ebs.yaml
@@ -47,6 +47,19 @@ spec:
     # Logging set to WARN
     - "true"
   sparkConf:
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.driver.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.executor.sink.prometheusServlet.path": "/metrics/executors/prometheus/"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "s3a://<S3_BUCKET>/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+
     "spark.network.timeout": "2000s"
     "spark.executor.heartbeatInterval": "300s"
     # AQE

--- a/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-1t-ssd.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-1t-ssd.yaml
@@ -47,6 +47,19 @@ spec:
     # Logging set to WARN
     - "true"
   sparkConf:
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.driver.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.executor.sink.prometheusServlet.path": "/metrics/executors/prometheus/"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "s3a://<S3_BUCKET>/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+
     "spark.network.timeout": "2000s"
     "spark.executor.heartbeatInterval": "300s"
     # AQE

--- a/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-data-generation-1t.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/benchmark/tpcds-benchmark-data-generation-1t.yaml
@@ -38,6 +38,19 @@ spec:
     # Logging set to WARN
     - "true"
   sparkConf:
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.driver.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.executor.sink.prometheusServlet.path": "/metrics/executors/prometheus/"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "s3a://<S3_BUCKET>/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+
     "spark.executorEnv.JAVA_HOME": "/opt/java/openjdk"
     "spark.driverEnv.JAVA_HOME": "/opt/java/openjdk"
     "spark.network.timeout": "2000s"

--- a/analytics/terraform/spark-k8s-operator/examples/docker/Dockerfile-benchmark
+++ b/analytics/terraform/spark-k8s-operator/examples/docker/Dockerfile-benchmark
@@ -1,5 +1,5 @@
 # Use the official Spark base image with Java 17 and Python 3
-FROM apache/spark:3.5.3-scala2.12-java17-python3-ubuntu as tpc-toolkit
+FROM apache/spark:3.5.3-scala2.12-java17-python3-ubuntu
 
 # Arguments for version control
 ARG HADOOP_VERSION=3.4.1

--- a/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
@@ -51,6 +51,25 @@ prometheus:
         - source_labels: [__meta_kubernetes_endpoint_port_name]
           regex: http-metrics
           action: keep
+  # Monitors for Spark Jobs
+  additionalPodMonitors:
+    - name: "spark-job-monitoring"
+      jobLabel: "spark-job-monitoring"
+      selector:
+        matchLabels:
+          spark-role: driver
+      namespaceSelector:
+        matchNames:
+          - spark-team-a
+          - spark-team-b
+          - spark-team-c
+      podMetricsEndpoints:
+        - port: "spark-ui"
+          interval: 30s
+          path: /metrics/driver/prometheus/
+        - port: "spark-ui"
+          interval: 30s
+          path: /metrics/executors/prometheus/
 
 alertmanager:
   enabled: false

--- a/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus.yaml
@@ -38,6 +38,25 @@ prometheus:
         - source_labels: [__meta_kubernetes_endpoint_port_name]
           regex: http-metrics
           action: keep
+  # Monitors for Spark Jobs
+  additionalPodMonitors:
+    - name: "spark-job-monitoring"
+      jobLabel: "spark-job-monitoring"
+      selector:
+        matchLabels:
+          spark-role: driver
+      namespaceSelector:
+        matchNames:
+          - spark-team-a
+          - spark-team-b
+          - spark-team-c
+      podMetricsEndpoints:
+        - port: "spark-ui"
+          interval: 30s
+          path: /metrics/driver/prometheus/
+        - port: "spark-ui"
+          interval: 30s
+          path: /metrics/executors/prometheus/
 
 alertmanager:
   enabled: false


### PR DESCRIPTION
### What does this PR do?
increases the observability for the spark benchmark jobs:
- enable spark metrics and eventlogging on the benchmark jobs
- add a PodMonitor config to the kube-prometheus-stack to scrape the metrics 
- cleanup the dockerfile to avoid a warning on build

### Motivation

As we've been running benchmarks the increased visibility has helped compare performance between runs.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?
