### PR TITLE
fix: add missing redis ha, torchx etcd vars

### DIFF
--- a/ai-ml/infrastructure/terraform/addons.tf
+++ b/ai-ml/infrastructure/terraform/addons.tf
@@ -604,6 +604,23 @@ module "eks_data_addons" {
 }
 
 #---------------------------------------------------------------
+# ETCD for TorchX
+#---------------------------------------------------------------
+data "http" "torchx_etcd_yaml" {
+  url = "https://raw.githubusercontent.com/pytorch/torchx/main/resources/etcd.yaml"
+}
+
+data "kubectl_file_documents" "torchx_etcd_yaml" {
+  content = data.http.torchx_etcd_yaml.response_body
+}
+
+resource "kubectl_manifest" "torchx_etcd" {
+  for_each   = var.enable_torchx_etcd ? data.kubectl_file_documents.torchx_etcd_yaml.manifests : {}
+  yaml_body  = each.value
+  depends_on = [module.eks.eks_cluster_id]
+}
+
+#---------------------------------------------------------------
 # Grafana Admin credentials resources
 # Login to AWS secrets manager with the same role as Terraform to extract the Grafana admin password with the secret name as "grafana"
 #---------------------------------------------------------------

--- a/ai-ml/infrastructure/terraform/elastic-cache-redis.tf
+++ b/ai-ml/infrastructure/terraform/elastic-cache-redis.tf
@@ -1,0 +1,57 @@
+#-------------------------------------------
+# For Rayhead High availability cluster
+#-------------------------------------------
+module "elasticache" {
+  create  = var.enable_rayserve_ha_elastic_cache_redis
+  source  = "terraform-aws-modules/elasticache/aws"
+  version = "1.2.0"
+
+  cluster_id               = local.name
+  create_cluster           = true
+  create_replication_group = false
+
+  engine_version = "7.1"
+  node_type      = "cache.t4g.small"
+
+  apply_immediately = true
+
+  # Security Group
+  vpc_id = module.vpc.vpc_id
+  security_group_rules = {
+    ingress_vpc = {
+      # Default type is `ingress`
+      # Default port is based on the default engine port
+      description = "VPC traffic"
+      cidr_ipv4   = module.vpc.vpc_cidr_block
+    }
+
+    ingress_from_eks_worker_node_tcp = {
+      description                  = "Ingress rule to allow TCP on port 6379 from EKS Ray Head Node"
+      protocol                     = "tcp"
+      from_port                    = 6379
+      referenced_security_group_id = module.eks.node_security_group_id
+      to_port                      = 6379
+      type                         = "ingress"
+    }
+  }
+
+  # Subnet Group
+  subnet_group_name        = local.name
+  subnet_group_description = "${title(local.name)} subnet group"
+  subnet_ids               = module.vpc.private_subnets
+
+  # Parameter Group
+  create_parameter_group      = true
+  parameter_group_name        = local.name
+  parameter_group_family      = "redis7"
+  parameter_group_description = "${title(local.name)} parameter group"
+  parameters = [
+    {
+      name  = "latency-tracking"
+      value = "yes"
+    }
+  ]
+
+  tags = local.tags
+
+}

--- a/ai-ml/infrastructure/terraform/variables.tf
+++ b/ai-ml/infrastructure/terraform/variables.tf
@@ -119,6 +119,17 @@ variable "huggingface_token" {
   default     = "DUMMY_TOKEN_REPLACE_ME"
   sensitive   = true
 }
+variable "enable_rayserve_ha_elastic_cache_redis" {
+  description = "Flag to enable Ray Head High Availability with Elastic Cache for Redis"
+  type        = bool
+  default     = false
+}
+
+variable "enable_torchx_etcd" {
+  description = "Flag to enable etcd deployment for torchx"
+  type        = bool
+  default     = false
+}
 
 # Jupyterhub Specific Variables
 


### PR DESCRIPTION
### What does this PR do?

Adds missing blueprint variables:
- `enable_rayserve_ha_elastic_cache_redis`
- `enable_torchx_etcd`

### Motivation

These were missing from the blueprint consolidation

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
