### PR TITLE
feat: Enable spark-operator prometheus metrics 

### DIFF
--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -386,6 +386,24 @@ module "eks_data_addons" {
           rbac:
             # -- Specifies whether to create RBAC resources for the controller.
             create: false
+        prometheus:
+          metrics:
+            enable: true
+            port: 8080
+            portName: metrics
+            endpoint: /metrics
+            prefix: ""
+          # Prometheus pod monitor for controller pods
+          podMonitor:
+            # -- Specifies whether to create pod monitor.
+            create: true
+            labels: {}
+            # -- The label to use to retrieve the job name from
+            jobLabel: spark-operator-podmonitor
+            # -- Prometheus metrics endpoint properties. `metrics.portName` will be used as a port
+            podMetricsEndpoint:
+              scheme: http
+              interval: 5s
       EOT
     ]
   }

--- a/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
@@ -28,6 +28,11 @@ prometheus:
           resources:
             requests:
               storage: 50Gi
+    # Find monitors in all namespaces 
+    podMonitorSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
     # Scrape Cost metrics for Karpenter and Yunikorn add-ons
     additionalScrapeConfigs:
       - job_name: yunikorn

--- a/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
@@ -28,7 +28,7 @@ prometheus:
           resources:
             requests:
               storage: 50Gi
-    # Find monitors in all namespaces 
+    # Find monitors in all namespaces
     podMonitorSelectorNilUsesHelmValues: false
     probeSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false

--- a/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus.yaml
@@ -15,7 +15,7 @@ prometheus:
           resources:
             requests:
               storage: 50Gi
-    # Find monitors in all namespaces 
+    # Find monitors in all namespaces
     podMonitorSelectorNilUsesHelmValues: false
     probeSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false

--- a/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus.yaml
@@ -15,6 +15,11 @@ prometheus:
           resources:
             requests:
               storage: 50Gi
+    # Find monitors in all namespaces 
+    podMonitorSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
     # Scrape Cost metrics for Karpenter and Yunikorn add-ons
     additionalScrapeConfigs:
       - job_name: yunikorn


### PR DESCRIPTION
### What does this PR do?
Enables the prometheus PodMonitor creation in the spark-operator helm chart and updates the prometheus config to pick up monitors across namespaces (`kube-prometheus-stack`, is the default)

### Motivation
as we continue benchmarks/testing having visibility into the operator performance will help us understand the performance

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
