### PR TITLE
fix: Add all VPC CIDRs to VPCe config

### DIFF
--- a/analytics/terraform/spark-k8s-operator/vpc.tf
+++ b/analytics/terraform/spark-k8s-operator/vpc.tf
@@ -54,7 +54,7 @@ module "vpc_endpoints_sg" {
     {
       rule        = "https-443-tcp"
       description = "VPC CIDR HTTPS"
-      cidr_blocks = join(",", module.vpc.private_subnets_cidr_blocks)
+      cidr_blocks = join(",", [module.vpc.vpc_cidr_block], module.vpc.vpc_secondary_cidr_blocks)
     },
   ]
 
@@ -82,7 +82,7 @@ module "vpc_endpoints" {
     s3 = {
       service         = "s3"
       service_type    = "Gateway"
-      route_table_ids = module.vpc.private_route_table_ids
+      route_table_ids = concat(module.vpc.public_route_table_ids, module.vpc.private_route_table_ids)
       tags = {
         Name = "${local.name}-s3"
       }


### PR DESCRIPTION
### What does this PR do?
Adds the public subnet CIDR blocks to the security group on the VPC endpoints and adds the S3 gateway endpoint to the Public route table. 

### Motivation
I launched an instance in the Spark operator VPC to use as a bastion instance and selected the Public subnets but the SSM agent on the instance never connected. I think when the vpc endpoints are enabled, the SSM endpoint overrides the DNS for the service, but the Security group blocks traffic from the public subnet.

This shouldn't cause a problem for our examples/eks nodes as we don't really leverage the Public subnet but was annoying to debug. 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

