### PR TITLE
docs: NVIDIA triton server monitoring namespace fix

### DIFF
--- a/website/docs/gen-ai/inference/GPUs/vLLM-NVIDIATritonServer.md
+++ b/website/docs/gen-ai/inference/GPUs/vLLM-NVIDIATritonServer.md
@@ -463,13 +463,13 @@ In addition to deploying CloudWatch EKS addon, we have also deployed the Kube Pr
 First, let's verify the services deployed by the Kube Prometheus stack:
 
 ```bash
-kubectl get svc -n kube-prometheus-stack
+kubectl get svc -n monitoring
 ```
 
 You should see output similar to this:
 
 ```text
-kubectl get svc -n kube-prometheus-stack
+kubectl get svc -n monitoring
 NAME                                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
 kube-prometheus-stack-grafana                    ClusterIP   172.20.252.10    <none>        80/TCP              11d
 kube-prometheus-stack-kube-state-metrics         ClusterIP   172.20.34.181    <none>        8080/TCP            11d
@@ -509,7 +509,7 @@ To create a new Grafana dashboard to monitor these metrics, follow the steps bel
 
 ```bash
 - Port-forward Grafana service:
-kubectl port-forward svc/kube-prometheus-stack-grafana 8080:80 -n kube-prometheus-stack
+kubectl port-forward svc/kube-prometheus-stack-grafana 8080:80 -n monitoring
 
 - Grafana Admin user
 admin


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Documentation was not on par with actual cluster that was created from instructions, namespace `kube-prometheus-stack` didn't exist, but commands worked as expected using namespace `monitoring`

```
$ kubectl get svc -n triton-vllm

NAME                                                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
nvidia-triton-server-triton-inference-server           ClusterIP   172.20.129.84    <none>        8000/TCP,8001/TCP,8002/TCP   48m
nvidia-triton-server-triton-inference-server-metrics   ClusterIP   172.20.101.120   <none>        8080/TCP                     48m

$ kubectl get svc -n kube-prometheus-stack

No resources found in kube-prometheus-stack namespace.

$ kubectl get svc -n monitoring

NAME                                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
kube-prometheus-stack-grafana                    ClusterIP   172.20.7.245     <none>        80/TCP              49m
kube-prometheus-stack-kube-state-metrics         ClusterIP   172.20.91.230    <none>        8080/TCP            49m
kube-prometheus-stack-operator                   ClusterIP   172.20.182.52    <none>        443/TCP             49m
kube-prometheus-stack-prometheus                 ClusterIP   172.20.85.102    <none>        9090/TCP,8080/TCP   49m
kube-prometheus-stack-prometheus-node-exporter   ClusterIP   172.20.101.14    <none>        9100/TCP            49m
prometheus-adapter                               ClusterIP   172.20.193.146   <none>        443/TCP             48m
prometheus-operated

$ kubectl get ns
NAME                   STATUS   AGE
amazon-cloudwatch      Active   51m
default                Active   58m
ingress-nginx          Active   51m
karpenter              Active   53m
karpenter-resources    Active   50m
kube-node-lease        Active   58m
kube-public            Active   58m
kube-system            Active   58m
monitoring             Active   49m
nvidia-device-plugin   Active   51m
triton-vllm            Active   51m
```

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
