### PR TITLE
chore: Spark blueprint version bump

### DIFF
--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -26,17 +26,17 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_amp_ingest_irsa"></a> [amp\_ingest\_irsa](#module\_amp\_ingest\_irsa) | aws-ia/eks-blueprints-addon/aws | ~> 1.0 |
-| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.34 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 20.26 |
-| <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | ~> 1.2 |
-| <a name="module_eks_data_addons"></a> [eks\_data\_addons](#module\_eks\_data\_addons) | aws-ia/eks-data-addons/aws | 1.34 |
+| <a name="module_amp_ingest_irsa"></a> [amp\_ingest\_irsa](#module\_amp\_ingest\_irsa) | aws-ia/eks-blueprints-addon/aws | ~> 1.1 |
+| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.52 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 20.33 |
+| <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | ~> 1.20 |
+| <a name="module_eks_data_addons"></a> [eks\_data\_addons](#module\_eks\_data\_addons) | aws-ia/eks-data-addons/aws | 1.35 |
 | <a name="module_jupyterhub_single_user_irsa"></a> [jupyterhub\_single\_user\_irsa](#module\_jupyterhub\_single\_user\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.52.0 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
-| <a name="module_spark_team_irsa"></a> [spark\_team\_irsa](#module\_spark\_team\_irsa) | aws-ia/eks-blueprints-addon/aws | ~> 1.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
-| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.0 |
-| <a name="module_vpc_endpoints_sg"></a> [vpc\_endpoints\_sg](#module\_vpc\_endpoints\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.6 |
+| <a name="module_spark_team_irsa"></a> [spark\_team\_irsa](#module\_spark\_team\_irsa) | aws-ia/eks-blueprints-addon/aws | ~> 1.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.19 |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.19 |
+| <a name="module_vpc_endpoints_sg"></a> [vpc\_endpoints\_sg](#module\_vpc\_endpoints\_sg) | terraform-aws-modules/security-group/aws | ~> 5.3 |
 
 ## Resources
 

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -50,7 +50,7 @@ resource "aws_eks_access_entry" "karpenter_nodes" {
 #---------------------------------------------------------------
 module "eks_data_addons" {
   source  = "aws-ia/eks-data-addons/aws"
-  version = "1.34" # ensure to update this to the latest/desired version
+  version = "1.35" # ensure to update this to the latest/desired version
 
   oidc_provider_arn = module.eks.oidc_provider_arn
 
@@ -461,7 +461,7 @@ module "eks_data_addons" {
 #---------------------------------------------------------------
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version               = "~> 5.34"
+  version               = "~> 5.52"
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {
@@ -478,7 +478,7 @@ module "ebs_csi_driver_irsa" {
 #---------------------------------------------------------------
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.2"
+  version = "~> 1.20"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint
@@ -626,7 +626,7 @@ module "eks_blueprints_addons" {
 #tfsec:ignore:*
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.0"
+  version = "~> 4.6"
 
   bucket_prefix = "${local.name}-spark-logs-"
 

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -491,18 +491,18 @@ module "eks_blueprints_addons" {
   eks_addons = {
     aws-ebs-csi-driver = {
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
-      most_recent = true
+      most_recent              = true
     }
     coredns = {
-      preserve = true
+      preserve    = true
       most_recent = true
     }
     vpc-cni = {
-      preserve = true
+      preserve    = true
       most_recent = true
     }
     kube-proxy = {
-      preserve = true
+      preserve    = true
       most_recent = true
     }
   }

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -368,7 +368,7 @@ module "eks_data_addons" {
   #---------------------------------------------------------------
   enable_spark_operator = true
   spark_operator_helm_config = {
-    version = "2.0.2"
+    version = "2.1.0"
     values = [
       <<-EOT
         spark:
@@ -415,7 +415,7 @@ module "eks_data_addons" {
   #---------------------------------------------------------------
   enable_yunikorn = var.enable_yunikorn
   yunikorn_helm_config = {
-    version = "1.6.0"
+    version = "1.6.1"
     values  = [templatefile("${path.module}/helm-values/yunikorn-values.yaml", {})]
   }
 
@@ -491,15 +491,19 @@ module "eks_blueprints_addons" {
   eks_addons = {
     aws-ebs-csi-driver = {
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+      most_recent = true
     }
     coredns = {
       preserve = true
+      most_recent = true
     }
     vpc-cni = {
       preserve = true
+      most_recent = true
     }
     kube-proxy = {
       preserve = true
+      most_recent = true
     }
   }
 
@@ -517,7 +521,7 @@ module "eks_blueprints_addons" {
   #---------------------------------------
   enable_cluster_autoscaler = true
   cluster_autoscaler = {
-    chart_version = "9.43.1"
+    chart_version = "9.46.2"
     values = [templatefile("${path.module}/helm-values/cluster-autoscaler-values.yaml", {
       aws_region     = var.region,
       eks_cluster_id = module.eks.cluster_name
@@ -536,7 +540,7 @@ module "eks_blueprints_addons" {
     }
   }
   karpenter = {
-    chart_version       = "1.0.6"
+    chart_version       = "1.2.1"
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
   }
@@ -575,7 +579,7 @@ module "eks_blueprints_addons" {
 
   enable_aws_load_balancer_controller = true
   aws_load_balancer_controller = {
-    chart_version = "1.9.2"
+    chart_version = "1.11.0"
     set = [{
       name  = "enableServiceMutatorWebhook"
       value = "false"
@@ -584,7 +588,7 @@ module "eks_blueprints_addons" {
 
   enable_ingress_nginx = true
   ingress_nginx = {
-    version = "4.11.3"
+    version = "4.12.0"
     values  = [templatefile("${path.module}/helm-values/nginx-values.yaml", {})]
   }
 
@@ -608,7 +612,7 @@ module "eks_blueprints_addons" {
         amp_url             = "https://aps-workspaces.${local.region}.amazonaws.com/workspaces/${aws_prometheus_workspace.amp[0].id}"
       }) : templatefile("${path.module}/helm-values/kube-prometheus.yaml", {})
     ]
-    chart_version = "65.5.1"
+    chart_version = "69.5.2"
     set_sensitive = [
       {
         name  = "grafana.adminPassword"

--- a/analytics/terraform/spark-k8s-operator/amp.tf
+++ b/analytics/terraform/spark-k8s-operator/amp.tf
@@ -118,7 +118,7 @@ module "amp_ingest_irsa" {
   count = var.enable_amazon_prometheus ? 1 : 0
 
   source         = "aws-ia/eks-blueprints-addon/aws"
-  version        = "~> 1.0"
+  version        = "~> 1.1"
   create_release = false
   create_role    = true
   create_policy  = false

--- a/analytics/terraform/spark-k8s-operator/eks.tf
+++ b/analytics/terraform/spark-k8s-operator/eks.tf
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.26"
+  version = "~> 20.33"
 
   cluster_name    = local.name
   cluster_version = var.eks_cluster_version

--- a/analytics/terraform/spark-k8s-operator/spark-team.tf
+++ b/analytics/terraform/spark-k8s-operator/spark-team.tf
@@ -44,7 +44,7 @@ module "spark_team_irsa" {
   for_each = toset(local.teams)
 
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   create_release = false
   create_role    = true

--- a/analytics/terraform/spark-k8s-operator/vpc.tf
+++ b/analytics/terraform/spark-k8s-operator/vpc.tf
@@ -6,7 +6,7 @@
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 5.19"
 
   name = local.name
   cidr = var.vpc_cidr
@@ -42,7 +42,7 @@ module "vpc" {
 
 module "vpc_endpoints_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 5.0"
+  version = "~> 5.3"
 
   create = var.enable_vpc_endpoints
 
@@ -71,7 +71,7 @@ module "vpc_endpoints_sg" {
 
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "~> 5.0"
+  version = "~> 5.19"
 
   create = var.enable_vpc_endpoints
 


### PR DESCRIPTION
### What does this PR do?

Updates the Terraform modules and Helm charts to the latest available. 

Modules
- aws-ia/eks-data-addons/aws 1.34 -> 1.35
- aws-ia/eks-blueprints-addons/aws ~>1.2 -> ~>1.20
- terraform-aws-modules/s3-bucket/aws ~>3.0 -> ~>4.6
- terraform-aws-modules/eks/aws ~>20.26 -> ~>20.33
- aws-ia/eks-blueprints-addon/aws ~>1.0 -> ~>1.1 (Spark team IRSA)
- terraform-aws-modules/vpc/aws ~>5.0 -> ~>5.19
- terraform-aws-modules/security-group/aws ~>5.0 -> ~>5.3
- terraform-aws-modules/vpc/aws//modules/vpc-endpoints ~>5.0 -> ~>5.19
- terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks ~>5.34 > ~>5.52

Helm chart versions
- spark-operator 2.0.1 -> 2.1.0 
- yunikorn 1.6.0 -> 1.6.1 
- aws-ebs-csi-driver default -> most_recent
- coredns default -> most_recent
- vpc-cni default -> most_recent
- kube-proxy default -> most_recent
- cluster-autoscaler 9.43.1 -> 9.46.2
- karpenter 1.0.6 -> 1.2.1
- aws-for-fluentbit 0.1.34 -> 0.1.34
- aws-load-balancer-controller 1.9.2 -> 1.11.0
- ingress-nginx 4.11.3 -> 4.12.0
- kube-prometheus-stack 65.5.1 -> 69.5.2

### Motivation
Some of the modules/addons were a bit out of date, trying to avoid issues by updating things. 
The Yunikorn change looks to have some good notes in [the changelog](https://yunikorn.apache.org/release-announce/1.6.1) and may address #690 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
