### PR TITLE
fix: Disable spark-operator podmonitor

### DIFF
--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -394,16 +394,18 @@ module "eks_data_addons" {
             endpoint: /metrics
             prefix: ""
           # Prometheus pod monitor for controller pods
-          podMonitor:
-            # -- Specifies whether to create pod monitor.
-            create: true
-            labels: {}
-            # -- The label to use to retrieve the job name from
-            jobLabel: spark-operator-podmonitor
-            # -- Prometheus metrics endpoint properties. `metrics.portName` will be used as a port
-            podMetricsEndpoint:
-              scheme: http
-              interval: 5s
+          # Note: The kube-prometheus-stack addon must deploy before the PodMonitor CRD is available.
+          #       This can cause the terraform apply to fail since the addons are deployed in parallel
+          # podMonitor:
+          #   # -- Specifies whether to create pod monitor.
+          #   create: true
+          #   labels: {}
+          #   # -- The label to use to retrieve the job name from
+          #   jobLabel: spark-operator-podmonitor
+          #   # -- Prometheus metrics endpoint properties. `metrics.portName` will be used as a port
+          #   podMetricsEndpoint:
+          #     scheme: http
+          #     interval: 5s
       EOT
     ]
   }


### PR DESCRIPTION
### What does this PR do?

This disables the monitoring for Spark-operator by default to address #740

### Motivation

The change to enable these metrics broke the deployment of the solution

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
