### PR TITLE
feat: Add an example notebook for S3 Tables

### DIFF
--- a/analytics/terraform/spark-k8s-operator/examples/s3-tables/s3table-duckdb-demo.ipynb
+++ b/analytics/terraform/spark-k8s-operator/examples/s3-tables/s3table-duckdb-demo.ipynb
@@ -1,0 +1,856 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "607dd579-22c7-4d1f-bdef-5dd518cac38a",
+   "metadata": {},
+   "source": [
+    "# Spark and S3 Buckets integration demo\n",
+    "\n",
+    "**In this demo, we will use a public dataset from libraries in Seattle to see how easy S3 Tables can be used in Spark applications.**\n",
+    "\n",
+    "# Spark configuration and namespace configuration.\n",
+    "\n",
+    "\n",
+    "**First. let's create and configure a Spark session object. Then create a S3 Tables namespace under the table.**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f9e8e20-bb76-4332-9b43-35add77439c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "import os\n",
+    "from datetime import datetime\n",
+    "from decimal import Decimal\n",
+    "from IPython.display import display, HTML\n",
+    "\n",
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql.types import StructType, StructField, StringType, IntegerType, FloatType, DecimalType, LongType\n",
+    "\n",
+    "\n",
+    "# Logging configuration\n",
+    "formatter = logging.Formatter('[%(asctime)s] %(levelname)s @ line %(lineno)d: %(message)s')\n",
+    "handler = logging.StreamHandler(sys.stdout)\n",
+    "handler.setLevel(logging.INFO)\n",
+    "handler.setFormatter(formatter)\n",
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.INFO)\n",
+    "logger.addHandler(handler)\n",
+    "color = \"------------------------- \\n\\x1b[94;1m\"\n",
+    "\n",
+    "# Application-specific variables\n",
+    "dt_string = datetime.now().strftime(\"%Y_%m_%d_%H_%M_%S\")\n",
+    "AppName = \"Demo\"\n",
+    "\n",
+    "input_csv_path = \"s3a://<DATA_SET>/library-checkout/\"\n",
+    "s3table_arn = \"arn:aws:s3tables:us-west-2:<ACC_NUM>:bucket/demo\"\n",
+    "\n",
+    "spark = (SparkSession\n",
+    "    .builder\n",
+    "    .appName(f\"{AppName}_{dt_string}\")\n",
+    "    # Spark S3 Tables library configurations.\n",
+    "    .config(\"spark.sql.extensions\", \"org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions\")\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket\", \"org.apache.iceberg.spark.SparkCatalog\")\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.catalog-impl\", \"software.amazon.s3tables.iceberg.S3TablesCatalog\")\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.warehouse\", s3table_arn)\n",
+    "    .config('spark.hadoop.fs.s3.impl', \"org.apache.hadoop.fs.s3a.S3AFileSystem\")\n",
+    "    .config(\"spark.sql.defaultCatalog\", \"s3tablesbucket\")\n",
+    "    .config(\"spark.hadoop.fs.s3a.connection.timeout\", \"1200000\") \\\n",
+    "    .config(\"spark.hadoop.fs.s3a.path.style.access\", \"true\") \\\n",
+    "    .config(\"spark.hadoop.fs.s3a.connection.maximum\", \"200\") \\\n",
+    "    .config(\"spark.hadoop.fs.s3a.fast.upload\", \"true\") \\\n",
+    "    .config(\"spark.hadoop.fs.s3a.readahead.range\", \"256K\") \\\n",
+    "    .config(\"spark.hadoop.fs.s3a.input.fadvise\", \"random\") \\\n",
+    "    .config(\"spark.hadoop.fs.s3a.aws.credentials.provider.mapping\", \"com.amazonaws.auth.WebIdentityTokenCredentialsProvider=software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider\") \\\n",
+    "    .config(\"spark.hadoop.fs.s3a.aws.credentials.provider\", \"software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider\")\n",
+    "    .getOrCreate())\n",
+    "\n",
+    "namespace = \"demo\"\n",
+    "table_name = \"demo\"\n",
+    "full_table_name = f\"s3tablesbucket.{namespace}.{table_name}\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9b7ed4a5-af9b-4897-97ed-7598022374f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>namespace</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>demo</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  namespace\n",
+       "0      demo"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Create a namespace\n",
+    "spark.sql(f\"CREATE NAMESPACE IF NOT EXISTS s3tablesbucket.{namespace}\")\n",
+    "results = spark.sql(\"SHOW NAMESPACES;\")\n",
+    "display(results.toPandas())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13949daa-a17d-4ca7-8263-9062752a82e1",
+   "metadata": {},
+   "source": [
+    "# Read CSV data from a S3 Bucket\n",
+    "\n",
+    "Our example data files store checkout data from [Seattle area libraries](https://data.seattle.gov/Community-and-Culture/Checkouts-by-Title/tmmm-ytt6/about_data) in 2024. Data includes information such as, how many times a book was checked out, when it was checked out, and media type (books, e-books, etc). \n",
+    "For this demo purposes, they are stored in a S3 Bucket in CSV format. Let's read data from them.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f30bba56-792f-4972-aa33-ec44368d2197",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>usageclass</th>\n",
+       "      <th>checkouttype</th>\n",
+       "      <th>materialtype</th>\n",
+       "      <th>checkoutyear</th>\n",
+       "      <th>checkoutmonth</th>\n",
+       "      <th>checkouts</th>\n",
+       "      <th>title</th>\n",
+       "      <th>isbn</th>\n",
+       "      <th>creator</th>\n",
+       "      <th>subjects</th>\n",
+       "      <th>publisher</th>\n",
+       "      <th>publicationyear</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Digital</td>\n",
+       "      <td>OverDrive</td>\n",
+       "      <td>AUDIOBOOK</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>The Age of Doubt (unabridged)</td>\n",
+       "      <td>9781481590273</td>\n",
+       "      <td>Andrea Camilleri</td>\n",
+       "      <td>Fiction, Mystery</td>\n",
+       "      <td>Blackstone Audio, Inc.</td>\n",
+       "      <td>2012</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Digital</td>\n",
+       "      <td>OverDrive</td>\n",
+       "      <td>AUDIOBOOK</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Boys I Know (unabridged)</td>\n",
+       "      <td>9780593558829</td>\n",
+       "      <td>Anna Gracia</td>\n",
+       "      <td>Romance, Young Adult Fiction, Young Adult Lite...</td>\n",
+       "      <td>Books on Tape</td>\n",
+       "      <td>2022</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  usageclass checkouttype materialtype  checkoutyear  checkoutmonth  \\\n",
+       "0    Digital    OverDrive    AUDIOBOOK          2023              3   \n",
+       "1    Digital    OverDrive    AUDIOBOOK          2023              3   \n",
+       "\n",
+       "   checkouts                          title           isbn           creator  \\\n",
+       "0          1  The Age of Doubt (unabridged)  9781481590273  Andrea Camilleri   \n",
+       "1          1       Boys I Know (unabridged)  9780593558829       Anna Gracia   \n",
+       "\n",
+       "                                            subjects               publisher  \\\n",
+       "0                                   Fiction, Mystery  Blackstone Audio, Inc.   \n",
+       "1  Romance, Young Adult Fiction, Young Adult Lite...           Books on Tape   \n",
+       "\n",
+       "  publicationyear  \n",
+       "0            2012  \n",
+       "1            2022  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "library_checkout = spark.read.options(mode='FAILFAST', multiLine=True, escape='\"').csv(input_csv_path, header=True, inferSchema=True)\n",
+    "library_checkout.createOrReplaceTempView(\"checkout_data\")\n",
+    "spark.sql(\"SELECT * FROM checkout_data LIMIT 2;\").toPandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6982a72-97fc-443e-a1dd-a413f4e2d178",
+   "metadata": {},
+   "source": [
+    "# A quick peek \n",
+    "\n",
+    "Let's take a quick look at total usage data by Media Type like books, e-book, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "b2f03232-01c5-4b0c-9c23-abc59ec62c1a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhgAAAGxCAYAAAAgf8+rAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACG7klEQVR4nO3dd3iT1RcH8O+b3b1L924pZZS9oWXvochQFFFEBBScqKCiKKD+xIGDIbKULVNA9t57tYVSoBS6926z7u+P2EhsOtKkzej5PE8faPLem/OmaXpy33vP5RhjDIQQQgghBsQzdgCEEEIIsTyUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMThKMAghhBBicJRg1NGxY8fAcRw+/fRTozx+QEAAAgICNG779NNPwXEcjh07ZpSYEhMTwXEcJk6caJTHN4T8/Hy8/vrr8Pf3h0AgAMdxSExMNPjjREdHg+M4g/dbF6YUS32yhNenIVT13qXtPYUQfTTqBKPiDefJL2tra3h5eaFPnz745JNPcO/evXp5bHN9U7f0N6H33nsPP//8M1q3bo3Zs2dj7ty5cHR0rFXbw4cP47nnnkNAQACsrKxgY2ODZs2aYcqUKTh//nz9Bm4hOI5DdHS0scMwuIr3FysrK+Tl5Wk9Jjs7G2KxGBzHQSKRNGyA9aQimantlyX+7BszgbEDMAXBwcF4/vnnAQDl5eXIyMjAhQsX8Pnnn2PBggWYNWsW5s+fr5EQdOzYEXFxcXB1dTVKzIcPHzbK41bH29sbcXFxcHBwMHYodbZ37140bdoUO3furHWb0tJSvPzyy9i4cSOsra3Rt29fhIWFAQDi4+Oxbt06LF++HGvXrsULL7xQX6ETEycQCFBWVob169dj2rRple7//fffIZVKIRAY5225Pt5TAgICMHfuXI3bEhMTsWbNGkRGRmLkyJGVjieWgxIMACEhIVovdZw8eRITJkzAwoULwefz8fnnn6vvs7a2Rnh4eANGqSk4ONhoj10VoVBo1OfEEFJSUtCzZ0+d2kyaNAkbN25Ev3798Pvvv6NJkyYa9+fl5WHhwoVVfnIljUNwcDAYY1i5cqXWBGPVqlVo1aoV8vPzkZaWZpT4DC0gIKDSe+uxY8ewZs0atG7d2miXmEnDaNSXSGrSo0cP7N+/H2KxGF9//TUePXqkvq+q65h3797FSy+9hMDAQEgkEri6uqJt27Z455131MdwHIfjx4+r/1/xVXFt+Mlrxbdv38bTTz8NV1dXjfkANV2q+PXXX9G8eXNIJBL4+fnhww8/RFlZmcYx1c0j+e/16orvHz58iIcPH2rEXdG+umvcSUlJmDRpEry9vSESieDj44NJkyZpPKcVKi4fyeVyfP755wgMDIRYLEZYWBh++eWXKs9ZG7lcju+++w6RkZGwsrKCg4MDevXqhT179mgcN3HiRHAcB8YYjh8/XulnUpWjR49iw4YNCAsLw44dOyolFwDg6OiIr776Cq+++qrW+Gp7jhV/nLp16wZ7e3tYW1ujffv2WLlyZZXHr1mzBj179oSjoyOsra0RGhqK1157DUlJSdWeFwCsX78eIpEI7dq1Q0ZGhvr2NWvWoHPnzrC1tYWtrS06d+6MNWvWVGq/evVqcByH1atXV7rvv6+9iu8BaDz/T7ZXKpVYsWIFOnbsCGdnZ1hbWyMgIAAjR47EiRMnajyfJ926dQuDBg2Cg4MD7O3tMWzYMMTGxmocExUVBaFQiNTUVK19jBkzBhzH4erVq7V+3IkTJ+Ly5cu4ceOGxu2XLl3CjRs38NJLL1XbfufOnejTpw+cnJwgkUjQokULfPPNN1AoFJWOLS0txQcffABfX1/1sb/++muVfWt7T0lJScHcuXPRuXNnuLu7QywWIyAgANOmTdN4Tehr7ty54DgOW7Zs0Xr/L7/8Ao7j8N1336lvq7ik8ujRI4wdOxYuLi6wsbFBdHQ0zpw5o7UfqVSKb7/9Fm3btoWNjQ3s7OzQo0cP7Nq1y2DnQp7AGrEHDx4wAGzAgAHVHjdhwgQGgC1evFh929GjRxkANnfuXPVtycnJzNHRkQmFQjZy5Ej2/vvvs+nTp7P+/fszoVCoPm7u3LnM399f3b7ia/v27RpxdevWjTk4OLCuXbuyt99+m02cOJElJyczxhjz9/dn/v7+GnHOnTuXAWBDhw5ltra2bNKkSWzWrFmsRYsW6vNUKpXVnsN/n5sXX3yRMcZYbm4umzt3LnNwcGAODg4acR89elRrmwrx8fHM3d2dAWDDhg1jH3zwARs2bBgDwNzd3dndu3c1jo+KimIA2DPPPMN8fX3Zq6++yqZOncpcXFwYALZ8+fJqf14VlEole/rppxkAFhYWxt555x322muvMWdnZwaA/fDDD+pjt2/frn7+/P39K/1MqjJ+/HidYqrrOSqVSvbcc8+pz2XKlCnsjTfeYOHh4QwAe+eddyodP3bsWAaAeXt7s9dee43NmjWLjRkzhjk6OmqcV0UsT/r+++8Zx3Gsd+/erKCgQH37m2++qe5zxowZbObMmczHx4cBYG+99ZZGH6tWrWIA2KpVqyqd/39few8ePND6/M+dO5ddvXqVMcbYrFmzGAAWHBzMpk+fzj744AP2wgsvsICAAK2v4f+qeH326NGD2dvbs759+7IPPviAjRo1ivF4PObo6MhiY2PVx69bt44BYPPnz6/UV2ZmJhOJRKxdu3Y1Pi5jjAFgTZs2ZcnJyYzP57M333xT4/6pU6cykUjEMjMzmb+/PxOLxZX6+PDDDxkA5uPjwyZNmsTeeust1q5dO/Xr6EkKhYL17duXAWAtW7Zks2bNYpMmTWI2NjZs6NChWn/vtb2nbNiwgdnY2LDhw4ezGTNmsHfeeYf17t2bAWBBQUEsLy+vVuf/pIqf/ZPvE0lJSYzP57N+/fppbdOmTRsmEolYVlaW+jYArFWrVszX15d17NhR/XoQiURMJBKp35cqlJWVsejoaAaAtWnThr3xxhvstddeY76+vgwA+/HHH3U+F1I9SjBqkWD89ttvDAB74YUX1Ldp++O8ePHiSn+4KmRmZmp8r+1N/b9xAWAff/yx1mOqSzAkEgm7deuW+naZTMb69evHALC1a9dWew7/jeG/yYK2x62pTcUb0rJlyzRuX7ZsGQPA+vTpo3F7xXPTqVMnlp+fr7799u3bTCAQsKZNm2p9/P9au3YtA8CioqJYeXm5+vZHjx4xd3d3JhQK2f379zXaVBxfWwEBAQwAS0hIqHUbxnQ/x+XLlzMAbNKkSUwmk6lvLy8vVydrly5dUt/+888/q5/bkpISjb5KSkpYdnZ2pVgqVPwhGz16tMbzduLECQaANWvWTOMPS15enjrROXnypPp2XRKMCtU9/87Ozszb25sVFxdr3K5UKjXOpypP/l599NFHGvetWbOGAWC9e/dW31ZWVsZcXFxYcHCwRmLOGGPffvstA8CWLFlS4+NWnFfFz3Tw4MHM1dWVSaVSxhhjpaWlzNHRkY0aNYoxxrQmGAcOHGAA2KBBgzTOX6lUstdee40BYH/++af69ornfuDAgUwul6tvv3HjBhOJRLVOMNLT01lhYWGl86l4vr744otanf+TtCUYjDE2ZMgQxnEce/DggcbtV69eZQDY2LFjNW6v+Fm+8MILGj+fY8eOMY7jWEhICFMoFOrbZ8+ezQCwTz/9VOP4goIC1r59eyYSidQf4IhhUIJRiwTj77//Vv9yV6guwajNp9naJBgeHh4ab/BPqi7BmDx5cqXjL168WOmPeUMkGElJSQwAi4iIqPQmrVQqWbNmzRgAlpSUpL694rk5cuRIpceouO/JT9VVqUhszp8/X+m+hQsXMgDs888/17hd1wRDIpEwAKysrKzWbRjT/RxbtWrFbGxsWGlpaaXjb9y4UWkUIyIigvH5fBYfH1/rWORyOZs0aRIDwKZOnarx5swYYy+//DIDwDZt2lSpjw0bNqgToAr1kWAEBgZW+TtRk4rXp5OTEysqKtK4T6lUqkf6nnwtvv322wwAO3z4sMbxzZs3Z9bW1hrJYXWeTDD+/PNPjYTgjz/+YADYnj17GGPaE4zhw4dXiq1CXl4e4zhOnaAwxlivXr0YAHb58uVKx1f8jGuTYFRFqVQye3t7Fh0dXavjn1RVgrFr1y6tH6qmTZvGALBDhw5p3A6A8fl8rc/JkCFDNBJehULBnJycWEhISKX3oScfm0YxDIsmedYCY6xWxw0dOhQffPABpk+fjoMHD2LgwIHo3r27ekWBriIjIyESiXRu16NHj0q3tW/fHlZWVrh27VqdYqmriuvTUVFRlZblchyHnj17Ii4uDtevX4evr6/G/W3btq3Un4+PDwDVxEk7O7saH9vKygodO3asdF/FcriGfj7+qzbnWFJSgps3b8LLywtffvllpeNlMhkA4Pbt2wCA4uJixMbGIiQkBKGhobWO5emnn8auXbswd+5crfNyKn6W2pYSNsTzOWbMGCxduhQtWrTA2LFjERUVhS5dusDGxkanftq0aVOpDcdx6N69O27duqXxWnz11Vfx7bffYsWKFejduzcA4Ny5c4iJicHEiRNhb2+v83kMHz4crq6uWLlyJUaNGoWVK1fCy8sLAwYMqLLNuXPnYGNjg99++03r/VZWVuqfPwBcv34d1tbWWl9fPXr0qLIfbbZt24Zly5bhypUryM3N1ZjvkZKSUut+ajJ48GD4+Phg1apV+PTTT8Hj8dSrboKCgtTP/5P8/f0rvW8AqnPcs2cPrl27hu7du+POnTvIzc2Fl5cXPvvss0rHZ2ZmAoDGc0j0RwlGLVRM8nJzc6v2uMDAQJw9exafffYZ/v77b/WEpaZNm+Lzzz/H6NGjdXpcbRMGa8Pd3b3K25OTk+vUZ10VFBQAqPpcPDw8AKgKXP2XtuWuFUv4tE1q0/bY2t58anpcXXh4eCAxMRHJyckICgrSuX1tzjE3NxeMMSQnJ2t9c6xQXFwMAOrVKt7e3jrFcvLkSVhZWWHQoEFa7y8oKACPx9P6e9CkSRPweDy9n8/qLF68GEFBQVi9ejW++OILfPHFF5BIJBgzZgwWLVpU6yXjVf1+VLxGnzyHpk2bIioqCtu2bUNOTg6cnZ2xYsUKAMDkyZPrdB5CoRDjx4/HTz/9hDNnzuDo0aN4//33wefzq2yTk5MDuVxeq59/xTlU9drX5X1l0aJFePfdd+Hm5ob+/fvDx8cHVlZWAIDvv/8e5eXlte6rJnw+H5MmTcJnn32Gffv2YfDgwfjzzz+Rl5eH9957T2vdoNr+LHNycgAAMTExiImJqTKGJ59Doj9aRVILFZUxO3ToUOOxrVq1wtatW5GTk4OzZ8/ik08+QXp6OsaOHYvTp0/r9Lh1LcRV1ezujIwMjT9oPJ7qxy+Xyysda6g/FBWf8NLT07XeX3F7XT4J1uax6/txu3XrBqB+65JUxNiuXTsw1WVNrV9Hjx4F8G/SomsyefjwYVhZWaF///44d+6c1jiUSqX6096TMjIyoFQqNZ5PQ7++hEIh3nvvPcTExCA5ORnr169Hjx49sHbtWowfP77W/VT1+1Hxmvhv0jdlyhSUl5fjjz/+QFFRETZt2oSIiAh07dpV53OoMGnSJCgUCowZMwaMMbz88svVHm9vbw8XF5dqf/4PHjxQH+/g4FDjedakYoWTl5cXYmJisG7dOnz11Vf49NNPMXfuXEil0tqfcC298sor4PP56iRuxYoVEAgEVa7mqu3PsuJ1OWrUqGqfw1WrVhn4jBo3SjBqEB8fj82bN0MsFuOpp56qdTuhUIjOnTvjs88+w+LFi8EYw+7du9X3V3xaqc0ncV2dPHmy0m2XLl1CaWkpWrdurb7NyckJgPY/RFUtvePz+TrFXPF4J06cqHSpiTGmjvXJuAylTZs2KC0txYULFyrdV7FMWN/HnTRpEgDVJ73S0tJqj63rpz07Ozs0a9YMcXFxtaqlYWtri4iICDx48AB3796t9eO0adMGhw8fhkAgwIABAyolGW3atAEAraXotT2fdXl98Xi8Wr2+vLy88Oyzz2Lfvn0IDQ3FoUOHanz+n3xsbZ9UKz4AREZGatw+atQouLq6YsWKFdi0aROKiorwyiuv1OqxqtKyZUu0a9cOycnJ6N69e42Xsjp16oTs7Oxa/zwjIyNRUlKCK1euVLpP2/uDNllZWcjPz0fnzp0rjVpVvJ8Ymo+PDwYNGoTdu3fj9OnTOHHiBAYPHgwvLy+txz98+FDrUvf/vq80a9YM9vb2uHTpkvqSIql/lGBU49SpUxgwYADKy8vx4Ycf1jjkfPHiRa0ZdUU2XTG0CADOzs4AgMePHxswYpXff/9dYxhQLpdj9uzZAIAXX3xRfXvTpk1ha2uLXbt2qYcQK+L94osvtPbt7OyMrKysSjU1quLn54devXohJiamUr2GlStXIiYmBr17965yOFcfFef64YcfarypJCcn49tvv4VAINDpk682vXr1wrPPPos7d+7g6aef1vrzLygowOzZs7F8+fI6P86MGTNQUlKCyZMna/3j+ODBA409U6ZPnw6FQoFp06ZV+kNQVlam8fN+UuvWrXHkyBEIhUL0799fo55AxfP52WefqS99VZxfxdD9k6+vtm3bguM4bNy4UeP1cvfuXfzwww9aH9/Z2Vnr70R5eTmOHDlSKUktLi5GYWEhhEJhtZcYnpSbm1tpLsvatWtx8+ZNra9FkUiEF198ETdv3sQnn3wCkUiECRMm1OqxqrNmzRps37692toUFWbMmAEAePnll5GdnV3p/rS0NMTFxam/r6gYO2fOHI2E7ebNm/j9999rFZ+7uzusrKxw5coVlJSUqG/Pzc3FG2+8Uas+6mLKlCmQyWTq0Z3qLkUpFArMmTNH43Vx/Phx7N27FyEhIepRJoFAgKlTp+Lhw4d49913tSYZt27dMmhtD0JzMAAACQkJ6kltUqkUGRkZOH/+PG7dugU+n4+PPvoIn3zySY39rFu3Dr/88guio6MREhICe3t7xMbGYu/evXB1ddUYBu3duzf+/PNPjB49GoMHD4ZEIkHLli0xZMgQvc+nb9++6Ny5M8aNGwdnZ2fs3bsXt27dwoABA9Ql0QHVG+frr7+OL7/8Em3btsWIESNQWFiIv/76C1FRUVr3YenduzcuXbqEYcOGoUePHhCJROjevTu6d+9eZTxLlixB9+7dMXnyZPz111+IiIhAbGwsdu3aBTc3NyxZskTvc9bmhRdewLZt27Bz5060atUKQ4cORXFxMTZv3ozs7GwsWrSoTvMm/uu3334DYwwbN25EYGAg+vfvj7CwMDDGcPfuXRw+fBiFhYW1fmPXZsqUKTh37hzWrFmD06dPo2/fvvDy8kJ6ejpu376N8+fPY/369epCSVOnTsXx48exefNmhIaGYvjw4bC3t0dSUhL279+P3377rVKZ5gqRkZE4cuQI+vTpg4EDB2Lfvn3o2rUrevbsiTfeeAM//vgjWrRooR5u3rZtGx49eoQZM2ZoVEH19vbG2LFjsXHjRrRr1w4DBw5ERkYGtm/fjoEDB2Lr1q2VHrt3797YvHkznnnmGbRp0wZ8Ph9DhgyBr68v+vTpg6CgIHTq1Al+fn4oKirC7t27kZaWhvfff7/WE6J79OiBxYsX49y5c+jQoQPi4+Oxfft2ODg44KefftLa5tVXX8WiRYuQkpKiLuqkr+bNm6N58+a1OnbgwIH4+OOP8fnnnyMkJAQDBw6Ev78/srOzkZCQgJMnT+KLL75As2bNAKgSvfXr12Pfvn1o06YNBg0ahJycHGzYsAH9+/fXGE2tCo/Hw7Rp07Bo0SJERkZi2LBhKCgowN9//w1/f/8qRxX0NXjwYPj6+uLRo0fw9vauck4QoLokfezYMXTu3Bm9e/dGSkoKNm7cCKFQiF9//VV9mQ5QJcZXrlzB4sWLsWfPHkRFRcHNzQ3Jycm4efMmrl+/jrNnz1Y5r4PUQb2vUzFhT66Lr/iysrJinp6erFevXuzjjz+usr6BtmV2586dY1OmTGEtWrRgjo6OzMrKioWGhrIZM2ZUWkolk8nYrFmzmJ+fHxMIBBrLtqpaIvqk6papHj16lC1btoxFREQwsVjMfHx82AcffFCpHgJjjMnlcvbJJ58wX19fJhKJWFhYGPvhhx/Y/fv3tcZQWFjIJk+ezDw9PRmPx9N4DqqLOzExkb300kvM09OTCQQC5unpyV566SWWmJhY6djqlvC++OKLDECltfJVkclk7JtvvmEtW7ZkYrGY2dnZsaioKLZz506tx0PHZapPOnjwIHv22WeZv78/k0gkTCKRsNDQUDZp0qRKS2Xreo6bNm1iffv2ZU5OTkwoFDJvb28WHR3NFi1aVKnWilKpZCtWrGCdO3dmNjY2zNramoWGhrLXXntN67Lg/7p+/TpzdXVltra2GvUtVq5cyTp06MCsra2ZtbU169ChA1u5cqXWcykuLmZvvPEGa9KkCROLxaxVq1Zs3bp1VS5TTU1NZWPGjGGurq7q19eqVauYVCplX331Fevfvz/z8fFhIpGINWnShEVFRbGNGzdqfez/evL1eePGDTZw4EBmZ2fHbG1t2ZAhQzRqx2jTpUsXrcslawNPLFOtSVWFthhTvcaGDRvG3NzcmFAoZB4eHqxLly7s888/r/QeU1xczGbNmsW8vb2ZWCxmERERbNmyZVU+99reU6RSKZs/fz4LDQ1lYrGY+fn5sbfffpsVFhbqtKz1SVUtU31SRS2W/9YreVLF7+rDhw/Z6NGjmZOTE7OysmI9e/Zkp06d0tpGLpezZcuWsW7dujF7e3v1OQ0cOJAtWbKk0vJloh+OsVquwSSEkEaqrKwM3t7ecHR0REJCglnuhGxOBg8ejH379uH+/ftVbonAcRyioqK0zgkipoHmYBBCSA1WrlyJnJwcTJkyhZKLehYTE4N9+/Zh4MCBtLuqmaM5GIQQUoUvv/wSmZmZWLZsGdzd3fHaa68ZOySLtX79ety5cwdr164FAHz88cdGjojoixIMQgipwocffgiRSITIyEgsXry4Xuq1EJXly5fj5MmT8Pf3x2+//YYuXboYOySiJ5qDQQghhBCDozkYhBBCCDE4SjAIIYQQYnCUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMThKMAghhBBicJRgEEIIIcTgKMEghBBCiMFRgkEIIYQQg6MEgxBCCCEGRwkGIYQQQgyOEgxCCCGEGBwlGIQQQggxOEowCCGEEGJwlGAQQgghxOAowSCEEEKIwVGCQQghhBCDowSDEEIIIQZHCQYhhBBCDI4SDEIIIYQYHCUYhBBCCDE4SjAIIYQQYnCUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMThKMAghhBBicJRgEEKIHiZOnAiO4yp9DRw4EAAQEBCgvo3P58PLywuTJk1Cbm6uRj85OTl48803ERAQAJFIBE9PT7z00ktISkqq9JiPHj3CpEmT4OXlBZFIBH9/f8ycORPZ2dkax0VHR+PNN9/UuO2HH36AWCzG+vXrDftEEPIflGAQQoieBg4ciNTUVI2vDRs2qO+fN28eUlNTkZSUhHXr1uHEiROYMWOG+v6cnBx07twZhw4dwi+//IKEhARs2rQJ9+7dQ4cOHXD//n31sffv30f79u0RHx+PDRs2ICEhAUuXLsXhw4fRpUsX5OTkVBnn3Llz8eGHH2L79u147rnn6ufJIOQfAmMHQAgh5k4sFsPDw6PK++3s7NT3e3t7Y8KECdi4caP6/jlz5iAlJQUJCQnq4/z8/LB//36EhoZi+vTp+PvvvwEA06dPh0gkwoEDB2BlZaU+tk2bNggODsacOXOwZMkSjcdnjGHGjBn4/fffceDAAXTv3t2g50+INjSCQQghDSg5ORm7d+9Gp06dAABKpRIbN27E+PHjKyUpVlZWmDZtGvbv34+cnBzk5ORg//79mDZtmjq5qODh4YHx48dj06ZNYIypb5fL5XjhhRewZcsWHD9+nJIL0mAowSCEED3t3r0btra2Gl+ff/65+v73338ftra2sLKygo+PDziOw7fffgsAyMzMRF5eHpo1a6a172bNmoExhoSEBNy9exeMsWqPzc3NRWZmpvq2X3/9FVu2bMGxY8cQGRlpwLMmpHp0iYQQC6ZkDFI5IFMwlMsZpIon/88gUwBKBnD/HM9xWv7/xG0CHgexgINYAIgFHCRC1fdCPlfpsRuTXr16Vbos4ezsrP7/e++9h4kTJ4IxhkePHmH27NkYMmQITpw4UWPfFaMRHMdpjEzUdGyF7t2749q1a/joo4+wceNGCAT0tk8aBr3SCDFT5XKGwjIliqUMReUMReWq/xdLVQmETM4gUzZMLHxOlXCIhRwkTyQfdmIe7CUc7K14sBVxGn/4LImNjQ1CQkKqvN/V1VV9f2hoKL7//nt06dIFR48eRe/eveHo6IjY2FitbW/fvg2O4xAcHAzGGDiOQ2xsLEaOHKn1WCcnJ7i6uqpva9myJRYtWoS+fftizJgx2LRpE4RCoX4nTEgtUIJBiAljjKGwjCG3VIn8MiUKShkKypQoKFNCqjB2dP9SMKBExlAiq/oTNp8D7CQc7CU82El4cPjn//YSHiRCy0w8qsLn8wEApaWl4PF4GDNmDNatW4d58+ZpzMMoLS3FL7/8ggEDBqhHRPr164dffvkFb731lsY8jLS0NKxbtw4TJkyolMi1bt0aR44cQd++fTF69Ghs2bKFkgxS7yjBIMSElEiVyCpWIrtIiaxiBbKLTSuR0IeCAXmlDHmlCgCaJyXiAy42PLjZ8uFmq/pXJDCfpKO8vBxpaWkatwkEAvVIQmFhIdLS0tSXSGbNmgVXV1d07doVADB//nwcPnwY/fr1w9dff40WLVrgwYMH+OijjyCTyfDzzz+r+/3pp5/QtWtXDBgwAF988QUCAwMRExOD9957D97e3pg/f77WGFu1aqUeMXnmmWewZcsWiESienpGCAE4VtNFPUJIvZDKGbKLVYlERVJR3QhAY+NgxWkkHA4S07zEMnHiRKxZs6bS7U2bNsXt27cREBCAhw8fqm93c3NDhw4dMH/+fLRu3Vp9e1ZWFubNm4cdO3YgNTUVLi4uGDhwIObNmwc/Pz+Nvh8+fIhPP/0U+/btQ3Z2Njw8PDBy5EjMnTsXLi4u6uOio6PRunVrfP/99+rbYmNj0adPH7Rv3x5bt26lJIPUG0owCGkgSsaQUahEcr4CKXkK5JY20AQJCyHiA67/JBxe9ny42vJMMuEghKhQgkFIPSqRKpGcp0ByvgKpBQrILORyhymQCABvRwF8HPnwcuA3+pUshJgaSjAIMaAnRymS8+TIK6Vfr4bA44Amdjz4OArg68SHrZhK/BBibJRgEKInJWNIzVfgfrYcj/NolMIUOFpx8HYUwNdRdUmFLqUQ0vAowSCkjrKLFbifJceDHAXKaHKmybIVcwh2FSDYVUAjG4Q0IEowCNFBsVSJB1ly3M+myx/myMOOh2A3AfydBBDQnA1C6hUlGITUQKZgeJijSirSC5SgXxjzJ+QD/s4ChLgK4G7HN3Y4hFgkSjAIqUJBqRKx6TLcz5JDTitKLZa95N9LKNYiuoRCiKFQgkHIf6QVKBCbJsPjPJqt2ZjwOMDfmY8IDyFcbGhUgxB9UYJBCAClkiExR5VY5JTQcEVj18SOh+YeQng78mkFCiF1RAkGadSkcob4DBlup8upTDepxEHCobmnEEEuAvB4lGgQogtKMEijVFSuREyqDPdofgWpBRsRhwgPIULdBRBQokFIrVCCQRqVMhnDjRQp4jPkUNIrn+hIIgCaeQgR3kRIpckJqQElGKRRkCkYYlJliE2T0YgF0ZuVkEOktxAhbgLwaI4GIVpRgkEsmkLJEJ8hx80UKcrkxo6GWBpHKw5tfUXwcRQYOxRCTA4lGMQiMcZwP1uO649lKJLSS5zULw97Htr5imh5KyFPoASDWJzHeXJceSSlUt6kwQW58NHGRwQb2vOEEEowiOUoKFPifGI5UgtokgUxHj4HhHsI0dJTCJGA5meQxosSDGL2lEqGmDQZbiTLoKBXMzERYgHQ3leEYDehsUMhxCgowSBmLaNQgXOJ5XQ5hJgsLwc+OgeIaKt40uhQgkHMklTOcOWxqp4FIaZOwAPa+IgQ3kRApcdJo0EJBjE7D3PkuPBQilIq7U3MjJstD10DxXCwotEMYvkowSBmo6hciQsPpbTLKTFrPA6I9BaiuaeQinQRi0YJBjELCZkyXHgopSqcxGI4W/PQJZBqZxDLRQkGMWkyBcO5xHI8yKZRC2J5OA5o4SlEpDeNZhDLQwkGMVnZxQqcSChHYTm9RIlla2LHQ49gMaxFNDeDWA5KMIjJYYwhLk2OK4+ltOMpaTQkAqB7sAReDnTJhFgGSjCISSmTMZy+X47kfLokQhofDkBLL9UlE1rOSswdJRjEZKQVKHDyXjktPyWNnoc9Dz2CJbASUpJBzBclGMTolIzherIMt1JkoBcjISpWQg49gsXwsKdLJsQ8UYJBjEoqZzieUEYblBGiBQdVzYyWXnTJhJgfSjCI0RSUKnHkbhkKyuglSEh1vB346BkihpBPSQYxH5RgEKNIyVfgREIZpDSXk5BacbLmoU8YLWUl5oMSDNLgUvMVOHSnjOZbEKIjaxGHPmESOFlTkkFMH71KSYNrYseDux299AjRVYmUYV9cKVJoGTcxA/QuTxocj8chOlQCewldTyZEVzIFcCS+DAmZMmOHQki1KMEgRiEWcOgdJoFYYOxICDE/SgaceSDFtcdSY4dCSJUowSBGYy/hITpEAh4NZBBSJzdSZDh9vxxKqqlPTBAlGMSomtjz0SVAZOwwCDFb97LkOBRfBqmCkgxiWijBIEYX7CZES0+hscMgxGylFShx+E4ZZJRkEBNCCQYxCa19hPB3ppLIhNRVZpEShyjJICaEEgyiv9J8oDBDry44jkO3IDFcbeglSUhdUZJBTAm9mxP95KcCp1cCFzcCZUV6dSXgcegVJoGNiGZ9ElJXmUV0uYSYBkowSN2lxwNn1wDlRapRjMubAIV+a/OthKrlq0J6ZRJSZxlFShyOpySDGBe9jZO6eXgZuLxZM6HISwGu7QT0rD7vZM1DzxAxaByDkLrLKFTiCCUZxIgowSC6u3cGuLVXeyKRFgfcOar3Q3g7CtDej5avEqKP9H+SDDklGcQIKMEguok/Dtw+XP0x904Dj67r/VDNPIRo6k6lPgnRR3qh6nIJJRmkoVGCQWov7hBw90Ttjr21B8h+qPdDdvAXwduBlq8Soo/0QiVO3isHbZ5NGhIlGKRmjAE39wL3z9a+jVIBXN4CFGfr9dA8jkPPEDEcrWhGBiH6eJSnwKUk2ruENBxKMEj1mBK4vgtIuqx7W1mpavmqtFSvEIR81coSiZCSDEL0EZcux+102oWVNAxKMEjVlArg6jYg+Ubd+yjOUY1kKBV6hWIr5qF3qBh8esUSopeLD6V4nCc3dhikEaC3a6IdUwJXtwOpcfr3lfMQuLlH725cbfnoFiTWPx5CGjEG4ERCObKL9Uv6CakJJRhEu5t7VEtODeXxdSDhtN7dBDgL0MaHNkYjRB9yJXAkvhzFUqWxQyEWjBIMUlncIeDRNcP3e+eIQUZEWnqJEOxKy1cJ0UepjOHInXIqxEXqDSUYRFPCKd1Wi+jq2g5VxU89dQ4QoYkdvXwJ0UduqRLHE8qhpOWrpB7QOzT518PLBqnCWS2lHLi0SbV3iR74PA7RoRLYiWllCSH6SMlX4OJDWr5KDI8SDKKSEgPc+rthHqu8SLV8VV6uVzdiAYc+YRKIqA4XIXq5kyFHYjatLCGGRQkGATISVJcu0IDDpIUZwJVtqtUqerC34iE6VAIeDWQQopezieUoLKNJn8RwKMFo7ArSgCt/6v2Hvk4yE4DYg3p342HPR+cA2hiNEH3IFKrlqwolzccghkEJRmNWXgxc+s+W6w0t8QKQeFHvbkLchGjuSctXCdFHdokSlx/RfAxiGJRgNFYVe4XoOdnSIGL3qy7T6KmtjxB+TjQhgxB93E6XIymH5mMQ/VGC0Vjd3AvkPjJ2FCqMqUqSF2bo1Q3HcegeLIaLDb2sCdHHmQflKCqn+RhEP/RO3Bg9OA88vmbsKDTJy1UrS8qL9OpGwOPQO1QMaxHN+iSkrqT/zMdQ0nwMogdKMBqbzHtAnP4TK+tFaf4/c0L0G561EvHQJ0wCIb26TcLhrb9izvhOmNLLE1N6eWLepN64fuaAxjEpD27ju3fH4LXeXpjSywPzXu6F7LSqR9iO7ViF+a/2w9S+Ppja1wdfvT4U92IuaRxzZt8mvDWsKab188XGxXM07stMeYhZz7RGaVGB4U7UwmQVK3HlMc3HIHXHMUYl3BqNoizg9Eq960/UO88IoM3TAKffKMTjPDmOxpc35OJbosXVk3vB4/HRxDcIAHBqzzrs/eMHzPv9NHyCIpD++D4+eykaUcMnoHP/0bCytUfKgzsIimgLe2d3rX0u/eRlhLbqjJBWnSEUibH39+9x+dguzN9wEc7uXijMy8Jbw8Mx+eOlcPMOxLdvj8IrHy1F6+4DAQDfvPkUokdMRPteIxrqaTBbvcPE8HGk0vxEd5RgNBZyKXBqBVCcbexIaiekO9C0l97dxKXJcDGJPoWZmmn9fDH2jS8QNfxF/DLnRfAFQkz5bEWd+1MqFJja1wcvvLcI3Qc/h3sxl/DDu2Ow+O/7AICf50xAYHhbDH7hTZzdvxnnD27Fm99sMtTpWDQrIYcRLa0gEtBlR6IbGkRuLGL2mU9yAaj2RHl8Xe9umnkI0dSdPn2ZCqVCgXMHtqC8tBghLTpCqVTi+pn98PALwf9mjMDrAwPw2cvRuHz8L536LS8rgUIhg629EwDAwzcY5WWleHjnOoryc/Ag9gp8Q1ugKD8H25Z/gRfeW1Qfp2eRSmWMknRSJ5RgNAbJNw3yx7rB3dwD5CTp3U0HfxG8HGj5qjE9SriFV6ObYFIPZ6z56k3M+GoDvIOaoSA3E2UlRdi99lu07NIP7y3ehXZRw/Dj+8/h9pWTte5/y8+fwMnNCxEdVKNeNvZOmDx3GZZ/NhmfvRyNboOfRcvOfbFx8Rz0Gz0FmSmJ+PiFrpj9bAdcPLy9vk7bYtzLkiM5j5auEt3QJRJLV5wDnPpVdYnEHAmtgG4vAzbOenUjVTDsiy1FXim93I1BLpMiO+0RSorycfHITpzYtRofLtkHaztHvDk0FJ37j8bUz1epj//u3TEQS6wx7YvVNfa95/fvsGftt/jgl7/hF9qiyuPiLp/Aph8/wodL92HWqFaY+vkqOLg0wWcvRePrP69VOd+DqNiIOAxvaQUhny6VkNqhEQxLplSo6kuYa3IBALJS1fJVWale3Yj4HHqHSSChqyVGIRCK0MQ3GIHN2mLM9M/gG9oSBzb9AjtHF/D5AngFhmsc7xXQFNnpj2vsd+8fP2D36m/w3uKd1SYXMmk51n79FiZ+sBjpj+5DoZAjvG0PePqHwcMvpNIKFFJZsZRRlU+iE0owLNntI0B+qrGj0F9xNnD5T1XCpAdbMQ+9wiSgD2AmgDHIZVIIhCIERrRD2sO7GnenJd2Fq4dvtV3s/f177Fr5Fd75fjsCm7Wt9tidK79Eq679ERDeGkypgFLx72tJIZdBqedrq7GIz5Ajs4ieK1I7lGBYqowE4ME5Y0dhONmJwK29enfjZstH1yCx/vGQWtvyy6e4c/U0MlMe4lHCLfy55FPEXTmJLgPGAgAGPT8T5w9txbEdq5D+6B4OblmKa6f+Rp9Rk9V9LPt0Mjb/PFf9/Z7fv8PWZfMw6aNf4Orlj7zsdORlp6OspHKhtsf3Y3Hh4DY8/epHAABP/zBwHIfju9bg2ql9SH0Yj8Bm7er5WbAc5x5IoaQr66QWaMDYEpUVAdd3GjsKw3t0DbBxAYK76tVNoIsAhWVKXEs24iZvjUhBTgaWfzYZeVlpsLK1h29IC7z7/Q606NQbANA+ejgmvv8Ddq9ZhD++fQ+efqF4Y+E6hLX+9+eck/4IPN6/n4eObP0VcpkUP334vMZjjXzlQzw1+d+iWowxrFo4A8+99SXEVjYAAJHECpM/WYa1/3sbcmk5nn93EZzdverzKbAouaVKxKbJ0MKTdjAm1aNJnpbo0iYgPd7YUdSfdqMBj/Caj6vBqXvluJ9NM+MJ0ZWABwxvaQVbMQ2Ck6rRq8PSpMZadnIBANd2GGRuSZdAEdzt6FeAEF3JlcDFhzThk1SP3l0tibRUVVDL0ilkqpUlpfrtI8HncYgOkcBOTLM+CdHVozwF0gtpwiepGiUYliTuAFBebOwoGkZ5EXBpo95LcCVC1fJVEdXhIkRnV2jZKqkGJRiWIvMe8PiGsaNoWAXpqjofek4jcrDiISpUAh4NZBCik8wiJZJyaB4T0Y4SDEsglwI39V/CaZYy7hpk+3lPez46+dOseEJ0deUxLVsl2lGCYQnuHAVK84wdhfE8OA88vKx3N6HuQjT3EBogIEIaj4IyhoRMGsUglVGCYe7ykoHEi8aOwvhi9qkuE+mpra8Qfk40IYMQXVxPlkGmoFEMookSDHPGGBCzHwD9YoMpgStbgcJMvbrhOA7dg8RwsaZfDUJqq1TGEJdGheuIJnoXNWcpt1QjGERFXq5avqrnShoBn0OvMDGsRTTrk5DaikmVoUxGH3bIvyjBMFcKmWozM6KpNA+4tBlQ6HdN2FrEQ+9QMQT0G0JIrciUwPVkWrZK/kVvn+bq/jmgTL9CUxYr7zFwY5fey1edbfjoESwGjWMQUjt3M+UoKlcaOwxiIijBMEdlhcC908aOwrSlxAB3j+vdja+TAO38aPkqIbWhZKC5GESNEgxzdOeo6hIJqd7dk0DyTb27ifAQIsydNh4mpDbuZsohldNcDEIJhvnJT218FTv1ceMvIOeR3t109BfB056WrxJSE7kSuJNBH4AIJRjmJ+4QaFmqDpQK4PJmoCRXr254HIeoEDEcrGhGBiE1uZ0uh0JJ71ONHSUY5iTrPpCdaOwozI+0BLiwAZCV6dWNSKDaGE1CV0sIqVapjOFBNlX3bOwowTAnd08aOwLzVZwNXP4TUOo3w91OzEOvUAn4NJBBSLViabJno0cJhrnIfgjkJBk7CvOW/QC4pf+mcG52fHQNEhsgIEIsV14pQ3IejWI0ZpRgmIu7J4wdgWV4dBW4d1bvbgJdBIj0po3RCKlODI1iNGqUYJiDnEc098KQbh8G0u7o3U2ktwiBLrSyhJCqpBUokV2sMHYYxEgowTAHCTT3wrAYcG27asmvnroGiuFmS79GhFSF5mI0XvTOaOryUgyyDTn5D4UMuLhJ73LrfB6HXqES2Ipp1ich2jzMUaCcCm81SpRgmDqae1F/ygtVSYZcvw2aJELV8lUhXS0hpBIlAxJpyWqjRAmGKStIBzLuGjsKy1aQprpcoufGaI5WPESFSMDRQAYhldzLogSjMaIEw5Q9uGDsCBqH9Ph/KqTqx8uBj07+tDEaIf+VVaxEfintstrYUIJhqqQlQMotY0fReDw4ByRd0bubMHchIjyo1Cch/0WjGI0PJRimKukKoKRfyAZ1629VOXY9tfMVwdeRJmQQ8qT72XIwPS9FEvNCCYYpUiqBh5eNHUXjw5SqcuKFmXp1w3EcugeL4WxNv16EVCiRMqQW0GWSxoTeAU1RRrzeyydJHcnLgUubgPJivboR8jn0DhPDSkizPgmpcD+LamI0JpRgmCIavTCuklzVFu8K/S5RWYt46B0mhoB+ywgBACTlKiBT0GWSxoLe+kxNcY5B5gEQPeU+Bm78pXc3LjZ8dA8Wg8YxCAHkSiAxh+aWNRaUYJgaA6xkIAaScguIP653N35OArT1peWrhADAA1pN0mhQgmFKmBJIvmHsKMiT7p4Akm/q3U1zTyFC3Wj5KiHpRUpIqXR4o0AJhinJeqD35EJSD278pdrRVk+dAkTwsKdfOdK4MQakFNAOq40BvduZkmQqrGWSlArVpM+SXL264XEcokMkcJDQjAzSuCXnUYLRGFCCYSoUciD9trGjIFWRlgAXNwKyMr26EQlUG6OJ6WoJacSS86joVmNACYapyIjXe1dPUs+KsoArW1WF0PRgJ+GhV6gEPBrIII1UmRzILqaiW5aOEgxTQZdHzEPWfSDmb727cbfjo2ug2AABEWKeHtNlEotHCYYpkJUBmQnGjoLUVtIV4P45vbsJchWglZfQAAERYn6S8ynBsHSUYJiC1DjVREJiPuIOqbZ511NrHxECnGljNNL4ZBcrUSqjeRiWjBIMU5ASY+wIiM4YcHUbkJ+md0/dgsRws6VfRdL4JOdR0S1LRu9qxiYrBXISjR0FqQuFTLUxWlmhXt3weRyiQyWwFdOsT9K40HJVy0YJhrFl3lNVniHmqaxAtXxVod8ukVZC1fJVIV0tIY1ISoGClqtaMEowjC3jnrEjIPoqSAOubtc7UXS04iEqRAyOBjJIIyFTAPmllGBYKkowjIkx1QgGMX/pd4Dbh/XuxstBgI7+tDEaaTwyi+kyiaWiBMOY8lMBKe09YjHunwWSrurdTVN3IZo1oVKfpHHIKqKCW5aKEgxjotoXlufWXtWmdXpq7yeCjyNNyCCWjxIMy0UJhjFlUIJhcZgSuPynqqy4HjiOQ49gMZys6VeUWLa8UiVkCpqHYYno3ctYpCVAXoqxoyD1QV6mWlkiLdGrGyGfQ+8wMayENOuTWC4G2pfEUlGCYSyZ96D61SIWqSQXuLRZ7wqtNiIeeoeJIaDfVGLBMotooqclorctY8lONHYEpL7lPgJu/KV3Ny42fHQPoo3RiOXKohEMi0QJhrHkPjZ2BKQhJN8E7p7Quxs/ZwHa+tLGaMQy0URPy0QJhjHISvWeBEjMSPxxg+w308JThBA3Wr5KLE+pjKGonJIMS0MJhjHkJhs7AtLQru8yyKhVZ38RPOzp15ZYHproaXnoncoY6PJI46OUqyZ9luTp1Q2PxyEqRAJ7Ca0sIZaloIwSDEtDCYYx5FGC0ShJi1XLV2XlenUjFnDoEyaBmK6WEAtSUEar6iwNJRgNjTEgjy6RNFpFmcDVraqCXHqwk/AQHSoBjwYyiIUopBEMi0MJRkMrzADkUmNHQYwp8x5wa5/e3TSx46NLIG2MRixDQTmNYFgaSjAaGs2/IACQdBl4cF7vboJdhWjpRctXifkrkzEqGW5hKMFoaPlUHpz8I/YgkB6vdzetvYXwd6aN0Yj5o4meloUSjIZWmGnsCIjJYMDV7UBBml69cByH7kFiuNrQrzMxb4U00dOi0DtSQ6MCW+RJCilwcRNQVqhXN3weh15hEtiIaNYnMV8FVGzLolCC0ZDKCgG5fksUiQUqKwAubQIUMr26sRJy6B0mgZCulhAzRSMYloUSjIZURJdHSBXyU4FrO1TLmPXgZM1Dz2AxaByDmCOag2FZKMFoSIV0eYRUI+02cOeI3t14OwrQwZ+WrxLzQ7UwLAslGA2JRjBITe6dAR5d07ub8CZChDehUp/EvJTJAabnKB4xHZRgNCSa4Elq4+YeICtR727a+4ng7UATMoh5KZcbOwJiKJRgNCRaokpqgymBK1uAomy9uuFxHHqGiOFkRb/mxHxI5TSCYSnonaehSEsAWamxoyDmQlam2hhNWqJXN0I+h95hYlgJadonMQ/lVM3TYlCC0VBKC4wdATE3JTnA5S2AUqFXNzZiHnqFisGn33ZiBsppBMNi0FtOQ9GzkBJppHKSgBu79e7G1ZaP7kFiAwRESP2iBMNyUILRUMopwSB1lHwDuHtS7278nQVo40MboxHTJqVJnhaDEoyGQiMYRB/xx4DUWL27aeklQrArLV8lpotGMCwHJRgNhRIMoq9rO4HcZL276RIgQhM7+tUnpokSDMtB7zINhRIMoi+lHLi8CSjJ06sbHo9DdKgEdmJaWUJMDyUYloMSjIZCczCIIZQXA5c2AjL9Ns0TCzj0aSqBiOpwERMj1W/RFDEhlGA0FBrBIIZSmAlc3aoqyKUHewkP0aES8Gggg5gQGdXBsBiUYDQEpULvgkmEaMi8B8Qc0LsbD3s+OgfQxmjEdNBWJJaDEoyGICszdgTEEj28CDy4oHc3IW5CtPCk5avENFB+YTkowWgICqmxIyCWKu4AkHFX727a+Ajh70QTMojxKSnDsBiUYDQEOSUYpJ4wBlzdBhSk69UNx3HoFiyGqw29JRDjou3aLQdV3GkICpmxIyCWTC4FLm0Cur4MSGzr3I2Ax6FXqBgH75TRltnEaMQCmnVsKThG6WL9y7wPXFhn7CiIpXP0AjpPAPg0n4IQYnw0HtoQaA4GaQh5Kapqn/SZgRBiAijBaAg0B4M0lLQ44M5RY0dBCCGUYDQImoNBGtK908Cj68aOghDSyFGC0RDoEglpaLf2ANkPjR0FIaQRowSjISipuD5pYEoFcHkLUJxt7EgIIY0UJRgNgaNlV8QIZKXAxY2AtNTYkRBCGiGqg9EQOMrjiJEU56g2Ruv0vF7dKOSqPEVWRotUSMOT2AJia2NHQXRFCUZDoASDGJODp95d8AWAlR0gsQGk5arBEWmZKumQPvF/PXeRt0i/bViIw6e2IfHRbYjFVoiM6Io3X/kKAb5Nq2136fpxLFr2Nu4lxsDNxQsTx8zC6GGvqe8/e/kgFv44HTm56YjuNhJz3/oVQqFq47rC4nyMn94By74+BE93v3o9v4bgGQK4Bxg7CqIrSjAagpklGAs3n8C2s7G4/TgLViIhujbzxVcT+6Opj6v6mPTcIry/+gAOXL2HvOIy9Gzujx+nDEGot0uV/crkCizccgJrDl9DcnYhmnq74KuX+mNgu1D1MeuOXscHaw6iuEyGSf3b4n8vD1Dfl5iei/4fr8Wl76fA3lpSPydvaawcgdCe+vUhlwP5+YCtLTixGGIrQGyl/VCmfCLx+O+/pY1zxfblG8cxdvh0NG/aAQqFHD+tmoOpH/THthWxsLKy0domOfUBXv9oMJ4eNBnz3/8D12JOY8GP0+Dk6Ia+PUZBqVRi9pfj8fLYD9Cl/QC8N+8ZbN37K8aNmA4A+OHX9zF66GsWkVwQ80UJRkMwszkYx28lYvqQTugQ6g25Qok5vx9C/4/XIHbJG7CRiMAYw8gv1kMo4GPnR8/B3lqMb3ecQd+PVquP0eaj3w/jj6PX8esbIxDu64r9VxLw1PwNOPO/yWgT7Ims/GK88uNOrH7zKQR5OGPIZ38gumUAhnRQfdKb+stf+HJiP0oudNFysP6VPQUC1XWRIweBnBzA1hawtVP9a2f37/9t7cCJRBBbVz2crVSqRj/Ky7SPglhiAvLLwn0a33/27ir0Hu2O2LuX0a6V9uRvy+6l8HTzw6xp3wMAgvybITb+EtZu+QZ9e4xCXn4WcvMyMWb4NIhFEkR1GY77D2MBAFdvnUZs/CV8+MbP9XpeDcnM3kLJPyjBaAhmNoKxb94Eje9XvfkU3Md/hcsJKejZIgB3U7Jx7s5j3Pr5dTT3dwcA/DJ1KNyf/wobjt/EKwPaae3396PXMWdMTwzuEAYAmDq4I/ZfScCi7afxx7vP4H5aLhysJRjbsyUAoFerQMQmZWJIh6ZYf+wGRAIBnu4aUY9nbmG8mgNuwYbpy9UVGDQUeJgIXL4APKpiCaxI/ETiUZGI/Pt/nlAIsQ0g1v7BHUqF9ksvFf9aQkmZouJ8AICDnXOVx9yIO4vO7fpr3Na1/QDs2PcbZHIZnBzd4ObsibOXDqBzu364cuskhvd7ETKZFAsWT8Wn76wEn29Bu+NSgmGWKMFoCGaWYPxXfnEZAMDZVjUuXi5TLbuViP59+fD5PIgEfJyKfVhlglEuk2u0AQArkRCnYpMAAKHeLigpl+HqvVT4uzvgYnwyXu7bBjmFJfhk3REcXfCSwc/NYgkkQET/mo/TlX8A4OsHxMUC16+qJmQ8SVoO5JQDOVUsjxVLqk9ABAJIbFRzPbRRyFXJhqwUKP9n0qlGAmLim7QxxrBo6dto06I7QgJbVHlcVk4aurZvonGbs1MTyBVy5OVnwc3FE19/vBn/W/IWvl4yE907DMaIgS9j5YaF6NimD8RiK7w4sxvyCrLw7Ig3MG7k6/V9avWKRjDMk3n/5TMXZvzbwRjD2yv2oXuEH1oEqN7wwn1c4e/uiA/XHERuUSmkMjm+3HICablFSM0prLKvAW1D8O2OM7ibnA2lUomDVxOw8/xtdRsnWyuseespTPh2Kzq+vRwTekdiQLtQvPvbfrwxtBMepOeizYxf0GLaT/jzVEyDnL/ZatYHENd9Z9Vq8XhA8xbAqDFARAvV97VVXgZkZwGJD4BbN4FzZ4BD+4EdW4E/VgMb1wG7dwLHjwCXLwJ34oDkx6o5IAqFarKpLWDvBrj5AV5hQEAkENYJaBGt+grrBAS0Ut3n6qs6VmIL8EzgA/3CH19H/IMb+HL2hhqP5f7zvlGxL2XF7W1adMf6ny9i7+8PMHvGz0hJe4Ddh37H9Imf46OvXsAzQ6dg1bcnsWzdPMTfv2H4k2lAhvqMlpGRgSlTpsDPzw9isRgeHh4YMGAAzp49qz7mzJkzGDx4MJycnCCRSNCyZUssWrQICsW/9YwSExPBcRyuXbtW6TFGjhyJiRMnqr+Pjo4Gx3HYuHGjxnHff/89AgIC1N+vXr0aHMeB4zjw+Xw4OTmhU6dOmDdvHvLz8zXaTpw4UX2sUChEkyZN0K9fP6xcuRJKpVLj2ICAAHz//ffq769evYqhQ4fC3d0dEokEAQEBGDt2LLKysjTabd26FdHR0XBwcICtrS1atWqFefPmIScnp6anWY1GMBqCGY9gvL50D24kpuPU15PUtwkFfGydPQ6TftgB53ELwefx0Ld1EAY9MVlTmx9eHYzJP+5E+NTF4MAh2NMJL/Vtg1WHrqqPeaprBJ564jLIsRsPcPNhOn56bQhCXv0BG957Bh5Oduj49jL0bOEPd8d6+iNqzpx8Ad829f84YjHQsTMQ3gy4dAFIMkDl0LJS1VdWpvb7ra21jnxU/J8v4MHKTrXiRRu57N8RD22jIPVZE+/Ln97A8XO7sHLRCTRx86n2WFdnD2TlpGnclpuXAQFfAAf7yhOpGWOY992reGfKIiiVStxOuIq+PZ6BlcQa7VpG4fKN4wgLamXQ82lIfAP9pRo1ahRkMhnWrFmDoKAgpKen4/Dhw+o/mtu3b8eYMWPw0ksv4ejRo3B0dMShQ4cwa9YsnDt3Dps3b66U+NWGRCLBRx99hFGjRkEorHpOlL29Pe7cuQPGGPLy8nDmzBksXLgQq1atwunTp+Hl5aU+duDAgVi1ahUUCgXS09Oxb98+zJw5E3/++Sd27doFgaDyk5aRkYG+ffti2LBh2L9/PxwdHfHgwQPs2rULJSUl6uPmzJmDr776Cm+99RYWLFgALy8v3L17F0uXLsXvv/+OmTNn1uq8TSrBmDhxItasWaP+3tnZGR06dMDXX3+NVq1UvxwKhQKLFy/GqlWrEB8fD4lEgi5duuCjjz5Ct27dNPorLS3Fl19+iY0bNyIxMRF2dnaIjo7GZ599hubNm6uP+/TTT7Fjxw6NbPTkyZMYNmwYXnjhBSxevLhOLyo1gbjubY3ojaV7sOv8bZz4chJ8XB007msX4oVrP05DfnEZpHIF3Bxs0OntZWgf6l1lf24ONtjx0XMok8qQXVAKLxc7fLD6IAKbOGo9vlwmx7Qlu/HHO6OQkJoDuUKJqJaBAIAwbxecv/MYwzqFG+x8LQLHU03srMPrNbbkPm6V3EWUfXs0EVW9GqgSewegdz8gLRW4eA7IrsfqoSUlqq+MjMr3cdw/CYj2yy+wsYFAyINACFjba+9eLq1iBcw//zKl9nbVYYzhy5/ewJHT27Him2Pw9gyssU2rZl1w4txfGredvXwAEWHtIRRU/gO1/e/f4Gjvguiuw1FQmKs6l38mrMgVMijMvJowzwB/qfLy8nDq1CkcO3YMUVFRAAB/f3907NgRAFBcXIzJkydj+PDhWL58ubrdK6+8giZNmmD48OHYvHkzxo4dq/NjP/vss/jrr7/w66+/Ytq0aVUex3EcPDw8AACenp5o1qwZhg0bhubNm2PWrFn4448/1MdWjMAAgLe3N9q2bYvOnTujT58+WL16NV555ZVK/Z85cwYFBQVYsWKFOgEJDAxE79691cdcuHABCxYswPfff6+RSAQEBKBfv37Iy8ur9Xmb3EfrgQMHIjU1FampqTh8+DAEAgGGDh0KQPWLOm7cOMybNw8zZsxAXFwcjh8/Dl9fX0RHR2PHjh3qfsrLy9G3b1+sXLkSn3/+OeLj47F3714oFAp06tQJ586dqzKGPXv2YMCAAZg5cyZ+/PFH/ZILABCa16oHxhheX7Ib287E4sj8lxDo4VTlsQ42Erg52OBucjYuJaRgRC3+4EtEQni72kOuUGLrmdgq23y+8RgGtQtF2xAvKJQMcsW/7+4yuRIKJVV8qiSoC2DnrnOzUmU5jhdcwmNpOtZl7cG+3FMoVJTU3PBJHp7A0JFA9yjVH/qGxhhQXAykpwH3ElRzRE6fAPbvBbZuAn5fBfy5Edi3Bzh1HLh2BUi4q0qMiosAxiAQAdYOgGMTVd0Fn3AgqA0Q3gVo1RuI6AGEdAD8WgAeIYCzN2DrrFo1U9VA5YIfp2PP4T+w8MP1sLG2Q1ZOGrJy0lBW/m+F1cW/fYiPvvp3cvXooa8hJeMhvln6Nu4/jMOOfSuxfd9vmDD63Ur95+Rm4Nf1X2DW9MUAAHs7JwT5NcO6bd/jeuxZXLh6GJERXQ36VDc0Q8xXtbW1ha2tLXbs2IHy8soFWw4cOIDs7Gy8+27l53jYsGEICwvDhg01X9rSxt7eHrNnz8a8efNQXFysU1t3d3eMHz8eu3bt0rhMo03v3r0RGRmJbdu2ab3fw8MDcrkc27dvV19y+69169bB1ta2ykTI0dGx1rGb1AgGoJmVeXh44P3330fPnj2RmZmJI0eOqId/hg0bpm6zfPlyZGdn45VXXkG/fv1gY2OD77//HmfPnsXVq1cRGRkJQJWtbt26FZ06dcKkSZNw69atSsnD+vXr8dJLL+F///sfZsyYYZiTMrMRjOlLdmP98ZvY+dGzsLMWIS1XNUfCwVoCK7Hq09OWU7fgZm8DP3cH3ExMx8zlf2Nk52bo3zZE3c+ERVvh7WKPhRP7AQDO33mE5OxCtA7yQHJWAT5dfxRKJcOsUd0rxRDzMAObTtzCtR9VL/JwH1fweBx+O3AZHk62uP04Cx2qGS1plKyd6lzz4kTBZZQqy9Tfx5beR3xZEtrbRKCDbXMIebVc6spxQEgoEBAI3Lqh+pKbyMxLxoCiItWXNjweYGP7z4jHEyMgFRNSrawhFHMQigEbh8rNGXtiBOSJUY8tfy0BALzybrTG8Z+9uwojBkwEAGRmpyI1I0l9n7dnIH76Yi++WfoWNu36GW4uXnh/2mL07TGq0uN+/ctMvPjMu2ji+u/vw2fvrcYnX7+IDdsX48XR76FleEfdnisTY4gRDIFAgNWrV2Py5MlYunQp2rZti6ioKIwbNw6tWrVCfHw8AKBZs2Za24eHh6uPqYtp06bhhx9+wLfffouPP/5Yp7bh4eEoLCxEdnY23N2r/wARHh6OGze0z7np3LkzZs+ejeeeew6vvfYaOnbsiN69e2PChAlo0kQ1x+7u3bsICgqq9lJObZlcgvGkoqIirFu3DiEhIXBxccH69esRFhamkVxUeOedd7Bt2zYcPHgQI0eOxPr169GvXz91clGBx+Phrbfewvjx43H9+nW0bt1afd/PP/+Mt99+G7/99huef16/0soazGwEY8neiwCA6A9Xady+6s2nMLGv6tp+ak4R3l6xD+l5xfB0ssWE3q3x8bgojeOTMvPB4/2bwJVJ5fjo98O4n5YLWysRBrcLxe/vjIKjrWbVJsYYXv1pJ76bPEhdU8NKLMTqN5/C9CW7US5T4KfXhsDbtYpx7saq5eA6Xax+XJ6OmJKESrfLmRznim7gZslddLNvjeZWIbUfzRMIgNZtgbBw4Ool1UiBqdcYVyqBwgLVlzY8fuXko+L/drbgrKwhFEOVgDj+26zikyJjqkqn2pbgfvXJatWCnCeeovaRUdi45EqNYX85p/Kn6pbhHbF9ZZwOJ2/atFwVqpNRo0ZhyJAhOHnyJM6ePYt9+/bh66+/xooVK9THVPXJnjGm12i2WCzGvHnz8Prrr2Pq1Kk6tf3vBN+ajq3uuPnz5+Ptt9/GkSNHcO7cOSxduhQLFizAiRMn0LJlS73P80kml2Ds3r0btraqiXvFxcXw9PTE7t27wePxEB8fX2V2WXF7RYYZHx+PXr161XhsRYIRFxeH119/3fDJBQAIqyh7aKLY7nk1HjNjeGfMGN652mOOffmyxvdRLQMRu+SNGvvmOA6n/ze50u1DOzbF0I7Vl1dutLxaAK5BOjdTMAUO5Vd9uRAAipWlOJB3FleLbiPKoT38xDqUHre2Brr1BJo1By6eB1JTdI7RZCgVQEG+6ksbPv8/SYfmXBBOIoFIAogkALRcdWTKJxIQLVVQG3MZdn1rxT1JIpGgX79+6NevHz755BO88sormDt3rnqlRVxcHLp2rXxJ6fbt24iIUE1Ad3BQDWH9d3UHoJrr4e/vr/Wxn3/+eXzzzTf44osvNFaQ1CQuLg729vZwcal5blRcXBwCA6uf5+Pi4oLRo0dj9OjRWLhwIdq0aYNvvvkGa9asQVhYGE6dOgWZTKb3KIbJJRi9evXCkiWqIcWcnBz88ssvGDRoEC5cuFCr9rXN8P57rI+PDxwdHfH1119j0KBB8PTUf/8GNYFINcanNJGhYmJZhFZ1rnlxoegWcuRV/MH8j0x5Lv7MPoggsQ96OrSDs0DLdYKqOLsAAwarCnRdvFD1H2lzplAA+XmqL20EQs0RkP8mIGIxRFaAqKYy7FUUIpNbaALC4+m2ElpXERER2LFjB/r37w9nZ2csWrSoUoKxa9cu3L17F59//jkAwMnJCW5ubrh48aJ6wiigWlgQExODMWPGVHEuPCxcuBBPP/10rUcxMjIysH79eowcORK8Gp6II0eO4ObNm3jrrbdq1TcAiEQiBAcHq+eGPPfcc1i8eDF++eUXratF8vLyaj0Pw+QSDBsbG4SE/Hsdv127dnBwcMCvv/6KsLAwxMbGam0XF6caDgwNVS2VrO7Y27dvaxwLAHZ2djh06BD69++P6OhoHD16VGNJkN5E1kBZFUOvhOgjvE/VpTGrkSsvwIXCmzq3u1/+GIkZyWhlE4YudpGw4ulwCdDXH/D2VdW3uHYF0DLZzmLJZUBerupLG6HIIGXYq1oBY65l2A01epGdnY3Ro0fj5ZdfRqtWrWBnZ4dLly7h66+/xogRI2BjY4Nly5Zh3LhxePXVV/H666/D3t4ehw8fxnvvvYdnnnlGI3F49913sWDBAjRp0gRdu3ZFbm4uvvrqKwgEgmpHwYcMGYJOnTph2bJl6nkPFRhjSEtLUy9TPXv2LBYsWAAHBwd8+eWXGseWl5cjLS1NY5nqwoULMXToUEyYoFmNucLu3buxceNGjBs3DmFhYWCM4a+//sLevXuxapXqkninTp0wa9YsvPPOO0hOTsZTTz0FLy8vJCQkYOnSpejevbt5LlPVhuM48Hg8lJaWYty4cXjuuefw119/VZqHsWjRIri4uKBfP9WEwnHjxmHOnDm4fv26xjwMpVKJ7777DhEREZXmZzg5OeHQoUMYMGCAOsnw9jbQREKxDSUYxPCc/QDf1nVqeijvHBSow7pLAEowXCu+g7iSB+hk1xJtbMLB52o51Z/HU10yCQoBblwD4mJUfx0bO5kUyM1RfWljyDLsWkZBTLUMu6ESDFtbW3Tq1Anfffcd7t27B5lMBl9fX0yePBmzZ88GADzzzDM4evQoFixYgJ49e6K0tBQhISGYM2cO3nzzTY1R73fffRe2trb45ptvcO/ePTg6OqJz5844efIk7O2rnx/21Vdfab0MU1BQAE9PT3AcB3t7ezRt2hQvvvgiZs6cWanPffv2wdPTEwKBAE5OToiMjMTixYvx4osvVjnSERERAWtra7zzzjt49OgRxGIxQkNDsWLFCrzwwgsa8bVr1w4///wzli5dCqVSieDgYDzzzDN48cUXa/2cc6yqGS1GMHHiRKSnp6szqdzcXPz0009YsmQJjhw5gqioKIwaNQrHjh3D//73P/Tp0wcFBQX4+eefsXLlSmzZsgUjR44EAJSVlSE6OhopKSlYtGgROnXqhPT0dCxYsAAHDx7EoUOH0Lmzag7Bf+tgFBQUYODAgcjMzMTRo0fh41N9UZxaubAeyLynfz+EVODxge6TATs3nZvGlNzD/rzTBgvFgW+LHvbtEGal/dpztQoLgEsXgYcPDBZPo1RDGXZoKbz0JIXinxGQqhIQI13htXNRLRUm5sfkRjAqsjJAddkiPDwcW7ZsQXR0NABg8+bN+OGHH/Ddd99h+vTpEIvF6NKlC44ePYru3f9d7iiRSHDkyBEsXLgQs2fPxsOHD2FnZ4devXrh3LlzaNGi6n0A7O3tsX//fgwaNEg9kuHr66vfiUmqKC1ISF0Fda1TclGqKMPxgksGDSVfUYTducfhXeyOKPv28BC51r6xnT3Qq4+qfsXF81VX8STVKy/7txS7NhIrrZde1FVQ+XzwbVVl1bVRyKvehE5aVn9TzETmtQiPPMGkRjAs2t2TQPwxY0dBLIWNM9BjSp2Wpe7LPY3Y0vodTQu3CkQP+7aw4+s4N4Qx4P494MpFVdEs0nBqKMNe00zLijLs/92ATt8y7B7BQJOai58SE2RyIxgWy7rqapiE6KxF3WpeJJWn1XtyAQC3Sx8goSwJbW0i0NG2BUS6FOoKDlHt2hp7C7h5HZCZ6OQAS2OgMuyorgx7FStgZKVVT8OhEQzzRSMYDSX3MXBmVc3HEVIT71ZA6xE6N5MzBX7P+Au5ioadbGzNk6CrXWu0sA4BT9eN/0pLgKuXgbvxpl+oqzHjOMDGRnsCYmcHWNvUuD+OrLxy0iEtU41gVLV3DDFtlGA0lPJi4NC3xo6CmDuhFRA9TbXsWUdnCq7hXJHxtu12FTgiyr49/CV1WP6dm6Oan5GSbPjASP2rqgx7RQJiZV2nDfqIaaMEoyHt+9J014IR89BqOOAbWfNx/5Ejy8fvmX/VeVmqIQWIvRFl3w4uQkfdGz9+BFw6D+iwoyMxAzw+YGvzROLxT/Lh6Kgq0kbMEiUYDenEUqCQZsiTOnL2B7poL6BTHcYYNmcfQLI0vR6CqhsOHFpah6KrXWtY83W8yK5UAvG3VYW6yspqPp6YLy9voP8gY0dB6sjktmu3aDTRk9QVj6/azKwOYkoTTCq5AAAGhhsl8ViZsR0XCm9BznRYYsDjAeERwNNjgBatVM8NsUz2OpSjJyaHEoyGRAkGqavgboCtDrUl/lGiKMOJ/Mv1EJBhSJkMpwqvYHXGTtwp1bHQlkgEtO8IPPUMEKD7Rm/EDNjR7E5zRglGQ7J2NnYExBzZuAAh3Ws+TovjBZdQxkx/E4oCRRH25J7Ehsy/kSLV8TKinR0Q3RsYPAxwc6+fAIlx1FBym5g2SjAakn2Tmo8h5L9aDqnTZYCk8lTEld6vh4DqT6osExuz/saenBPIlxfp1ti9CTBkOBDVSzVB0EiSc3Px/LIVcHn9TVhPmY7Wn3yGy4kPqzw+NS8Pzy39FU0//Ai8l1/Fm+s3VjrmYEwswj6YA4dpM/Diryshlf9bNjO/pARhH8xBUnZ2vZyPUVGCYdYowWhI9k0A0FIsogOfSMBF9/095EyBQ3nn6iGghnGnLBGrM3bgRMFllCt1HIEJDAaeGg206wAIDbRTVi3lFhej2/yvIBTw8ffbMxE7/zMsGjcGjtZV7MEOoFwuh5udHeYMHYxI38r7HimVSoxftgKv9YrCmTnv48KDB/j1+En1/e9v2YrXekXBz8XCVltwHF0iMXNUybMhCUSqEs/FFvhJgxieyBpo1q9OTc8X3kCeotDAATUsBZS4VBSDmJJ76GoXiZbWobUv1MXnAy0jgdAw4OoV1aqTBlgw99XeffB1dsKqSS+pbwtwrX7uTICrK34YPw4AsPJk5Q3osoqKkFlYiGm9e0EiFGJ460jEpqQAAE7fTcClxIf4+YXxBjwLE1GL8uTEtNFPr6E5eBg7AmIumvUFRFV/8q1KtiwPl4pi6iEg4yhVluFw/nn8nvkX7pc91q2xxAro0g0Y8TTgbYBdkWuw69p1tA8MwOifl8J9xttoM3cefj1+Qq8+3ezs4OnogAO3YlAqleJkfAJa+fhAKpdj6to/sHTC8+Bb4h9iWkFi9izwVWni7CnBILXgEqi6PKIjxhgO5Z8ziYJahpYtz8eOnCPYmn0QWbJc3Ro7OgH9Bqq+nOpvNdf9jEwsOXIMoU3csf+dN/FadBRmrNuItafP1LlPjuOweeoUfL5rNyLmfII2/r54uUc3fLnnb/SJaAYrkRDd5n+Jph9+hJ8OHTHg2RgZTdg1e3SJpKFRgkFqwhMALetWXOhmyV0kS7VsVmVBHpan4vfM3WhhHYKudq1hw9dhlMfbB/D0AhLigSuXgbJSg8amZAztAwKw4JmnAQBt/P0Qk5KCJUePY0K3rnXut3tYKC7O/Uj9fXxaGn4/cw5XP/sYPRf+D2/274OBLVugxUefomfTMLTSMpfD7LhTgmHuaASjodElElKTkO6qpak6KlGU4mTBlXoIyPQwMNwsuYtVGTtwvvCG7oW6wsKBUaOBVpGq+RoG4unogAgvT43bmnl6Iik7x2CPwRjDq6t/x6Jxo6FkDFeTkvBM+3Zwt7dHVNMwHL9zx2CPZTQcRyMYFoASjIYmsgYkNDOaVMHWFQiu2yfdYwWXUG4GNS8MScpkOF14DasydiCu5D502vlAKALadlCtOAkKNkg83UJCcCctTeO2+PR0+BtwhcdvJ07BxdYWw9u0huKfPc5lCoX6X4XSAnZ/cHRU/XyIWaMEwxhoFINUpY41LxLLUnBb10qYFqRQUYy/805hfdZeJJfrWBbd1hbo2QsYOkJVS0MPb/Xvi3P3H2DB7j1ISM/A+rPnsfzYCUzvE60+5sMt2zDh19802l1LSsK1pCQUlZcjs7AQ15KSEJucUqn/jIICfPHXHiz+Z9WJk40Nmnl54vsDh3A24R4Ox8Wha4hhkiWjcqOaQZaANjszhvvngLiDxo6CmBrfNkCroTo3kzE51mbsQr5Cx8JUFixU4oce9u3gKLDTvXHiA+DyBaCwbst8d1+7jg//3I676ekIdHPF2wP6YXJUT/X9E1esRGJWNo598J76Nu6lyZX68XdxQeI3X2rc9uzS5egWEoLX+/ZW33bh/gO8uGIlMgoKMbNfH3wyYlid4jYp3aOAkFBjR0H0RAmGMeSnAqdWGDsKYkpENkD0VECo+7LUkwVXcLHoVj0EZd744KG1TTg62bWChKfjcLtCAcTFADeuAdLGddnJJDw9mpapWgC6RGIM9h6AUMctqolli+hXp+QiS5aLy0Wx9RCQ+VNAicvFsViZsR1Xi+KgZDos3eXzVTu1Pj1GtXMrRxV4G4xEQsmFhaAEwxg4DnDWvfwzsVCuQYB3S52bMcZwKO8clBZY88KQypTlOFpwEWsyd+Fe2SPdGkskQOeuwMhRgK9f/QRINNHqEYtBCYaxuAQYOwJiCngCoOXgOjW9URKPFJmOO482YrnyAuzMOYotWQeQIdNx2aiDI9CnPzBgMOBsYXt+mBo9J9oS00EJhrHUYQMrYoFCewDWuleWLFaU4lTB1XoIyPI9kqZhXeYe7M89jSJFiW6NPb2AYSOBbj0AK+t6ia/RowTDYlAlT2Oxc1fVxJDq+AZHLIedGxDUpU5Nj+VfbHQ1LwyJgSGm9B7iyx6ivW1ztLdpDiGvlm+HHAeENgUCgoBbN4CYm8AT26cTPfB4gEv1m8MR80EjGMbCcYAzXdNt1FrUrebFg7Jk3ClLNHw8jZCMyXG28DpWZexATMk9HQt1CYE27VSFuoJpSaVBOLsAAvrcaykowTAml0BjR0CMxa8t4OyrczOZUo7D+efrIaDGrUhZgv15p7E+ay8elafV3OBJNjZAjyhg6EigCRXR0wtdHrEolGAYk3uIsSMgxiC2BcL71Knp2aLrKKCCWvUmXZaNLdkHsDPnKHLlBbo1dnUFBg0FevUF7Gk7gDqhBMOi0FiUMVk7qmpiFOj4iYmYt4h+daqDkinLxRWqedEg7pU9woOyZETaNEVnu1aw4olr39g/QLWkNS4WuH4VkJbXW5wWhccDvLyNHQUxIBrBMDaPcGNHQBqSWzDg1ULnZqqaF2ehBBXebShKKHG1OA4r07fjclEsFLoU6uLxgOYtgFFjgIgWqu9J9Ty8ABFtcGZJ6FVvbJRgNB58IdCibjUvrpfcQaosy8ABkdooZ1IcL7iENRk7cbc0SbfGYjHQsbOqUJcfLU2vFj0/FocSDGOzcwNsnI0dBWkIoT1Ul8V0VKQooZoXJiBPUYi/co9hc9Z+pEuzdWts7wD07gcMHAIYcOt2i0IJhsWhBMMU0CiG5bNzBwLrVvPiaP5FSJnMwAGRunosTce6rD3Yl3sKhboW6vLwVK026R4FWFOhLjVXN3o+LBAlGKagCSUYlo0DWg6p03X4+2WPcbfsYT3ERPQVW3ofqzJ24HTBNciUOiSAHKfaivzpMUDrtlT3AQD8AowdAakHlGCYAkcvQGJn7ChIffFrCzj56NxMppThCNW8MGlyJsf5ohtYmbEDN4vv6laoSyBQJRhPjwFCwxr3jq16XB4ZNmwY+vbtq/W+s2fPguM4XLlyBRzH4dq1awCAxMREcByn/rKzs0Pz5s0xffp03L17V6OP1atXaxxb8SWRaK4Ee/ToESZNmgQvLy+IRCL4+/tj5syZyM7WvJwWHR2t7kMsFsPb2xvDhg3Dtm3bKsXPcRx27Nih/v7o0aPo1asXnJ2dYW1tjdDQULz44ouQP1FJljGG5cuXo1OnTrC1tYWjoyPat2+P77//HiUlDVs5mhIMU8BxNIphqcS2QHjvOjU9U3gdBYpiAwdE6kOxshQH88/ij8zdSCpP1a2xtTXQradqjxNPr3qJz6Q5OgGOjnVuPmnSJBw5cgQPH1Ye6Vu5ciVat24NZ2ft89wOHTqE1NRUXL9+HQsWLEBcXBwiIyNx+PBhjePs7e2Rmpqq8fXk492/fx/t27dHfHw8NmzYgISEBCxduhSHDx9Gly5dkJOjubne5MmTkZqaioSEBGzduhUREREYN24cXn311SrPMyYmBoMGDUKHDh1w4sQJ3Lx5Ez/++COEQiGUyn9XOL3wwgt48803MWLECBw9ehTXrl3Dxx9/jJ07d+LAgQO1ek4NhcbmTIV3S+DhRWNHQQyt+YA61bzIkOXganFcPQRE6lOmPBd/Zh9EkNgHPe3bwVnoUPvGzi6q3VofPQQuXgAK8usvUFMSFKxX86FDh8Ld3R2rV6/G3Llz1beXlJRg06ZNWLBgQZVtXVxc4OGhqr4aFBSEYcOGoU+fPpg0aRLu3bsHPl9Vyp/jOPVx2kyfPh0ikQgHDhyAlZUVAMDPzw9t2rRBcHAw5syZgyVLlqiPt7a2Vvfn6+uLzp07Izw8HC+//DLGjBmjdUTm4MGD8PT0xNdff62+LTg4GAMHDlR/v3nzZqxbtw47duzAiBEj1LcHBARg+PDhKCjQsXicnmgEw1Q4eQO2bsaOghiSeyjgGaFzM8YYDlLNC7N2v/wx1mbuwuG88yhVlunW2Ndftay1UxfVMldLFxikV3OBQIAJEyZg9erVGpeotmzZAqlUivHjx9e6Lx6Ph5kzZ+Lhw4e4fPlyrdrk5ORg//79mDZtmjq5qODh4YHx48dj06ZNNV4+e/HFF+Hk5KT1UklFX6mpqThx4kSVfaxbtw5NmzbVSC4qcBwHBwcdEl4DoATDlPhGGjsCYih8IdB8YM3HaXGt+DbSZTougyQmRwmG6yV3sDJ9By4VxUDBFLVvzOMBzZqr5mc0b2m5hbpc3QA7/cuqv/zyy0hMTMSxY8fUt61cuRJPP/00nJycdOorPFx1uToxMVF9W35+PmxtbTW++vfvDwC4e1c196ZZs2Za+2vWrBlyc3ORmZlZ7ePyeDyEhYVpPO6TRo8ejWeffRZRUVHw9PTEU089hZ9++kljVOLu3bto2rSpDmdbvyz0VWumvFsBHP1ILEJoVJ1qXhQqSnC68JrBwyHGU86kOFFwGaszdiK+NFG3xmIx0KET8NQzgL8Fbo6o5+WRCuHh4ejatStWrlwJALh37x5OnjyJl19+Wee+KkYauCcm3drZ2eHatWsaX6tWrapzf9UdW9VxfD4fq1atwuPHj/H111/Dy8sL8+fPR/PmzZGamlpje2Ogv2amRGyjGlYn5s2+CRDYqU5Nj+ZfoJoXFipfUYTduSewMetvpEp1rMpqZw/06qPaTM3VQi6lchwQoN/lkSdNmjQJW7duRUFBAVatWgV/f3/06aP7poJxcaq5T4GB/yZ0PB4PISEhGl/e3qp9U0JCQsBxHGJjte8TdPv2bTg5OcHV1bXax1UoFLh7967G42rj7e2NF154AT///DNiY2NRVlaGpUuXAgDCwsLU8ZsCSjBMjW9rY0dA9MIBLYfWaUj7XtkjJJTpWIqamJ0UaSY2ZO3F3tyTKJDruDNuEw9gyHCgR7Rqm3hz5uFp0OJaY8aMAZ/Px/r167FmzRq89NJLOn+aVyqVWLx4MQIDA9GmTZtatXFxcUG/fv3wyy+/oLS0VOO+tLQ0rFu3DmPHjq0xljVr1iA3NxejRo2qdbxOTk7w9PREcbFqtdlzzz2H+Ph47Ny5s9KxjDHk5zfsxGFaRWJq3ENUSxvLaUtus+TfXlXXREdSqnnR6NwufYC7pUloZ9sMHW1bQsQT1q4hxwHBIapdW2NvATevAzIzHPUKNuxora2tLcaOHYvZs2cjPz8fEydOrLFNdnY20tLSUFJSglu3buH777/HhQsXsGfPHvUKEkD1xzktrfKu1+7u7uDxePjpp5/QtWtXDBgwAF988QUCAwMRExOD9957D97e3pg/f75Gu5KSEqSlpUEulyM5ORnbtm3Dd999h6lTp6JXr15aY122bBmuXbuGp556CsHBwSgrK8PatWsRExODH3/8EYAqydq+fTueffZZfPzxx+jXrx/c3Nxw8+ZNfPfdd3jjjTcwcuTI2j+peqIEw9RwPNWS1ftnjR0J0ZXEDgjX/uZQkzOF13QvO03MngIKXCi6hVslCehq1xotrEPAq+08LIEAaNVaVaTr6mXgbjygS6EvY7Ky0nv1iDaTJk3Cb7/9hv79+8PPz6/G4yuWg1pbW8Pf3x+9evXC8uXLERISonFcQUEBPD09K7VPTU2Fh4cHQkNDcenSJXz66acYO3YssrOz4eHhgZEjR2Lu3LmV6nD8+uuv+PXXXyESieDi4oJ27dph06ZNeOqpp6qMtWPHjjh16hRee+01pKSkwNbWFs2bN8eOHTsQFRUFQDXPY/369Vi+fDlWrlyJL774AgKBAKGhoZgwYQIGDBhQ43NiSBzTqfQcaRDF2cCxX4wdBdFV22cAT+0zyauTLs3G+qy9YLQstdFzETgiyr49AiR1KLiVmwNcPA+kJBs+MENr0w6IrN0lCGK+aA6GKbJxocme5qZJWJ2SCyVT4mD+WUouCAAgW56HbTmHsC37ELJlebo1dnIG+g8C+g7QqzJmvePzgaZUubgxoATDVAXVbedNYgR8kV41LzJkOTUfSBqVxPIUrM38C4fyzqFEUVpzgyf5+ALDnwY6dwUkuleRrXdBIYDEqubjiNmjBMNUufgDDpWv+RETFBYFWOleIa9QUUw1L0iVGBhulMRjZcYOXCi8CbmuhbrCI1SFulq0Anj8mts0lIgWxo6ANBBKMExZUGdjR0BqYu8BBHasU9Mj+echY/KaDySNmpTJcKrwKlZn7MTt0ge6NRaJgPYdVYW6DFhzos68vAEdK2sS80UJhinziKjTJ2PSQDgOaDW0TtVX75Ym4V7Z43oIiliqAkUR9uaexIbMvUiRVl92uhI7OyC6NzB4GODmXj8B1gaNXjQqlGCYMh4PCKjbp2PSAPw71OkyllQpw9H8C/UQEGkMUmVZ2Jj1N3bnHEe+roW63JuoCnVF9QJsbesnwKo4OADePg37mMSoKMEwdX5tAEEj2FHR3EjsgaZ1q3lxqvAqipRU84LoJ77sIVZn7MCJgssoV0p1axwYDDw1GmjXARDWssCXviJaqEb9SKNBCYapE4gBv7bGjoL8V/OBgECkc7M0aRauF9+ph4BIY6SAEpeKYrAyYweuFd+Gkilr35jPB1pGAqPGAE2b1e8ff7HY4JU7iemjBMMcBHZWbf9NTEOTpoCH7lsiK5kSh/LPUc0LYnClyjIcyb+A3zP/wn1d5/ZIrIAu3YART9ffJYym4arKo6RRoQTDHEhsgYAOxo6CAKpRizrWvLhSHEc1L0i9ypbnY0fOEWzNPohMWa5ujR2dgH4DVV+GXOlRsWSWNDqUYJiL4K40F8MUhPUCrOx1blYgL8LZwuv1EBAhlT0sT8UfmbtxIO8MinUt1OXtAwx7Cuja3TAFsQICAWsz3/mV1AklGOZCaEXVPY3NwbPOI0mHqeYFaWAMDLdKErAyYzvOF97Q7fXH4wFh4cCo0UCrSNV8jbpq3rLubYlZowTDnAR2AkT0ScAoOA5oOaROE+HiSx/iQbkZbEBFLJKMyXG68BpWZ+xAbMl96LS/pVAEtO2gWnESFKz7gwcGAS6uurcjFoESDHMiEAEh3YwdReMU0KlONS/KlVKqeUFMQqGiBPvyTmF91l4kl6fr1tjWFujZCxg6QlVLozZ4PKBte90DJRaDEgxz49eOqns2NCsH1X4jdXCq4CqKlTpeAyekHqXLsrEpez925RxDnrxQt8aubqpqoNF9VNVBq9M0HLDTfb4SsRyUYJgbvgAI6WHsKBqXOta8SJVm4kZJfD0ERIj+EsqSsCZjJ47nX0KZroW6AgKBkc+o9jkRafndEAqByDaGCZSYLUowzJFvJGBL1zUbhEc40CRM52ZKpsTBPKp5QUybAkpcLo7FyoztuFIUp3uhrhatVDu2hkdozk9q0Yq2ZCfgmE4zfojJyLoPnF9n7Cgsm0AMRE0FJDUMBWtxsfAWThZeqYegCKk/TgJ79LRvh2CJr+6N8/OASxeArExV0tFQJciJyaIEw5xd2gykU9npetN8YJ2WpebLi7AmcxfktCyVmClfkQeiHNrDXeise+PSUsCKRi8IXSIxbxH9AR6V360Xjt6Af91mwB/OP0/JBTFrj6RpWJe5B/tzT6NIoePGfJRckH9QgmHOrB1VFT6JYXE8oOXgOtW8uFP6AIlU84JYAAaGmNJ7WJWxA2cLr0OmpKSZ6IYSDHMX3A2wrsMwJqlaYCfA3kPnZuVKKY7lX6qHgAgxHhmT42zhdazK2IGYkgTdCnWRRo0SDHPHFwAt6rb5FtHCyrHONS9OFlyhmhfEYhUpS7A/7wzWZe3Bo/I0Y4dDzAAlGJbALRjwpN0KDaLFIICv++z3FKp5QRqJDFkOtmQfwOG888YOhZg4SjAsRUR/QCAxdhTmzTMCcA/RuZmCKXEw72w9BESI6fIWuxs7BGLiKMGwFBI7oPkAY0dhvgRiIKJuz9/lohhky/MMGw8hJsxL5IZwq0Bjh0FMHCUYlsSnlaryJNFdeB9AYqtzszx5Ic4V3aiHgAgxXdH2uteHIY0PJRiWpuUQQExbuuvE0Qfwa1unpqqaFwoDB0SI6WppHQoPEW1VQGpGCYalEVmrkgxSO3rUvLhd8gAPy1PqIShCTJMNzwo97NsZOwxiJijBsERNmgI+kcaOwjwEdQbsm+jcrExZjmMFF+shIEJMV7RDe0h4uu8sTBonSjAsVcQAwMrB2FGYNmsnILRnnZqeLLiCEmWZgQMixHQFir3RlCZ2Eh1QgmGphGKg1XBjR2Ha6ljzIrk8HTdL7tZDQISYJiEnQB+HTsYOg5gZ2inLkrkGAEFdgPtUo6ESr+aqAmU6UjAlDuWfq4eATM/hH//Czb8vIyMhFUKJEP7tQzF09hi4h3iqj9nw5q+4tOWURju/NsGYufuTavs+8et+nFl7BLkp2bBxskPkkPYY/OFoCCWq4ffL285gz4ItkJaWo9O4nhj28Th125xHmVj27P/w1t+fQWJHG2s1hC52kbAX6L7KijRulGBYuqa9gbxkICfJ2JGYDqFEVZisDi4V3UK2PN/AAZmme+fuoOuLfeDXOhBKuRJ7v/oTy5/7H947thBia7H6uPBeLTH221fU3wuE1b+tXN52BnsWbsHYRZMQ0D4EmffTsPGtFQCAEZ+NR1FOITa/txLjvp0MF383/DbhWwR3CUdE39YAgK0frsGQ2WMouWgg7kJntLVpZuwwiBmiBMPS8XhAm1HAqV+B8iJjR2MawvsAYt0/jeXKC3Cu8GY9BGSaXl33rsb34757BXNbvYHHNx4guPO/9Vb4IiHs3R1r3e/DywkIaB+Ktk91AQA4+7qhzYjOSLp2HwCQ8zADVnbWaDNCNSQf3LUZ0u+mIKJva1zZfhZ8oQCtBrfX8+xIbfDBwwDHbuBxdDWd6I5eNY2BxBZoO0q1JLOxc/IFfNvUqenhvPNQoPHWvCgrUG3kZu2omZzdO3sbc1u9joXdZ2HzeytRmFVQbT+BHcPw+GYikq7eAwBkP8xA3JHraNZHtfLJNdAD0tJyPL71ECW5RXh0/QE8m/miJLcI+77Zhqe+eKEezo5o092+LdyETsYOg5gpjtHeu43H/bNA3CFjR2E8HA/o8Spg56Zz09iS+9iXd6rmAy0UYwwrX/oepfkleH37HPXtV3eeh9hGDCcfV+QkZWLf/7ZBqVDgrb8/g0Bc9QTakysP4q95G8AYoJQr0HVCb4xa+KL6/pt/X8K+b7ZDViZFu6e7YsA7T2Hj2yvgFeEH7xZ+2PHJOijlCvR/+ylEDqWqkvXBT+SJUS59wdWhRgwhAF0iaVyCugC5j4G028aOxDiCutQpuShVluN4waV6CMh8bJvzO1LjHmskFwDUlzEAwDPcB76Rgfii09uIPXy9yssYCWficHjxX3h6wQT4twlGVmI6dnyyDvbujuj31ggAQMtB7dFyUHuNNmm3H+Pp+S9gYbdZeP7nqbBzc8APQz9DUOemsHO1r4ezbrwknAgDnLpRckH0QglGYxM5HCjMBIqzjR1Jw7J2rnPNixMFl1HaiGtebPvod8QcuIrp22bD0cu52mPtmzjCydsVWQ/Sqzxm3/+2od2oruj8XDQAwLOZL6Ql5dgyazX6zBwGHk/zUp68XIZts9fiuR+nIOtBOpRyBYK7qOaAuAV5IOnKPTTvX7fLXkS7vo5dYMe3NnYYxMzRRfnGRiAG2o0G+I2sGl/LQQBf93z6cXk6YkoS6iEg08cYw7Y5a3Hz70uYuvl9uPjVPPpTnFOEvNQc2LtXXeRNVloOjqf5yZjj88DAAC0XbA9+vxPhvVrBp2UAlEoGhUKpvk8hU0CpVFZuROoswioIYVb+xg6DWAAawWiM7NxUkz4vbQQawxQc75aAa5DOzRRM0WhqXmizbfZaXNlxDi+vnAmxrQQFGXkAACs7awitRCgvLsP+RdvRanAH2DdxQM6jLOz98k/YONmixaB/96tYP2MZHDydMOTDMQCAiH5tcHz5Pni38IffP5dI9v1vG5r3awMeX/MzT9qdx7i26wLePvg5AKBJsCc4jsP5Dcdh5+aAjHup8Iuk6pKG4sC3RS+HjsYOg1gISjAaK/cQoMVg4OYeY0dSv4RWQLN+dWp6oegWchpJzQttzqw9AgD45ZmFGreP/fYVdBzbAzweD6m3H+Pyn6dRWlACe3dHBHdthheWTIPE9t8aFXkpOeCeuOzRd+ZwgAP+/nor8tNyYetsh4h+bTD4/VEaj8MYw5ZZqzDi0+fUdTeEViI8+91kbJuzFnKpHE998TwcPKu/bENqR8DxMdw5GmLaa4QYCK0iaexuHwbunTF2FPWn5VDAT/fr87nyAqzN2AUFaPidNA4DHbshwlr36raEVIXmYDR2TXurymZbImc/wLd1nZoeyjtHyQVpNCKtwyi5IAZHCUZjx3GqTdGc/YwdiWHx+EDLIarz01FMyT08kqbVQ1CEmB5PoSuiHaiWCDE8SjCIanVF+zGAjYuxIzGcoK6AravOzUoVZTjRyGtekMbDmifBUOdo8Dm+sUMhFogSDKIitAI6PlenPTpMjo0zENK9Tk2PF1xGqbLcwAERYno4cBjs1JPqXZB6QwkG+Ze1I9BpPCAy8zecFkPqVPPiUXkaYkvv1UNAhJie3g4d4Sf2MHYYxIJRgkE02bkDnZ5XjWiYI+9WgGuAzs3kTIFDeY235gVpXNrZRCDSpqmxwyAWjhIMUpl9E9VIhlBi7Eh0I7QCIupY86LwJnIV1e8CSoglCJX4o6d9u5oPJERPlGAQ7Rw8gY7jVaXFzUWzfnW6vJMjy8fFolv1EBAhpsVT6IZBTt1pEzPSICjBIFVz9DKfJMPZH/CN1LkZYwwH86nmBbF8Dnw7jHDuBQGtGCENhBIMUj0nb6DDs6a9OVpFzYs6iClNQLK06p0/CbEEEk6Ep136wJpvZpc9iVmjBIPUzNkX6Pis6Y5kBHcDbHWv4VGiKMOJ/Mv1EBAhpkPICTDSpQ+cBPbGDoU0MpRgkNpx9gM6TzC9Ohk2LnrUvLiEMiY1cECEmA4Bx8dI597wErkZOxTSCFGCQWrPwQPoOhGwNqHdK1sOUV0i0VFSeSriSu/XQ0CEmAY+eBjmFA1fqnVBjIQSDKIbaydVkuHgaexIAJ9IwMVf52ZU84JYOh44DHHqiUCJt7FDIY0YJRhEd2Ib1eUS10DjxSCyVi1LrYPzhTeQpyg0cECEmAYOHAY6dkeIlYVtYEjMDiUYpG4EItXqEmNt9d6sHyDSvdpotiwPl4pi6iEgQkxDX4fOCLc2YvJPyD8owSB1x+MDrZ8CAjs17OO6BAI+rXRuxhjDIap5QSwUBw79HbuipU2osUMhBAAlGERfHAdE9K/zZEud8QRAy8F1anqz5C6SpRkGDogQ4+ODhyFOPdHCOsTYoRCiRgkGMQy/tkCnF+p/GWtId9V27DoqUZTiZMGVegiIEOMScAKMcO6FMCvdJzwTUp8owSCG4+wLdH8FcKynmeu2rkBw1zo1PVZwCeVU84JYGBEnxCjnPgig1SLEBFGCQQxLYqdaYeLT2vB91/EyTGJZCm6XPjB8PIQYkRVPjNEu/eEtbmLsUAjRihIMYnh8ARA5DGg+EOAM9BLzbaOqJqojGZPjcD7VvCCWxY5vgzEuA9BEpHuJfEIaisDYARALFtABsHMHrm4Fyovr3o/IBmjWp05NzxfeQL6iqO6PTYiJ8RC6YoRzL9jwdV+mTUhDohEMUr9c/IEeUwB3PZbORfQDhLq/mWbJcnGpKLbuj0uIiQmV+GO0a39KLohZoASD1D+xDdBhnOqSCU/HQTPXIMC7pc4PyRjDobxzUFLNC2IhOti2wFCnnhByNPBMzAO9UknDCegAuAQA17YDBek1H69nzYsUWWad2hJiSnjgoa9jZ6pxQcwOjWCQhmXnBnSbBAR2rvnY0B6qzdV0VEw1L4iFkHAijHLpS8kFMUs0gkEaHo+vmlfhHgxc2wWUa9l4zM4NCOpSp+6P5V+kmhfE7LkLnTHMKRoOgnouXkdIPaERDGI8rkFAz1e1z7FoUbeaFw/KknGnLFH/2AgxouZWwRjnOoiSC2LWaASDGJfIGmg9UpVk3NwLlOapyo47++rclUwpx+H88wYPkZCGwgcfvRw6oJVNmLFDIURvHGOMGTsIQgAAcilw77Tq0ohQonPzEwWXaSt2Yrac+PYY6hwFN6Hu844IMUWUYBCLkCnLxbrM3VCCXs7E/DS1CkA/hy4Q8YTGDoUQg6FLJMTsqWpenKXkgpgdMSdCH4dOCLcONHYohBgcJRjE7F0vuYNUWZaxwyBEJ/5iT/R37AY7vrWxQyGkXlCCQcxakaIEpwquGjsMQmpNwAnQ074tIq2bguM4Y4dDSL2hBIOYtaP5FyFlMmOHQUiteAhdMcipO5wE9sYOhZB6RwkGMVv3yx7jbtlDY4dBSI0EHB+dbVuhvW1z8DgqP0QaB0owiFmSKeU4QjUviBkIFHujt0NHOAjsjB0KIQ2KlqkSs8QYQ0xpAk4UXEGZstzY4RBSiS3PGtEOHRBm5W/sUAgxCkowiFkrVZbhRMEVxJQkGDsUQgAAHDi0sQlHV7vWVNeCNGqUYBCLkCLNxPH8S0ilLdqJEXkJ3dDbsRPchc7GDoUQo6MEg1iU+NJEnCy4gnxFkbFDIY2II98OPezbIpQuhxCiRgkGsTgKpsC14js4V3iDtm0n9cqKJ0EXu1ZoZR1Gq0MI+Q9KMIjFKlWW41zhDVwvvgMllMYOh1gQAcdHW5sIdLBtDjFPZOxwCDFJlGAQi5cvL8T5opuILblPiQbRCw88RFgHoYtdJOz4NsYOhxCTRgkGaTQK5EW4UHQLMSUJUFCiQXTABx8trEPQ0a4FJRaE1BIlGKTRKVQU40LhLdwquUuJBqmWkBOglXUY2tlGwJY2JSNEJ5RgkEarSFGCS0UxuFWSQPuZEA0iTojWNuFoZ9MMVnyJscMhxCxRgkEavXKlFDEl93C1+DbyFYXGDocYkSPfDq1twtHcOpgmbxKiJ0owCPkHYwz3yx/jatFtJElTjR0OaUCBYm+0tglHgNiLtlAnxEAowSBEiyxZHq4V30Zc6X3ImNzY4ZB6IOaEaG4dgkibprR9OiH1gBIMQqohVcpwt+whYkru4bE03djhEAPwETVBhHUQmkoCIKS9QgipN5RgEFJL+fIixJbeQ2zJPSpFbmacBPaIsApCM6sg2AtsjR0OIY0CJRiE6IgxhmRpBmJL7yGh7BFtF2+iJDwxmkoCEGEdDE+Rq7HDIaTRoQSDED0omRKPpelIKEtCQukjFClLjB1So2bHt0awxBfBEl/4iDzAp/1BCDEaSjAIMRDGGNJl2apko+wRcuT5xg6pUXATOCFY4osQK1+4C12MHQ4h5B+UYBBST3LlBXhYnoKk8jQ8Kk+jnV0NRMQJ4StuAj+RJ4IkvnCgORWEmCRKMAhpABWjG0nlaXgkTUWyNANypjB2WGZByAngJXKDj6gJfMWe8BC60NbohJgBSjAIMQI5UyBdmoU0WTbSZFlIk2bRypR/OPDt0EToDA+RK7xE7pRQEGKmKMEgxESUKsuQLs1WJR3SLGTIcix+0qg93xZNhC5oInRGE5ELmghdIOGJjR0WIcQAKMEgxISVK6XIlucjW5aHHHk+cuUFyFUUIF9eBKWZ7AQr5ARw5NvBSWD/z5eD+v8S2u+DEItFCQYhZkjJlChUlKBIUYJiperfQkUJipQlKFaU/nN7ab2XORdzItjwrWDDs1L/a8u3Vv/fUWAHW5417e9BSCNECQYhFowxBimTQcpkKFeq/pUqpZAyGWRMDgaGJ98BGDTfDgScACJOACFPABEnhJATanzP5/gNfEaEEHNBCQYhhBBCDI6mZhNCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQYhHOnDkDPp+PgQMHatx+7NgxcByHvLy8Sm1at26NTz/9VP19QEAAOI4Dx3GwsrJCQEAAxowZgyNHjmi0S0xMBMdxuHbtmsbta9asQceOHWFjYwM7Ozv07NkTu3fv1hrPk4/TvHlzLF++XOs5DR48GE5OTpBIJGjZsiUWLVoEhaJyFdjdu3cjOjoadnZ2sLa2RocOHbB69eoa4y4sLER0dDTCw8Px6NGjSv0SUleUYBBCLMLKlSvxxhtv4NSpU0hKSqpzP/PmzUNqairu3LmDtWvXwtHREX379sX8+fOrbffuu+9iypQpGDNmDK5fv44LFy6gR48eGDFiBH766adKx9+5cwepqamIjY3FlClTMHXqVBw+fFh9//bt2xEVFQUfHx8cPXoUt2/fxsyZMzF//nyMGzcOT87P//HHHzFixAh07doV58+fx40bNzBu3Di89tprePfdd6uMOTMzE7169UJRURFOnToFX1/fOjxjhFSBEUKImSsqKmJ2dnbs9u3bbOzYseyzzz5T33f06FEGgOXm5lZqFxkZyebOnav+3t/fn3333XeVjvvkk08Yj8djt2/fZowx9uDBAwaAXb16lTHG2NmzZxkAtnjx4kpt3377bSYUCllSUlK18QQFBbGvv/5afT4uLi7s6aefrtTfrl27GAC2ceNGxhhjSUlJTCgUsrfffrvSsYsXL2YA2Llz5yrFnZSUxJo2bcqio6NZQUFBpbaE6ItGMAghZm/Tpk1o2rQpmjZtiueffx6rVq3S+ISvr5kzZ4Ixhp07d2q9f8OGDbC1tcWUKVMq3ffOO+9AJpNh69atWtsyxrBv3z48evQInTp1AgAcOHAA2dnZWkcfhg0bhrCwMGzYsAEA8Oeff0Imk2k9dsqUKbC1tVUfW+HOnTvo1q0bwsPDsW/fPtjZ2VX/BBBSB5RgEELM3m+//Ybnn38eADBw4EAUFRVpXG7Ql7OzM9zd3ZGYmKj1/vj4eAQHB0Mkqlz63MvLCw4ODoiPj9e43cfHB7a2thCJRBgyZAjmzp2Lnj17qvsDgGbNmml9vPDwcPUx8fHxcHBwgKenZ6XjRCIRgoKCKj32hAkTEBwcjK1bt0Ispr1fSP2gBIMQYtbu3LmDCxcuYNy4cQAAgUCAsWPHYuXKlQZ9HMZYnUuea2t78uRJXLt2DdeuXcOKFSuwYMECLFmypFI7fWPRduyIESNw6tSpKkdVCDEEgbEDIIQQffz222+Qy+Xw9vZW38YYg1AoRG5uLuzt7QEA+fn5cHR01Gibl5cHBweHGh8jOzsbmZmZCAwM1Hp/WFgYTp06BalUWmkUIyUlBQUFBQgNDdW4PTAwUB1P8+bNcf78ecyfPx9Tp05FWFgYACAuLg5du3at9Hi3b99GRESE+rHz8/ORkpICLy8vjeOkUinu37+P3r17a9w+e/ZstGrVCuPHjwdjDGPHjq3xOSBEVzSCQQgxW3K5HGvXrsWiRYvUowHXrl3D9evX4e/vj3Xr1iE0NBQ8Hg8XL17UaJuamork5GQ0bdq0xsf54YcfwOPxMHLkSK33jxs3DkVFRVi2bFml+7755hsIhUKMGjWq2sfg8/koLS0FAPTv3x/Ozs5YtGhRpeN27dqFu3fv4tlnnwUAjBo1CgKBQOuxS5cuRXFxsfrYJ3300Uf4/PPPMX78+EpzNAgxCGPNLiWEEH1t376diUQilpeXV+m+2bNns9atWzPGGJs6dSrz8/Nj27dvZ/fv32enTp1iUVFRrGXLlkwmk6nb+Pv7s3nz5rHU1FSWlJTEjh8/ziZPnsw4jmNffvml+rj/riJhjLGZM2cysVjMvvnmG5aQkMDi4uLYnDlzGI/H01hdUrGK5M6dOyw1NZUlJiayzZs3Mzs7O/bSSy+pj9uyZQvj8/ls8uTJ7Pr16+zBgwdsxYoVzMnJiT3zzDNMqVSqj/32228Zj8djs2fPZnFxcSwhIYEtWrSIicVi9s4771Qb99dff834fD77448/6vZDIKQKlGAQQszW0KFD2eDBg7Xed/nyZQaAXb58mZWVlbF58+axZs2aMSsrK+bv788mTpzIUlNTNdr4+/szAAwAE4lEzM/Pj40ZM4YdOXJE4zhtf6gZY+y3335j7du3Z1ZWVsza2pp1796d7dq1S+OYigSj4ksgELDAwED27rvvsqKiIo1jT5w4wQYOHMgcHByYSCRiERER7JtvvmFyubzS+e7cuZP16NGD2djYMIlEwtq1a8dWrlxZq7gXLVrE+Hw+W7t2rdbnkpC6oN1UCSGEEGJwNAeDEEIIIQZHCQYhhBBCDI4SDEIIIYQYHCUYhBBCCDE4SjAIIYQQYnCUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMbj/AzYCPTiqbnXwAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import seaborn as sns\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.dates import YearLocator, DateFormatter\n",
+    "\n",
+    "\n",
+    "total_query = \"\"\"SELECT \n",
+    "    MaterialType,\n",
+    "    COUNT(*) as total_records,\n",
+    "    SUM(Checkouts) as total_checkouts\n",
+    "FROM checkout_data\n",
+    "GROUP BY MaterialType\n",
+    "ORDER BY total_checkouts DESC;\"\"\"\n",
+    "\n",
+    "total_result = spark.sql(total_query).toPandas().nlargest(5, \"total_checkouts\")\n",
+    "plt.pie(total_result['total_checkouts'], \n",
+    "        labels=total_result['MaterialType'],\n",
+    "        autopct='%1.1f%%',\n",
+    "        colors=sns.color_palette('pastel'),\n",
+    "        explode=[0.05] * 5\n",
+    "       )\n",
+    "plt.axis('equal')\n",
+    "plt.title('Distribution of Checkouts by Media Type', pad=20, size=14)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71b56487-c7e8-481e-8f13-734e1156969f",
+   "metadata": {},
+   "source": [
+    "# Store in S3 Tables\n",
+    "\n",
+    "Data looks ok. Let's store it in S3 Tables.\n",
+    "\n",
+    "We can write to S3 Tables just like you would to a normal S3 Bucket. E.g. `input_data.writeTo(\"catalog.db.table\").using(\"Iceberg\").Create()`\n",
+    "\n",
+    "You can get information about the table with standard queries supported by iceberg. E.g. `SELECT * FROM s3tablesbucket.demo.demo.files`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6ad24755-dda6-4ac9-b22c-a3153dc8c335",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2025-02-28 19:24:08,839] INFO @ line 1: Writing data to S3 Tables: s3tablesbucket.demo.demo\n",
+      "[2025-02-28 19:24:08,839] INFO @ line 1: Writing data to S3 Tables: s3tablesbucket.demo.demo\n",
+      "[2025-02-28 19:24:28,794] INFO @ line 3: Successfully written data to S3 Tables\n",
+      "[2025-02-28 19:24:28,794] INFO @ line 3: Successfully written data to S3 Tables\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3 style=\"color: #FFB26F\"> Iceberg Files</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>content</th>\n",
+       "      <th>file_path</th>\n",
+       "      <th>file_format</th>\n",
+       "      <th>spec_id</th>\n",
+       "      <th>record_count</th>\n",
+       "      <th>file_size_in_bytes</th>\n",
+       "      <th>column_sizes</th>\n",
+       "      <th>value_counts</th>\n",
+       "      <th>null_value_counts</th>\n",
+       "      <th>nan_value_counts</th>\n",
+       "      <th>lower_bounds</th>\n",
+       "      <th>upper_bounds</th>\n",
+       "      <th>key_metadata</th>\n",
+       "      <th>split_offsets</th>\n",
+       "      <th>equality_ids</th>\n",
+       "      <th>sort_order_id</th>\n",
+       "      <th>readable_metrics</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>s3://415f4796-36de-4868-cdf7h3rwcg77cdw99bnsnw...</td>\n",
+       "      <td>PARQUET</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2676026</td>\n",
+       "      <td>179205072</td>\n",
+       "      <td>{1: 349737, 2: 349739, 3: 991700, 4: 6228, 5: ...</td>\n",
+       "      <td>{1: 2676026, 2: 2676026, 3: 2676026, 4: 267602...</td>\n",
+       "      <td>{1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: ...</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{1: [68, 105, 103, 105, 116, 97, 108], 2: [72,...</td>\n",
+       "      <td>{1: [80, 104, 121, 115, 105, 99, 97, 108], 2: ...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>[4, 134112842]</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "      <td>((7872, 2676026, 0, None, 1, 12), (1366995, 26...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   content                                          file_path file_format  \\\n",
+       "0        0  s3://415f4796-36de-4868-cdf7h3rwcg77cdw99bnsnw...     PARQUET   \n",
+       "\n",
+       "   spec_id  record_count  file_size_in_bytes  \\\n",
+       "0        0       2676026           179205072   \n",
+       "\n",
+       "                                        column_sizes  \\\n",
+       "0  {1: 349737, 2: 349739, 3: 991700, 4: 6228, 5: ...   \n",
+       "\n",
+       "                                        value_counts  \\\n",
+       "0  {1: 2676026, 2: 2676026, 3: 2676026, 4: 267602...   \n",
+       "\n",
+       "                                   null_value_counts nan_value_counts  \\\n",
+       "0  {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: ...               {}   \n",
+       "\n",
+       "                                        lower_bounds  \\\n",
+       "0  {1: [68, 105, 103, 105, 116, 97, 108], 2: [72,...   \n",
+       "\n",
+       "                                        upper_bounds key_metadata  \\\n",
+       "0  {1: [80, 104, 121, 115, 105, 99, 97, 108], 2: ...         None   \n",
+       "\n",
+       "    split_offsets equality_ids  sort_order_id  \\\n",
+       "0  [4, 134112842]         None              0   \n",
+       "\n",
+       "                                    readable_metrics  \n",
+       "0  ((7872, 2676026, 0, None, 1, 12), (1366995, 26...  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3 style=\"color: #FFB26F\"> Iceberg History</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>made_current_at</th>\n",
+       "      <th>snapshot_id</th>\n",
+       "      <th>parent_id</th>\n",
+       "      <th>is_current_ancestor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2025-02-28 19:24:28.368</td>\n",
+       "      <td>1121241211332417717</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          made_current_at          snapshot_id  parent_id  is_current_ancestor\n",
+       "0 2025-02-28 19:24:28.368  1121241211332417717        NaN                 True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3 style=\"color: #FFB26F\"> Iceberg Snapshots</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>committed_at</th>\n",
+       "      <th>snapshot_id</th>\n",
+       "      <th>parent_id</th>\n",
+       "      <th>operation</th>\n",
+       "      <th>manifest_list</th>\n",
+       "      <th>summary</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2025-02-28 19:24:28.368</td>\n",
+       "      <td>1121241211332417717</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>append</td>\n",
+       "      <td>s3://415f4796-36de-4868-cdf7h3rwcg77cdw99bnsnw...</td>\n",
+       "      <td>{'engine-version': '3.5.3', 'added-data-files'...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             committed_at          snapshot_id  parent_id operation  \\\n",
+       "0 2025-02-28 19:24:28.368  1121241211332417717        NaN    append   \n",
+       "\n",
+       "                                       manifest_list  \\\n",
+       "0  s3://415f4796-36de-4868-cdf7h3rwcg77cdw99bnsnw...   \n",
+       "\n",
+       "                                             summary  \n",
+       "0  {'engine-version': '3.5.3', 'added-data-files'...  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "logger.info(f\"Writing data to S3 Tables: {full_table_name}\")\n",
+    "library_checkout.writeTo(full_table_name).using(\"Iceberg\").createOrReplace()\n",
+    "logger.info(f\"Successfully written data to S3 Tables\")\n",
+    "\n",
+    "def display_with_header(content, header, level=1):\n",
+    "    header_html = f'<h{level} style=\"color: #FFB26F\"> {header}</h{level}>'\n",
+    "    display(HTML(header_html))\n",
+    "    display(content)\n",
+    "\n",
+    "display_with_header(spark.sql(\"SELECT * FROM s3tablesbucket.demo.demo.files LIMIT 1;\").toPandas(), \"Iceberg Files\", 3)\n",
+    "display_with_header(spark.sql(\"SELECT * FROM s3tablesbucket.demo.demo.history LIMIT 1;\").toPandas(), \"Iceberg History\", 3)\n",
+    "display_with_header(spark.sql(\"SELECT * FROM s3tablesbucket.demo.demo.snapshots LIMIT 1;\").toPandas(), \"Iceberg Snapshots\", 3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b10540b-97d1-4dbf-a2d7-b3af0cfabce0",
+   "metadata": {},
+   "source": [
+    "# Read back from S3 Table\n",
+    "\n",
+    "Let's verify we can read data back from S3 Tables using DuckDB.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "96ae12a8-df3e-4073-b195-996a338ff604",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2025-02-28 18:58:38,383] INFO @ line 161: NumExpr defaulting to 16 threads.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e708114b45ec49e59d7ec7ee66ec1e5a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhgAAAGxCAYAAAAgf8+rAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACG7klEQVR4nO3dd3iT1RcH8O+b3b1L924pZZS9oWXvochQFFFEBBScqKCiKKD+xIGDIbKULVNA9t57tYVSoBS6926z7u+P2EhsOtKkzej5PE8faPLem/OmaXpy33vP5RhjDIQQQgghBsQzdgCEEEIIsTyUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMThKMAghhBBicJRg1NGxY8fAcRw+/fRTozx+QEAAAgICNG779NNPwXEcjh07ZpSYEhMTwXEcJk6caJTHN4T8/Hy8/vrr8Pf3h0AgAMdxSExMNPjjREdHg+M4g/dbF6YUS32yhNenIVT13qXtPYUQfTTqBKPiDefJL2tra3h5eaFPnz745JNPcO/evXp5bHN9U7f0N6H33nsPP//8M1q3bo3Zs2dj7ty5cHR0rFXbw4cP47nnnkNAQACsrKxgY2ODZs2aYcqUKTh//nz9Bm4hOI5DdHS0scMwuIr3FysrK+Tl5Wk9Jjs7G2KxGBzHQSKRNGyA9aQimantlyX+7BszgbEDMAXBwcF4/vnnAQDl5eXIyMjAhQsX8Pnnn2PBggWYNWsW5s+fr5EQdOzYEXFxcXB1dTVKzIcPHzbK41bH29sbcXFxcHBwMHYodbZ37140bdoUO3furHWb0tJSvPzyy9i4cSOsra3Rt29fhIWFAQDi4+Oxbt06LF++HGvXrsULL7xQX6ETEycQCFBWVob169dj2rRple7//fffIZVKIRAY5225Pt5TAgICMHfuXI3bEhMTsWbNGkRGRmLkyJGVjieWgxIMACEhIVovdZw8eRITJkzAwoULwefz8fnnn6vvs7a2Rnh4eANGqSk4ONhoj10VoVBo1OfEEFJSUtCzZ0+d2kyaNAkbN25Ev3798Pvvv6NJkyYa9+fl5WHhwoVVfnIljUNwcDAYY1i5cqXWBGPVqlVo1aoV8vPzkZaWZpT4DC0gIKDSe+uxY8ewZs0atG7d2miXmEnDaNSXSGrSo0cP7N+/H2KxGF9//TUePXqkvq+q65h3797FSy+9hMDAQEgkEri6uqJt27Z455131MdwHIfjx4+r/1/xVXFt+Mlrxbdv38bTTz8NV1dXjfkANV2q+PXXX9G8eXNIJBL4+fnhww8/RFlZmcYx1c0j+e/16orvHz58iIcPH2rEXdG+umvcSUlJmDRpEry9vSESieDj44NJkyZpPKcVKi4fyeVyfP755wgMDIRYLEZYWBh++eWXKs9ZG7lcju+++w6RkZGwsrKCg4MDevXqhT179mgcN3HiRHAcB8YYjh8/XulnUpWjR49iw4YNCAsLw44dOyolFwDg6OiIr776Cq+++qrW+Gp7jhV/nLp16wZ7e3tYW1ujffv2WLlyZZXHr1mzBj179oSjoyOsra0RGhqK1157DUlJSdWeFwCsX78eIpEI7dq1Q0ZGhvr2NWvWoHPnzrC1tYWtrS06d+6MNWvWVGq/evVqcByH1atXV7rvv6+9iu8BaDz/T7ZXKpVYsWIFOnbsCGdnZ1hbWyMgIAAjR47EiRMnajyfJ926dQuDBg2Cg4MD7O3tMWzYMMTGxmocExUVBaFQiNTUVK19jBkzBhzH4erVq7V+3IkTJ+Ly5cu4ceOGxu2XLl3CjRs38NJLL1XbfufOnejTpw+cnJwgkUjQokULfPPNN1AoFJWOLS0txQcffABfX1/1sb/++muVfWt7T0lJScHcuXPRuXNnuLu7QywWIyAgANOmTdN4Tehr7ty54DgOW7Zs0Xr/L7/8Ao7j8N1336lvq7ik8ujRI4wdOxYuLi6wsbFBdHQ0zpw5o7UfqVSKb7/9Fm3btoWNjQ3s7OzQo0cP7Nq1y2DnQp7AGrEHDx4wAGzAgAHVHjdhwgQGgC1evFh929GjRxkANnfuXPVtycnJzNHRkQmFQjZy5Ej2/vvvs+nTp7P+/fszoVCoPm7u3LnM399f3b7ia/v27RpxdevWjTk4OLCuXbuyt99+m02cOJElJyczxhjz9/dn/v7+GnHOnTuXAWBDhw5ltra2bNKkSWzWrFmsRYsW6vNUKpXVnsN/n5sXX3yRMcZYbm4umzt3LnNwcGAODg4acR89elRrmwrx8fHM3d2dAWDDhg1jH3zwARs2bBgDwNzd3dndu3c1jo+KimIA2DPPPMN8fX3Zq6++yqZOncpcXFwYALZ8+fJqf14VlEole/rppxkAFhYWxt555x322muvMWdnZwaA/fDDD+pjt2/frn7+/P39K/1MqjJ+/HidYqrrOSqVSvbcc8+pz2XKlCnsjTfeYOHh4QwAe+eddyodP3bsWAaAeXt7s9dee43NmjWLjRkzhjk6OmqcV0UsT/r+++8Zx3Gsd+/erKCgQH37m2++qe5zxowZbObMmczHx4cBYG+99ZZGH6tWrWIA2KpVqyqd/39few8ePND6/M+dO5ddvXqVMcbYrFmzGAAWHBzMpk+fzj744AP2wgsvsICAAK2v4f+qeH326NGD2dvbs759+7IPPviAjRo1ivF4PObo6MhiY2PVx69bt44BYPPnz6/UV2ZmJhOJRKxdu3Y1Pi5jjAFgTZs2ZcnJyYzP57M333xT4/6pU6cykUjEMjMzmb+/PxOLxZX6+PDDDxkA5uPjwyZNmsTeeust1q5dO/Xr6EkKhYL17duXAWAtW7Zks2bNYpMmTWI2NjZs6NChWn/vtb2nbNiwgdnY2LDhw4ezGTNmsHfeeYf17t2bAWBBQUEsLy+vVuf/pIqf/ZPvE0lJSYzP57N+/fppbdOmTRsmEolYVlaW+jYArFWrVszX15d17NhR/XoQiURMJBKp35cqlJWVsejoaAaAtWnThr3xxhvstddeY76+vgwA+/HHH3U+F1I9SjBqkWD89ttvDAB74YUX1Ldp++O8ePHiSn+4KmRmZmp8r+1N/b9xAWAff/yx1mOqSzAkEgm7deuW+naZTMb69evHALC1a9dWew7/jeG/yYK2x62pTcUb0rJlyzRuX7ZsGQPA+vTpo3F7xXPTqVMnlp+fr7799u3bTCAQsKZNm2p9/P9au3YtA8CioqJYeXm5+vZHjx4xd3d3JhQK2f379zXaVBxfWwEBAQwAS0hIqHUbxnQ/x+XLlzMAbNKkSUwmk6lvLy8vVydrly5dUt/+888/q5/bkpISjb5KSkpYdnZ2pVgqVPwhGz16tMbzduLECQaANWvWTOMPS15enjrROXnypPp2XRKMCtU9/87Ozszb25sVFxdr3K5UKjXOpypP/l599NFHGvetWbOGAWC9e/dW31ZWVsZcXFxYcHCwRmLOGGPffvstA8CWLFlS4+NWnFfFz3Tw4MHM1dWVSaVSxhhjpaWlzNHRkY0aNYoxxrQmGAcOHGAA2KBBgzTOX6lUstdee40BYH/++af69ornfuDAgUwul6tvv3HjBhOJRLVOMNLT01lhYWGl86l4vr744otanf+TtCUYjDE2ZMgQxnEce/DggcbtV69eZQDY2LFjNW6v+Fm+8MILGj+fY8eOMY7jWEhICFMoFOrbZ8+ezQCwTz/9VOP4goIC1r59eyYSidQf4IhhUIJRiwTj77//Vv9yV6guwajNp9naJBgeHh4ab/BPqi7BmDx5cqXjL168WOmPeUMkGElJSQwAi4iIqPQmrVQqWbNmzRgAlpSUpL694rk5cuRIpceouO/JT9VVqUhszp8/X+m+hQsXMgDs888/17hd1wRDIpEwAKysrKzWbRjT/RxbtWrFbGxsWGlpaaXjb9y4UWkUIyIigvH5fBYfH1/rWORyOZs0aRIDwKZOnarx5swYYy+//DIDwDZt2lSpjw0bNqgToAr1kWAEBgZW+TtRk4rXp5OTEysqKtK4T6lUqkf6nnwtvv322wwAO3z4sMbxzZs3Z9bW1hrJYXWeTDD+/PNPjYTgjz/+YADYnj17GGPaE4zhw4dXiq1CXl4e4zhOnaAwxlivXr0YAHb58uVKx1f8jGuTYFRFqVQye3t7Fh0dXavjn1RVgrFr1y6tH6qmTZvGALBDhw5p3A6A8fl8rc/JkCFDNBJehULBnJycWEhISKX3oScfm0YxDIsmedYCY6xWxw0dOhQffPABpk+fjoMHD2LgwIHo3r27ekWBriIjIyESiXRu16NHj0q3tW/fHlZWVrh27VqdYqmriuvTUVFRlZblchyHnj17Ii4uDtevX4evr6/G/W3btq3Un4+PDwDVxEk7O7saH9vKygodO3asdF/FcriGfj7+qzbnWFJSgps3b8LLywtffvllpeNlMhkA4Pbt2wCA4uJixMbGIiQkBKGhobWO5emnn8auXbswd+5crfNyKn6W2pYSNsTzOWbMGCxduhQtWrTA2LFjERUVhS5dusDGxkanftq0aVOpDcdx6N69O27duqXxWnz11Vfx7bffYsWKFejduzcA4Ny5c4iJicHEiRNhb2+v83kMHz4crq6uWLlyJUaNGoWVK1fCy8sLAwYMqLLNuXPnYGNjg99++03r/VZWVuqfPwBcv34d1tbWWl9fPXr0qLIfbbZt24Zly5bhypUryM3N1ZjvkZKSUut+ajJ48GD4+Phg1apV+PTTT8Hj8dSrboKCgtTP/5P8/f0rvW8AqnPcs2cPrl27hu7du+POnTvIzc2Fl5cXPvvss0rHZ2ZmAoDGc0j0RwlGLVRM8nJzc6v2uMDAQJw9exafffYZ/v77b/WEpaZNm+Lzzz/H6NGjdXpcbRMGa8Pd3b3K25OTk+vUZ10VFBQAqPpcPDw8AKgKXP2XtuWuFUv4tE1q0/bY2t58anpcXXh4eCAxMRHJyckICgrSuX1tzjE3NxeMMSQnJ2t9c6xQXFwMAOrVKt7e3jrFcvLkSVhZWWHQoEFa7y8oKACPx9P6e9CkSRPweDy9n8/qLF68GEFBQVi9ejW++OILfPHFF5BIJBgzZgwWLVpU6yXjVf1+VLxGnzyHpk2bIioqCtu2bUNOTg6cnZ2xYsUKAMDkyZPrdB5CoRDjx4/HTz/9hDNnzuDo0aN4//33wefzq2yTk5MDuVxeq59/xTlU9drX5X1l0aJFePfdd+Hm5ob+/fvDx8cHVlZWAIDvv/8e5eXlte6rJnw+H5MmTcJnn32Gffv2YfDgwfjzzz+Rl5eH9957T2vdoNr+LHNycgAAMTExiImJqTKGJ59Doj9aRVILFZUxO3ToUOOxrVq1wtatW5GTk4OzZ8/ik08+QXp6OsaOHYvTp0/r9Lh1LcRV1ezujIwMjT9oPJ7qxy+Xyysda6g/FBWf8NLT07XeX3F7XT4J1uax6/txu3XrBqB+65JUxNiuXTsw1WVNrV9Hjx4F8G/SomsyefjwYVhZWaF///44d+6c1jiUSqX6096TMjIyoFQqNZ5PQ7++hEIh3nvvPcTExCA5ORnr169Hjx49sHbtWowfP77W/VT1+1Hxmvhv0jdlyhSUl5fjjz/+QFFRETZt2oSIiAh07dpV53OoMGnSJCgUCowZMwaMMbz88svVHm9vbw8XF5dqf/4PHjxQH+/g4FDjedakYoWTl5cXYmJisG7dOnz11Vf49NNPMXfuXEil0tqfcC298sor4PP56iRuxYoVEAgEVa7mqu3PsuJ1OWrUqGqfw1WrVhn4jBo3SjBqEB8fj82bN0MsFuOpp56qdTuhUIjOnTvjs88+w+LFi8EYw+7du9X3V3xaqc0ncV2dPHmy0m2XLl1CaWkpWrdurb7NyckJgPY/RFUtvePz+TrFXPF4J06cqHSpiTGmjvXJuAylTZs2KC0txYULFyrdV7FMWN/HnTRpEgDVJ73S0tJqj63rpz07Ozs0a9YMcXFxtaqlYWtri4iICDx48AB3796t9eO0adMGhw8fhkAgwIABAyolGW3atAEAraXotT2fdXl98Xi8Wr2+vLy88Oyzz2Lfvn0IDQ3FoUOHanz+n3xsbZ9UKz4AREZGatw+atQouLq6YsWKFdi0aROKiorwyiuv1OqxqtKyZUu0a9cOycnJ6N69e42Xsjp16oTs7Oxa/zwjIyNRUlKCK1euVLpP2/uDNllZWcjPz0fnzp0rjVpVvJ8Ymo+PDwYNGoTdu3fj9OnTOHHiBAYPHgwvLy+txz98+FDrUvf/vq80a9YM9vb2uHTpkvqSIql/lGBU49SpUxgwYADKy8vx4Ycf1jjkfPHiRa0ZdUU2XTG0CADOzs4AgMePHxswYpXff/9dYxhQLpdj9uzZAIAXX3xRfXvTpk1ha2uLXbt2qYcQK+L94osvtPbt7OyMrKysSjU1quLn54devXohJiamUr2GlStXIiYmBr17965yOFcfFef64YcfarypJCcn49tvv4VAINDpk682vXr1wrPPPos7d+7g6aef1vrzLygowOzZs7F8+fI6P86MGTNQUlKCyZMna/3j+ODBA409U6ZPnw6FQoFp06ZV+kNQVlam8fN+UuvWrXHkyBEIhUL0799fo55AxfP52WefqS99VZxfxdD9k6+vtm3bguM4bNy4UeP1cvfuXfzwww9aH9/Z2Vnr70R5eTmOHDlSKUktLi5GYWEhhEJhtZcYnpSbm1tpLsvatWtx8+ZNra9FkUiEF198ETdv3sQnn3wCkUiECRMm1OqxqrNmzRps37692toUFWbMmAEAePnll5GdnV3p/rS0NMTFxam/r6gYO2fOHI2E7ebNm/j9999rFZ+7uzusrKxw5coVlJSUqG/Pzc3FG2+8Uas+6mLKlCmQyWTq0Z3qLkUpFArMmTNH43Vx/Phx7N27FyEhIepRJoFAgKlTp+Lhw4d49913tSYZt27dMmhtD0JzMAAACQkJ6kltUqkUGRkZOH/+PG7dugU+n4+PPvoIn3zySY39rFu3Dr/88guio6MREhICe3t7xMbGYu/evXB1ddUYBu3duzf+/PNPjB49GoMHD4ZEIkHLli0xZMgQvc+nb9++6Ny5M8aNGwdnZ2fs3bsXt27dwoABA9Ql0QHVG+frr7+OL7/8Em3btsWIESNQWFiIv/76C1FRUVr3YenduzcuXbqEYcOGoUePHhCJROjevTu6d+9eZTxLlixB9+7dMXnyZPz111+IiIhAbGwsdu3aBTc3NyxZskTvc9bmhRdewLZt27Bz5060atUKQ4cORXFxMTZv3ozs7GwsWrSoTvMm/uu3334DYwwbN25EYGAg+vfvj7CwMDDGcPfuXRw+fBiFhYW1fmPXZsqUKTh37hzWrFmD06dPo2/fvvDy8kJ6ejpu376N8+fPY/369epCSVOnTsXx48exefNmhIaGYvjw4bC3t0dSUhL279+P3377rVKZ5gqRkZE4cuQI+vTpg4EDB2Lfvn3o2rUrevbsiTfeeAM//vgjWrRooR5u3rZtGx49eoQZM2ZoVEH19vbG2LFjsXHjRrRr1w4DBw5ERkYGtm/fjoEDB2Lr1q2VHrt3797YvHkznnnmGbRp0wZ8Ph9DhgyBr68v+vTpg6CgIHTq1Al+fn4oKirC7t27kZaWhvfff7/WE6J79OiBxYsX49y5c+jQoQPi4+Oxfft2ODg44KefftLa5tVXX8WiRYuQkpKiLuqkr+bNm6N58+a1OnbgwIH4+OOP8fnnnyMkJAQDBw6Ev78/srOzkZCQgJMnT+KLL75As2bNAKgSvfXr12Pfvn1o06YNBg0ahJycHGzYsAH9+/fXGE2tCo/Hw7Rp07Bo0SJERkZi2LBhKCgowN9//w1/f/8qRxX0NXjwYPj6+uLRo0fw9vauck4QoLokfezYMXTu3Bm9e/dGSkoKNm7cCKFQiF9//VV9mQ5QJcZXrlzB4sWLsWfPHkRFRcHNzQ3Jycm4efMmrl+/jrNnz1Y5r4PUQb2vUzFhT66Lr/iysrJinp6erFevXuzjjz+usr6BtmV2586dY1OmTGEtWrRgjo6OzMrKioWGhrIZM2ZUWkolk8nYrFmzmJ+fHxMIBBrLtqpaIvqk6papHj16lC1btoxFREQwsVjMfHx82AcffFCpHgJjjMnlcvbJJ58wX19fJhKJWFhYGPvhhx/Y/fv3tcZQWFjIJk+ezDw9PRmPx9N4DqqLOzExkb300kvM09OTCQQC5unpyV566SWWmJhY6djqlvC++OKLDECltfJVkclk7JtvvmEtW7ZkYrGY2dnZsaioKLZz506tx0PHZapPOnjwIHv22WeZv78/k0gkTCKRsNDQUDZp0qRKS2Xreo6bNm1iffv2ZU5OTkwoFDJvb28WHR3NFi1aVKnWilKpZCtWrGCdO3dmNjY2zNramoWGhrLXXntN67Lg/7p+/TpzdXVltra2GvUtVq5cyTp06MCsra2ZtbU169ChA1u5cqXWcykuLmZvvPEGa9KkCROLxaxVq1Zs3bp1VS5TTU1NZWPGjGGurq7q19eqVauYVCplX331Fevfvz/z8fFhIpGINWnShEVFRbGNGzdqfez/evL1eePGDTZw4EBmZ2fHbG1t2ZAhQzRqx2jTpUsXrcslawNPLFOtSVWFthhTvcaGDRvG3NzcmFAoZB4eHqxLly7s888/r/QeU1xczGbNmsW8vb2ZWCxmERERbNmyZVU+99reU6RSKZs/fz4LDQ1lYrGY+fn5sbfffpsVFhbqtKz1SVUtU31SRS2W/9YreVLF7+rDhw/Z6NGjmZOTE7OysmI9e/Zkp06d0tpGLpezZcuWsW7dujF7e3v1OQ0cOJAtWbKk0vJloh+OsVquwSSEkEaqrKwM3t7ecHR0REJCglnuhGxOBg8ejH379uH+/ftVbonAcRyioqK0zgkipoHmYBBCSA1WrlyJnJwcTJkyhZKLehYTE4N9+/Zh4MCBtLuqmaM5GIQQUoUvv/wSmZmZWLZsGdzd3fHaa68ZOySLtX79ety5cwdr164FAHz88cdGjojoixIMQgipwocffgiRSITIyEgsXry4Xuq1EJXly5fj5MmT8Pf3x2+//YYuXboYOySiJ5qDQQghhBCDozkYhBBCCDE4SjAIIYQQYnCUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMThKMAghhBBicJRgEEIIIcTgKMEghBBCiMFRgkEIIYQQg6MEgxBCCCEGRwkGIYQQQgyOEgxCCCGEGBwlGIQQQggxOEowCCGEEGJwlGAQQgghxOAowSCEEEKIwVGCQQghhBCDowSDEEIIIQZHCQYhhBBCDI4SDEIIIYQYHCUYhBBCCDE4SjAIIYQQYnCUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMThKMAghhBBicJRgEEKIHiZOnAiO4yp9DRw4EAAQEBCgvo3P58PLywuTJk1Cbm6uRj85OTl48803ERAQAJFIBE9PT7z00ktISkqq9JiPHj3CpEmT4OXlBZFIBH9/f8ycORPZ2dkax0VHR+PNN9/UuO2HH36AWCzG+vXrDftEEPIflGAQQoieBg4ciNTUVI2vDRs2qO+fN28eUlNTkZSUhHXr1uHEiROYMWOG+v6cnBx07twZhw4dwi+//IKEhARs2rQJ9+7dQ4cOHXD//n31sffv30f79u0RHx+PDRs2ICEhAUuXLsXhw4fRpUsX5OTkVBnn3Llz8eGHH2L79u147rnn6ufJIOQfAmMHQAgh5k4sFsPDw6PK++3s7NT3e3t7Y8KECdi4caP6/jlz5iAlJQUJCQnq4/z8/LB//36EhoZi+vTp+PvvvwEA06dPh0gkwoEDB2BlZaU+tk2bNggODsacOXOwZMkSjcdnjGHGjBn4/fffceDAAXTv3t2g50+INjSCQQghDSg5ORm7d+9Gp06dAABKpRIbN27E+PHjKyUpVlZWmDZtGvbv34+cnBzk5ORg//79mDZtmjq5qODh4YHx48dj06ZNYIypb5fL5XjhhRewZcsWHD9+nJIL0mAowSCEED3t3r0btra2Gl+ff/65+v73338ftra2sLKygo+PDziOw7fffgsAyMzMRF5eHpo1a6a172bNmoExhoSEBNy9exeMsWqPzc3NRWZmpvq2X3/9FVu2bMGxY8cQGRlpwLMmpHp0iYQQC6ZkDFI5IFMwlMsZpIon/88gUwBKBnD/HM9xWv7/xG0CHgexgINYAIgFHCRC1fdCPlfpsRuTXr16Vbos4ezsrP7/e++9h4kTJ4IxhkePHmH27NkYMmQITpw4UWPfFaMRHMdpjEzUdGyF7t2749q1a/joo4+wceNGCAT0tk8aBr3SCDFT5XKGwjIliqUMReUMReWq/xdLVQmETM4gUzZMLHxOlXCIhRwkTyQfdmIe7CUc7K14sBVxGn/4LImNjQ1CQkKqvN/V1VV9f2hoKL7//nt06dIFR48eRe/eveHo6IjY2FitbW/fvg2O4xAcHAzGGDiOQ2xsLEaOHKn1WCcnJ7i6uqpva9myJRYtWoS+fftizJgx2LRpE4RCoX4nTEgtUIJBiAljjKGwjCG3VIn8MiUKShkKypQoKFNCqjB2dP9SMKBExlAiq/oTNp8D7CQc7CU82El4cPjn//YSHiRCy0w8qsLn8wEApaWl4PF4GDNmDNatW4d58+ZpzMMoLS3FL7/8ggEDBqhHRPr164dffvkFb731lsY8jLS0NKxbtw4TJkyolMi1bt0aR44cQd++fTF69Ghs2bKFkgxS7yjBIMSElEiVyCpWIrtIiaxiBbKLTSuR0IeCAXmlDHmlCgCaJyXiAy42PLjZ8uFmq/pXJDCfpKO8vBxpaWkatwkEAvVIQmFhIdLS0tSXSGbNmgVXV1d07doVADB//nwcPnwY/fr1w9dff40WLVrgwYMH+OijjyCTyfDzzz+r+/3pp5/QtWtXDBgwAF988QUCAwMRExOD9957D97e3pg/f77WGFu1aqUeMXnmmWewZcsWiESienpGCAE4VtNFPUJIvZDKGbKLVYlERVJR3QhAY+NgxWkkHA4S07zEMnHiRKxZs6bS7U2bNsXt27cREBCAhw8fqm93c3NDhw4dMH/+fLRu3Vp9e1ZWFubNm4cdO3YgNTUVLi4uGDhwIObNmwc/Pz+Nvh8+fIhPP/0U+/btQ3Z2Njw8PDBy5EjMnTsXLi4u6uOio6PRunVrfP/99+rbYmNj0adPH7Rv3x5bt26lJIPUG0owCGkgSsaQUahEcr4CKXkK5JY20AQJCyHiA67/JBxe9ny42vJMMuEghKhQgkFIPSqRKpGcp0ByvgKpBQrILORyhymQCABvRwF8HPnwcuA3+pUshJgaSjAIMaAnRymS8+TIK6Vfr4bA44Amdjz4OArg68SHrZhK/BBibJRgEKInJWNIzVfgfrYcj/NolMIUOFpx8HYUwNdRdUmFLqUQ0vAowSCkjrKLFbifJceDHAXKaHKmybIVcwh2FSDYVUAjG4Q0IEowCNFBsVSJB1ly3M+myx/myMOOh2A3AfydBBDQnA1C6hUlGITUQKZgeJijSirSC5SgXxjzJ+QD/s4ChLgK4G7HN3Y4hFgkSjAIqUJBqRKx6TLcz5JDTitKLZa95N9LKNYiuoRCiKFQgkHIf6QVKBCbJsPjPJqt2ZjwOMDfmY8IDyFcbGhUgxB9UYJBCAClkiExR5VY5JTQcEVj18SOh+YeQng78mkFCiF1RAkGadSkcob4DBlup8upTDepxEHCobmnEEEuAvB4lGgQogtKMEijVFSuREyqDPdofgWpBRsRhwgPIULdBRBQokFIrVCCQRqVMhnDjRQp4jPkUNIrn+hIIgCaeQgR3kRIpckJqQElGKRRkCkYYlJliE2T0YgF0ZuVkEOktxAhbgLwaI4GIVpRgkEsmkLJEJ8hx80UKcrkxo6GWBpHKw5tfUXwcRQYOxRCTA4lGMQiMcZwP1uO649lKJLSS5zULw97Htr5imh5KyFPoASDWJzHeXJceSSlUt6kwQW58NHGRwQb2vOEEEowiOUoKFPifGI5UgtokgUxHj4HhHsI0dJTCJGA5meQxosSDGL2lEqGmDQZbiTLoKBXMzERYgHQ3leEYDehsUMhxCgowSBmLaNQgXOJ5XQ5hJgsLwc+OgeIaKt40uhQgkHMklTOcOWxqp4FIaZOwAPa+IgQ3kRApcdJo0EJBjE7D3PkuPBQilIq7U3MjJstD10DxXCwotEMYvkowSBmo6hciQsPpbTLKTFrPA6I9BaiuaeQinQRi0YJBjELCZkyXHgopSqcxGI4W/PQJZBqZxDLRQkGMWkyBcO5xHI8yKZRC2J5OA5o4SlEpDeNZhDLQwkGMVnZxQqcSChHYTm9RIlla2LHQ49gMaxFNDeDWA5KMIjJYYwhLk2OK4+ltOMpaTQkAqB7sAReDnTJhFgGSjCISSmTMZy+X47kfLokQhofDkBLL9UlE1rOSswdJRjEZKQVKHDyXjktPyWNnoc9Dz2CJbASUpJBzBclGMTolIzherIMt1JkoBcjISpWQg49gsXwsKdLJsQ8UYJBjEoqZzieUEYblBGiBQdVzYyWXnTJhJgfSjCI0RSUKnHkbhkKyuglSEh1vB346BkihpBPSQYxH5RgEKNIyVfgREIZpDSXk5BacbLmoU8YLWUl5oMSDNLgUvMVOHSnjOZbEKIjaxGHPmESOFlTkkFMH71KSYNrYseDux299AjRVYmUYV9cKVJoGTcxA/QuTxocj8chOlQCewldTyZEVzIFcCS+DAmZMmOHQki1KMEgRiEWcOgdJoFYYOxICDE/SgaceSDFtcdSY4dCSJUowSBGYy/hITpEAh4NZBBSJzdSZDh9vxxKqqlPTBAlGMSomtjz0SVAZOwwCDFb97LkOBRfBqmCkgxiWijBIEYX7CZES0+hscMgxGylFShx+E4ZZJRkEBNCCQYxCa19hPB3ppLIhNRVZpEShyjJICaEEgyiv9J8oDBDry44jkO3IDFcbeglSUhdUZJBTAm9mxP95KcCp1cCFzcCZUV6dSXgcegVJoGNiGZ9ElJXmUV0uYSYBkowSN2lxwNn1wDlRapRjMubAIV+a/OthKrlq0J6ZRJSZxlFShyOpySDGBe9jZO6eXgZuLxZM6HISwGu7QT0rD7vZM1DzxAxaByDkLrLKFTiCCUZxIgowSC6u3cGuLVXeyKRFgfcOar3Q3g7CtDej5avEqKP9H+SDDklGcQIKMEguok/Dtw+XP0x904Dj67r/VDNPIRo6k6lPgnRR3qh6nIJJRmkoVGCQWov7hBw90Ttjr21B8h+qPdDdvAXwduBlq8Soo/0QiVO3isHbZ5NGhIlGKRmjAE39wL3z9a+jVIBXN4CFGfr9dA8jkPPEDEcrWhGBiH6eJSnwKUk2ruENBxKMEj1mBK4vgtIuqx7W1mpavmqtFSvEIR81coSiZCSDEL0EZcux+102oWVNAxKMEjVlArg6jYg+Ubd+yjOUY1kKBV6hWIr5qF3qBh8esUSopeLD6V4nCc3dhikEaC3a6IdUwJXtwOpcfr3lfMQuLlH725cbfnoFiTWPx5CGjEG4ERCObKL9Uv6CakJJRhEu5t7VEtODeXxdSDhtN7dBDgL0MaHNkYjRB9yJXAkvhzFUqWxQyEWjBIMUlncIeDRNcP3e+eIQUZEWnqJEOxKy1cJ0UepjOHInXIqxEXqDSUYRFPCKd1Wi+jq2g5VxU89dQ4QoYkdvXwJ0UduqRLHE8qhpOWrpB7QOzT518PLBqnCWS2lHLi0SbV3iR74PA7RoRLYiWllCSH6SMlX4OJDWr5KDI8SDKKSEgPc+rthHqu8SLV8VV6uVzdiAYc+YRKIqA4XIXq5kyFHYjatLCGGRQkGATISVJcu0IDDpIUZwJVtqtUqerC34iE6VAIeDWQQopezieUoLKNJn8RwKMFo7ArSgCt/6v2Hvk4yE4DYg3p342HPR+cA2hiNEH3IFKrlqwolzccghkEJRmNWXgxc+s+W6w0t8QKQeFHvbkLchGjuSctXCdFHdokSlx/RfAxiGJRgNFYVe4XoOdnSIGL3qy7T6KmtjxB+TjQhgxB93E6XIymH5mMQ/VGC0Vjd3AvkPjJ2FCqMqUqSF2bo1Q3HcegeLIaLDb2sCdHHmQflKCqn+RhEP/RO3Bg9OA88vmbsKDTJy1UrS8qL9OpGwOPQO1QMaxHN+iSkrqT/zMdQ0nwMogdKMBqbzHtAnP4TK+tFaf4/c0L0G561EvHQJ0wCIb26TcLhrb9izvhOmNLLE1N6eWLepN64fuaAxjEpD27ju3fH4LXeXpjSywPzXu6F7LSqR9iO7ViF+a/2w9S+Ppja1wdfvT4U92IuaRxzZt8mvDWsKab188XGxXM07stMeYhZz7RGaVGB4U7UwmQVK3HlMc3HIHXHMUYl3BqNoizg9Eq960/UO88IoM3TAKffKMTjPDmOxpc35OJbosXVk3vB4/HRxDcIAHBqzzrs/eMHzPv9NHyCIpD++D4+eykaUcMnoHP/0bCytUfKgzsIimgLe2d3rX0u/eRlhLbqjJBWnSEUibH39+9x+dguzN9wEc7uXijMy8Jbw8Mx+eOlcPMOxLdvj8IrHy1F6+4DAQDfvPkUokdMRPteIxrqaTBbvcPE8HGk0vxEd5RgNBZyKXBqBVCcbexIaiekO9C0l97dxKXJcDGJPoWZmmn9fDH2jS8QNfxF/DLnRfAFQkz5bEWd+1MqFJja1wcvvLcI3Qc/h3sxl/DDu2Ow+O/7AICf50xAYHhbDH7hTZzdvxnnD27Fm99sMtTpWDQrIYcRLa0gEtBlR6IbGkRuLGL2mU9yAaj2RHl8Xe9umnkI0dSdPn2ZCqVCgXMHtqC8tBghLTpCqVTi+pn98PALwf9mjMDrAwPw2cvRuHz8L536LS8rgUIhg629EwDAwzcY5WWleHjnOoryc/Ag9gp8Q1ugKD8H25Z/gRfeW1Qfp2eRSmWMknRSJ5RgNAbJNw3yx7rB3dwD5CTp3U0HfxG8HGj5qjE9SriFV6ObYFIPZ6z56k3M+GoDvIOaoSA3E2UlRdi99lu07NIP7y3ehXZRw/Dj+8/h9pWTte5/y8+fwMnNCxEdVKNeNvZOmDx3GZZ/NhmfvRyNboOfRcvOfbFx8Rz0Gz0FmSmJ+PiFrpj9bAdcPLy9vk7bYtzLkiM5j5auEt3QJRJLV5wDnPpVdYnEHAmtgG4vAzbOenUjVTDsiy1FXim93I1BLpMiO+0RSorycfHITpzYtRofLtkHaztHvDk0FJ37j8bUz1epj//u3TEQS6wx7YvVNfa95/fvsGftt/jgl7/hF9qiyuPiLp/Aph8/wodL92HWqFaY+vkqOLg0wWcvRePrP69VOd+DqNiIOAxvaQUhny6VkNqhEQxLplSo6kuYa3IBALJS1fJVWale3Yj4HHqHSSChqyVGIRCK0MQ3GIHN2mLM9M/gG9oSBzb9AjtHF/D5AngFhmsc7xXQFNnpj2vsd+8fP2D36m/w3uKd1SYXMmk51n79FiZ+sBjpj+5DoZAjvG0PePqHwcMvpNIKFFJZsZRRlU+iE0owLNntI0B+qrGj0F9xNnD5T1XCpAdbMQ+9wiSgD2AmgDHIZVIIhCIERrRD2sO7GnenJd2Fq4dvtV3s/f177Fr5Fd75fjsCm7Wt9tidK79Eq679ERDeGkypgFLx72tJIZdBqedrq7GIz5Ajs4ieK1I7lGBYqowE4ME5Y0dhONmJwK29enfjZstH1yCx/vGQWtvyy6e4c/U0MlMe4lHCLfy55FPEXTmJLgPGAgAGPT8T5w9txbEdq5D+6B4OblmKa6f+Rp9Rk9V9LPt0Mjb/PFf9/Z7fv8PWZfMw6aNf4Orlj7zsdORlp6OspHKhtsf3Y3Hh4DY8/epHAABP/zBwHIfju9bg2ql9SH0Yj8Bm7er5WbAc5x5IoaQr66QWaMDYEpUVAdd3GjsKw3t0DbBxAYK76tVNoIsAhWVKXEs24iZvjUhBTgaWfzYZeVlpsLK1h29IC7z7/Q606NQbANA+ejgmvv8Ddq9ZhD++fQ+efqF4Y+E6hLX+9+eck/4IPN6/n4eObP0VcpkUP334vMZjjXzlQzw1+d+iWowxrFo4A8+99SXEVjYAAJHECpM/WYa1/3sbcmk5nn93EZzdverzKbAouaVKxKbJ0MKTdjAm1aNJnpbo0iYgPd7YUdSfdqMBj/Caj6vBqXvluJ9NM+MJ0ZWABwxvaQVbMQ2Ck6rRq8PSpMZadnIBANd2GGRuSZdAEdzt6FeAEF3JlcDFhzThk1SP3l0tibRUVVDL0ilkqpUlpfrtI8HncYgOkcBOTLM+CdHVozwF0gtpwiepGiUYliTuAFBebOwoGkZ5EXBpo95LcCVC1fJVEdXhIkRnV2jZKqkGJRiWIvMe8PiGsaNoWAXpqjofek4jcrDiISpUAh4NZBCik8wiJZJyaB4T0Y4SDEsglwI39V/CaZYy7hpk+3lPez46+dOseEJ0deUxLVsl2lGCYQnuHAVK84wdhfE8OA88vKx3N6HuQjT3EBogIEIaj4IyhoRMGsUglVGCYe7ykoHEi8aOwvhi9qkuE+mpra8Qfk40IYMQXVxPlkGmoFEMookSDHPGGBCzHwD9YoMpgStbgcJMvbrhOA7dg8RwsaZfDUJqq1TGEJdGheuIJnoXNWcpt1QjGERFXq5avqrnShoBn0OvMDGsRTTrk5DaikmVoUxGH3bIvyjBMFcKmWozM6KpNA+4tBlQ6HdN2FrEQ+9QMQT0G0JIrciUwPVkWrZK/kVvn+bq/jmgTL9CUxYr7zFwY5fey1edbfjoESwGjWMQUjt3M+UoKlcaOwxiIijBMEdlhcC908aOwrSlxAB3j+vdja+TAO38aPkqIbWhZKC5GESNEgxzdOeo6hIJqd7dk0DyTb27ifAQIsydNh4mpDbuZsohldNcDEIJhvnJT218FTv1ceMvIOeR3t109BfB056WrxJSE7kSuJNBH4AIJRjmJ+4QaFmqDpQK4PJmoCRXr254HIeoEDEcrGhGBiE1uZ0uh0JJ71ONHSUY5iTrPpCdaOwozI+0BLiwAZCV6dWNSKDaGE1CV0sIqVapjOFBNlX3bOwowTAnd08aOwLzVZwNXP4TUOo3w91OzEOvUAn4NJBBSLViabJno0cJhrnIfgjkJBk7CvOW/QC4pf+mcG52fHQNEhsgIEIsV14pQ3IejWI0ZpRgmIu7J4wdgWV4dBW4d1bvbgJdBIj0po3RCKlODI1iNGqUYJiDnEc098KQbh8G0u7o3U2ktwiBLrSyhJCqpBUokV2sMHYYxEgowTAHCTT3wrAYcG27asmvnroGiuFmS79GhFSF5mI0XvTOaOryUgyyDTn5D4UMuLhJ73LrfB6HXqES2Ipp1ich2jzMUaCcCm81SpRgmDqae1F/ygtVSYZcvw2aJELV8lUhXS0hpBIlAxJpyWqjRAmGKStIBzLuGjsKy1aQprpcoufGaI5WPESFSMDRQAYhldzLogSjMaIEw5Q9uGDsCBqH9Ph/KqTqx8uBj07+tDEaIf+VVaxEfintstrYUIJhqqQlQMotY0fReDw4ByRd0bubMHchIjyo1Cch/0WjGI0PJRimKukKoKRfyAZ1629VOXY9tfMVwdeRJmQQ8qT72XIwPS9FEvNCCYYpUiqBh5eNHUXjw5SqcuKFmXp1w3EcugeL4WxNv16EVCiRMqQW0GWSxoTeAU1RRrzeyydJHcnLgUubgPJivboR8jn0DhPDSkizPgmpcD+LamI0JpRgmCIavTCuklzVFu8K/S5RWYt46B0mhoB+ywgBACTlKiBT0GWSxoLe+kxNcY5B5gEQPeU+Bm78pXc3LjZ8dA8Wg8YxCAHkSiAxh+aWNRaUYJgaA6xkIAaScguIP653N35OArT1peWrhADAA1pN0mhQgmFKmBJIvmHsKMiT7p4Akm/q3U1zTyFC3Wj5KiHpRUpIqXR4o0AJhinJeqD35EJSD278pdrRVk+dAkTwsKdfOdK4MQakFNAOq40BvduZkmQqrGWSlArVpM+SXL264XEcokMkcJDQjAzSuCXnUYLRGFCCYSoUciD9trGjIFWRlgAXNwKyMr26EQlUG6OJ6WoJacSS86joVmNACYapyIjXe1dPUs+KsoArW1WF0PRgJ+GhV6gEPBrIII1UmRzILqaiW5aOEgxTQZdHzEPWfSDmb727cbfjo2ug2AABEWKeHtNlEotHCYYpkJUBmQnGjoLUVtIV4P45vbsJchWglZfQAAERYn6S8ynBsHSUYJiC1DjVREJiPuIOqbZ511NrHxECnGljNNL4ZBcrUSqjeRiWjBIMU5ASY+wIiM4YcHUbkJ+md0/dgsRws6VfRdL4JOdR0S1LRu9qxiYrBXISjR0FqQuFTLUxWlmhXt3weRyiQyWwFdOsT9K40HJVy0YJhrFl3lNVniHmqaxAtXxVod8ukVZC1fJVIV0tIY1ISoGClqtaMEowjC3jnrEjIPoqSAOubtc7UXS04iEqRAyOBjJIIyFTAPmllGBYKkowjIkx1QgGMX/pd4Dbh/XuxstBgI7+tDEaaTwyi+kyiaWiBMOY8lMBKe09YjHunwWSrurdTVN3IZo1oVKfpHHIKqKCW5aKEgxjotoXlufWXtWmdXpq7yeCjyNNyCCWjxIMy0UJhjFlUIJhcZgSuPynqqy4HjiOQ49gMZys6VeUWLa8UiVkCpqHYYno3ctYpCVAXoqxoyD1QV6mWlkiLdGrGyGfQ+8wMayENOuTWC4G2pfEUlGCYSyZ96D61SIWqSQXuLRZ7wqtNiIeeoeJIaDfVGLBMotooqclorctY8lONHYEpL7lPgJu/KV3Ny42fHQPoo3RiOXKohEMi0QJhrHkPjZ2BKQhJN8E7p7Quxs/ZwHa+tLGaMQy0URPy0QJhjHISvWeBEjMSPxxg+w308JThBA3Wr5KLE+pjKGonJIMS0MJhjHkJhs7AtLQru8yyKhVZ38RPOzp15ZYHproaXnoncoY6PJI46OUqyZ9luTp1Q2PxyEqRAJ7Ca0sIZaloIwSDEtDCYYx5FGC0ShJi1XLV2XlenUjFnDoEyaBmK6WEAtSUEar6iwNJRgNjTEgjy6RNFpFmcDVraqCXHqwk/AQHSoBjwYyiIUopBEMi0MJRkMrzADkUmNHQYwp8x5wa5/e3TSx46NLIG2MRixDQTmNYFgaSjAaGs2/IACQdBl4cF7vboJdhWjpRctXifkrkzEqGW5hKMFoaPlUHpz8I/YgkB6vdzetvYXwd6aN0Yj5o4meloUSjIZWmGnsCIjJYMDV7UBBml69cByH7kFiuNrQrzMxb4U00dOi0DtSQ6MCW+RJCilwcRNQVqhXN3weh15hEtiIaNYnMV8FVGzLolCC0ZDKCgG5fksUiQUqKwAubQIUMr26sRJy6B0mgZCulhAzRSMYloUSjIZURJdHSBXyU4FrO1TLmPXgZM1Dz2AxaByDmCOag2FZKMFoSIV0eYRUI+02cOeI3t14OwrQwZ+WrxLzQ7UwLAslGA2JRjBITe6dAR5d07ub8CZChDehUp/EvJTJAabnKB4xHZRgNCSa4Elq4+YeICtR727a+4ng7UATMoh5KZcbOwJiKJRgNCRaokpqgymBK1uAomy9uuFxHHqGiOFkRb/mxHxI5TSCYSnonaehSEsAWamxoyDmQlam2hhNWqJXN0I+h95hYlgJadonMQ/lVM3TYlCC0VBKC4wdATE3JTnA5S2AUqFXNzZiHnqFisGn33ZiBsppBMNi0FtOQ9GzkBJppHKSgBu79e7G1ZaP7kFiAwRESP2iBMNyUILRUMopwSB1lHwDuHtS7278nQVo40MboxHTJqVJnhaDEoyGQiMYRB/xx4DUWL27aeklQrArLV8lpotGMCwHJRgNhRIMoq9rO4HcZL276RIgQhM7+tUnpokSDMtB7zINhRIMoi+lHLi8CSjJ06sbHo9DdKgEdmJaWUJMDyUYloMSjIZCczCIIZQXA5c2AjL9Ns0TCzj0aSqBiOpwERMj1W/RFDEhlGA0FBrBIIZSmAlc3aoqyKUHewkP0aES8Gggg5gQGdXBsBiUYDQEpULvgkmEaMi8B8Qc0LsbD3s+OgfQxmjEdNBWJJaDEoyGICszdgTEEj28CDy4oHc3IW5CtPCk5avENFB+YTkowWgICqmxIyCWKu4AkHFX727a+Ajh70QTMojxKSnDsBiUYDQEOSUYpJ4wBlzdBhSk69UNx3HoFiyGqw29JRDjou3aLQdV3GkICpmxIyCWTC4FLm0Cur4MSGzr3I2Ax6FXqBgH75TRltnEaMQCmnVsKThG6WL9y7wPXFhn7CiIpXP0AjpPAPg0n4IQYnw0HtoQaA4GaQh5Kapqn/SZgRBiAijBaAg0B4M0lLQ44M5RY0dBCCGUYDQImoNBGtK908Cj68aOghDSyFGC0RDoEglpaLf2ANkPjR0FIaQRowSjISipuD5pYEoFcHkLUJxt7EgIIY0UJRgNgaNlV8QIZKXAxY2AtNTYkRBCGiGqg9EQOMrjiJEU56g2Ruv0vF7dKOSqPEVWRotUSMOT2AJia2NHQXRFCUZDoASDGJODp95d8AWAlR0gsQGk5arBEWmZKumQPvF/PXeRt0i/bViIw6e2IfHRbYjFVoiM6Io3X/kKAb5Nq2136fpxLFr2Nu4lxsDNxQsTx8zC6GGvqe8/e/kgFv44HTm56YjuNhJz3/oVQqFq47rC4nyMn94By74+BE93v3o9v4bgGQK4Bxg7CqIrSjAagpklGAs3n8C2s7G4/TgLViIhujbzxVcT+6Opj6v6mPTcIry/+gAOXL2HvOIy9Gzujx+nDEGot0uV/crkCizccgJrDl9DcnYhmnq74KuX+mNgu1D1MeuOXscHaw6iuEyGSf3b4n8vD1Dfl5iei/4fr8Wl76fA3lpSPydvaawcgdCe+vUhlwP5+YCtLTixGGIrQGyl/VCmfCLx+O+/pY1zxfblG8cxdvh0NG/aAQqFHD+tmoOpH/THthWxsLKy0domOfUBXv9oMJ4eNBnz3/8D12JOY8GP0+Dk6Ia+PUZBqVRi9pfj8fLYD9Cl/QC8N+8ZbN37K8aNmA4A+OHX9zF66GsWkVwQ80UJRkMwszkYx28lYvqQTugQ6g25Qok5vx9C/4/XIHbJG7CRiMAYw8gv1kMo4GPnR8/B3lqMb3ecQd+PVquP0eaj3w/jj6PX8esbIxDu64r9VxLw1PwNOPO/yWgT7Ims/GK88uNOrH7zKQR5OGPIZ38gumUAhnRQfdKb+stf+HJiP0oudNFysP6VPQUC1XWRIweBnBzA1hawtVP9a2f37/9t7cCJRBBbVz2crVSqRj/Ky7SPglhiAvLLwn0a33/27ir0Hu2O2LuX0a6V9uRvy+6l8HTzw6xp3wMAgvybITb+EtZu+QZ9e4xCXn4WcvMyMWb4NIhFEkR1GY77D2MBAFdvnUZs/CV8+MbP9XpeDcnM3kLJPyjBaAhmNoKxb94Eje9XvfkU3Md/hcsJKejZIgB3U7Jx7s5j3Pr5dTT3dwcA/DJ1KNyf/wobjt/EKwPaae3396PXMWdMTwzuEAYAmDq4I/ZfScCi7afxx7vP4H5aLhysJRjbsyUAoFerQMQmZWJIh6ZYf+wGRAIBnu4aUY9nbmG8mgNuwYbpy9UVGDQUeJgIXL4APKpiCaxI/ETiUZGI/Pt/nlAIsQ0g1v7BHUqF9ksvFf9aQkmZouJ8AICDnXOVx9yIO4vO7fpr3Na1/QDs2PcbZHIZnBzd4ObsibOXDqBzu364cuskhvd7ETKZFAsWT8Wn76wEn29Bu+NSgmGWKMFoCGaWYPxXfnEZAMDZVjUuXi5TLbuViP59+fD5PIgEfJyKfVhlglEuk2u0AQArkRCnYpMAAKHeLigpl+HqvVT4uzvgYnwyXu7bBjmFJfhk3REcXfCSwc/NYgkkQET/mo/TlX8A4OsHxMUC16+qJmQ8SVoO5JQDOVUsjxVLqk9ABAJIbFRzPbRRyFXJhqwUKP9n0qlGAmLim7QxxrBo6dto06I7QgJbVHlcVk4aurZvonGbs1MTyBVy5OVnwc3FE19/vBn/W/IWvl4yE907DMaIgS9j5YaF6NimD8RiK7w4sxvyCrLw7Ig3MG7k6/V9avWKRjDMk3n/5TMXZvzbwRjD2yv2oXuEH1oEqN7wwn1c4e/uiA/XHERuUSmkMjm+3HICablFSM0prLKvAW1D8O2OM7ibnA2lUomDVxOw8/xtdRsnWyuseespTPh2Kzq+vRwTekdiQLtQvPvbfrwxtBMepOeizYxf0GLaT/jzVEyDnL/ZatYHENd9Z9Vq8XhA8xbAqDFARAvV97VVXgZkZwGJD4BbN4FzZ4BD+4EdW4E/VgMb1wG7dwLHjwCXLwJ34oDkx6o5IAqFarKpLWDvBrj5AV5hQEAkENYJaBGt+grrBAS0Ut3n6qs6VmIL8EzgA/3CH19H/IMb+HL2hhqP5f7zvlGxL2XF7W1adMf6ny9i7+8PMHvGz0hJe4Ddh37H9Imf46OvXsAzQ6dg1bcnsWzdPMTfv2H4k2lAhvqMlpGRgSlTpsDPzw9isRgeHh4YMGAAzp49qz7mzJkzGDx4MJycnCCRSNCyZUssWrQICsW/9YwSExPBcRyuXbtW6TFGjhyJiRMnqr+Pjo4Gx3HYuHGjxnHff/89AgIC1N+vXr0aHMeB4zjw+Xw4OTmhU6dOmDdvHvLz8zXaTpw4UX2sUChEkyZN0K9fP6xcuRJKpVLj2ICAAHz//ffq769evYqhQ4fC3d0dEokEAQEBGDt2LLKysjTabd26FdHR0XBwcICtrS1atWqFefPmIScnp6anWY1GMBqCGY9gvL50D24kpuPU15PUtwkFfGydPQ6TftgB53ELwefx0Ld1EAY9MVlTmx9eHYzJP+5E+NTF4MAh2NMJL/Vtg1WHrqqPeaprBJ564jLIsRsPcPNhOn56bQhCXv0BG957Bh5Oduj49jL0bOEPd8d6+iNqzpx8Ad829f84YjHQsTMQ3gy4dAFIMkDl0LJS1VdWpvb7ra21jnxU/J8v4MHKTrXiRRu57N8RD22jIPVZE+/Ln97A8XO7sHLRCTRx86n2WFdnD2TlpGnclpuXAQFfAAf7yhOpGWOY992reGfKIiiVStxOuIq+PZ6BlcQa7VpG4fKN4wgLamXQ82lIfAP9pRo1ahRkMhnWrFmDoKAgpKen4/Dhw+o/mtu3b8eYMWPw0ksv4ejRo3B0dMShQ4cwa9YsnDt3Dps3b66U+NWGRCLBRx99hFGjRkEorHpOlL29Pe7cuQPGGPLy8nDmzBksXLgQq1atwunTp+Hl5aU+duDAgVi1ahUUCgXS09Oxb98+zJw5E3/++Sd27doFgaDyk5aRkYG+ffti2LBh2L9/PxwdHfHgwQPs2rULJSUl6uPmzJmDr776Cm+99RYWLFgALy8v3L17F0uXLsXvv/+OmTNn1uq8TSrBmDhxItasWaP+3tnZGR06dMDXX3+NVq1UvxwKhQKLFy/GqlWrEB8fD4lEgi5duuCjjz5Ct27dNPorLS3Fl19+iY0bNyIxMRF2dnaIjo7GZ599hubNm6uP+/TTT7Fjxw6NbPTkyZMYNmwYXnjhBSxevLhOLyo1gbjubY3ojaV7sOv8bZz4chJ8XB007msX4oVrP05DfnEZpHIF3Bxs0OntZWgf6l1lf24ONtjx0XMok8qQXVAKLxc7fLD6IAKbOGo9vlwmx7Qlu/HHO6OQkJoDuUKJqJaBAIAwbxecv/MYwzqFG+x8LQLHU03srMPrNbbkPm6V3EWUfXs0EVW9GqgSewegdz8gLRW4eA7IrsfqoSUlqq+MjMr3cdw/CYj2yy+wsYFAyINACFjba+9eLq1iBcw//zKl9nbVYYzhy5/ewJHT27Him2Pw9gyssU2rZl1w4txfGredvXwAEWHtIRRU/gO1/e/f4Gjvguiuw1FQmKs6l38mrMgVMijMvJowzwB/qfLy8nDq1CkcO3YMUVFRAAB/f3907NgRAFBcXIzJkydj+PDhWL58ubrdK6+8giZNmmD48OHYvHkzxo4dq/NjP/vss/jrr7/w66+/Ytq0aVUex3EcPDw8AACenp5o1qwZhg0bhubNm2PWrFn4448/1MdWjMAAgLe3N9q2bYvOnTujT58+WL16NV555ZVK/Z85cwYFBQVYsWKFOgEJDAxE79691cdcuHABCxYswPfff6+RSAQEBKBfv37Iy8ur9Xmb3EfrgQMHIjU1FampqTh8+DAEAgGGDh0KQPWLOm7cOMybNw8zZsxAXFwcjh8/Dl9fX0RHR2PHjh3qfsrLy9G3b1+sXLkSn3/+OeLj47F3714oFAp06tQJ586dqzKGPXv2YMCAAZg5cyZ+/PFH/ZILABCa16oHxhheX7Ib287E4sj8lxDo4VTlsQ42Erg52OBucjYuJaRgRC3+4EtEQni72kOuUGLrmdgq23y+8RgGtQtF2xAvKJQMcsW/7+4yuRIKJVV8qiSoC2DnrnOzUmU5jhdcwmNpOtZl7cG+3FMoVJTU3PBJHp7A0JFA9yjVH/qGxhhQXAykpwH3ElRzRE6fAPbvBbZuAn5fBfy5Edi3Bzh1HLh2BUi4q0qMiosAxiAQAdYOgGMTVd0Fn3AgqA0Q3gVo1RuI6AGEdAD8WgAeIYCzN2DrrFo1U9VA5YIfp2PP4T+w8MP1sLG2Q1ZOGrJy0lBW/m+F1cW/fYiPvvp3cvXooa8hJeMhvln6Nu4/jMOOfSuxfd9vmDD63Ur95+Rm4Nf1X2DW9MUAAHs7JwT5NcO6bd/jeuxZXLh6GJERXQ36VDc0Q8xXtbW1ha2tLXbs2IHy8soFWw4cOIDs7Gy8+27l53jYsGEICwvDhg01X9rSxt7eHrNnz8a8efNQXFysU1t3d3eMHz8eu3bt0rhMo03v3r0RGRmJbdu2ab3fw8MDcrkc27dvV19y+69169bB1ta2ykTI0dGx1rGb1AgGoJmVeXh44P3330fPnj2RmZmJI0eOqId/hg0bpm6zfPlyZGdn45VXXkG/fv1gY2OD77//HmfPnsXVq1cRGRkJQJWtbt26FZ06dcKkSZNw69atSsnD+vXr8dJLL+F///sfZsyYYZiTMrMRjOlLdmP98ZvY+dGzsLMWIS1XNUfCwVoCK7Hq09OWU7fgZm8DP3cH3ExMx8zlf2Nk52bo3zZE3c+ERVvh7WKPhRP7AQDO33mE5OxCtA7yQHJWAT5dfxRKJcOsUd0rxRDzMAObTtzCtR9VL/JwH1fweBx+O3AZHk62uP04Cx2qGS1plKyd6lzz4kTBZZQqy9Tfx5beR3xZEtrbRKCDbXMIebVc6spxQEgoEBAI3Lqh+pKbyMxLxoCiItWXNjweYGP7z4jHEyMgFRNSrawhFHMQigEbh8rNGXtiBOSJUY8tfy0BALzybrTG8Z+9uwojBkwEAGRmpyI1I0l9n7dnIH76Yi++WfoWNu36GW4uXnh/2mL07TGq0uN+/ctMvPjMu2ji+u/vw2fvrcYnX7+IDdsX48XR76FleEfdnisTY4gRDIFAgNWrV2Py5MlYunQp2rZti6ioKIwbNw6tWrVCfHw8AKBZs2Za24eHh6uPqYtp06bhhx9+wLfffouPP/5Yp7bh4eEoLCxEdnY23N2r/wARHh6OGze0z7np3LkzZs+ejeeeew6vvfYaOnbsiN69e2PChAlo0kQ1x+7u3bsICgqq9lJObZlcgvGkoqIirFu3DiEhIXBxccH69esRFhamkVxUeOedd7Bt2zYcPHgQI0eOxPr169GvXz91clGBx+Phrbfewvjx43H9+nW0bt1afd/PP/+Mt99+G7/99huef16/0soazGwEY8neiwCA6A9Xady+6s2nMLGv6tp+ak4R3l6xD+l5xfB0ssWE3q3x8bgojeOTMvPB4/2bwJVJ5fjo98O4n5YLWysRBrcLxe/vjIKjrWbVJsYYXv1pJ76bPEhdU8NKLMTqN5/C9CW7US5T4KfXhsDbtYpx7saq5eA6Xax+XJ6OmJKESrfLmRznim7gZslddLNvjeZWIbUfzRMIgNZtgbBw4Ool1UiBqdcYVyqBwgLVlzY8fuXko+L/drbgrKwhFEOVgDj+26zikyJjqkqn2pbgfvXJatWCnCeeovaRUdi45EqNYX85p/Kn6pbhHbF9ZZwOJ2/atFwVqpNRo0ZhyJAhOHnyJM6ePYt9+/bh66+/xooVK9THVPXJnjGm12i2WCzGvHnz8Prrr2Pq1Kk6tf3vBN+ajq3uuPnz5+Ptt9/GkSNHcO7cOSxduhQLFizAiRMn0LJlS73P80kml2Ds3r0btraqiXvFxcXw9PTE7t27wePxEB8fX2V2WXF7RYYZHx+PXr161XhsRYIRFxeH119/3fDJBQAIqyh7aKLY7nk1HjNjeGfMGN652mOOffmyxvdRLQMRu+SNGvvmOA6n/ze50u1DOzbF0I7Vl1dutLxaAK5BOjdTMAUO5Vd9uRAAipWlOJB3FleLbiPKoT38xDqUHre2Brr1BJo1By6eB1JTdI7RZCgVQEG+6ksbPv8/SYfmXBBOIoFIAogkALRcdWTKJxIQLVVQG3MZdn1rxT1JIpGgX79+6NevHz755BO88sormDt3rnqlRVxcHLp2rXxJ6fbt24iIUE1Ad3BQDWH9d3UHoJrr4e/vr/Wxn3/+eXzzzTf44osvNFaQ1CQuLg729vZwcal5blRcXBwCA6uf5+Pi4oLRo0dj9OjRWLhwIdq0aYNvvvkGa9asQVhYGE6dOgWZTKb3KIbJJRi9evXCkiWqIcWcnBz88ssvGDRoEC5cuFCr9rXN8P57rI+PDxwdHfH1119j0KBB8PTUf/8GNYFINcanNJGhYmJZhFZ1rnlxoegWcuRV/MH8j0x5Lv7MPoggsQ96OrSDs0DLdYKqOLsAAwarCnRdvFD1H2lzplAA+XmqL20EQs0RkP8mIGIxRFaAqKYy7FUUIpNbaALC4+m2ElpXERER2LFjB/r37w9nZ2csWrSoUoKxa9cu3L17F59//jkAwMnJCW5ubrh48aJ6wiigWlgQExODMWPGVHEuPCxcuBBPP/10rUcxMjIysH79eowcORK8Gp6II0eO4ObNm3jrrbdq1TcAiEQiBAcHq+eGPPfcc1i8eDF++eUXratF8vLyaj0Pw+QSDBsbG4SE/Hsdv127dnBwcMCvv/6KsLAwxMbGam0XF6caDgwNVS2VrO7Y27dvaxwLAHZ2djh06BD69++P6OhoHD16VGNJkN5E1kBZFUOvhOgjvE/VpTGrkSsvwIXCmzq3u1/+GIkZyWhlE4YudpGw4ulwCdDXH/D2VdW3uHYF0DLZzmLJZUBerupLG6HIIGXYq1oBY65l2A01epGdnY3Ro0fj5ZdfRqtWrWBnZ4dLly7h66+/xogRI2BjY4Nly5Zh3LhxePXVV/H666/D3t4ehw8fxnvvvYdnnnlGI3F49913sWDBAjRp0gRdu3ZFbm4uvvrqKwgEgmpHwYcMGYJOnTph2bJl6nkPFRhjSEtLUy9TPXv2LBYsWAAHBwd8+eWXGseWl5cjLS1NY5nqwoULMXToUEyYoFmNucLu3buxceNGjBs3DmFhYWCM4a+//sLevXuxapXqkninTp0wa9YsvPPOO0hOTsZTTz0FLy8vJCQkYOnSpejevbt5LlPVhuM48Hg8lJaWYty4cXjuuefw119/VZqHsWjRIri4uKBfP9WEwnHjxmHOnDm4fv26xjwMpVKJ7777DhEREZXmZzg5OeHQoUMYMGCAOsnw9jbQREKxDSUYxPCc/QDf1nVqeijvHBSow7pLAEowXCu+g7iSB+hk1xJtbMLB52o51Z/HU10yCQoBblwD4mJUfx0bO5kUyM1RfWljyDLsWkZBTLUMu6ESDFtbW3Tq1Anfffcd7t27B5lMBl9fX0yePBmzZ88GADzzzDM4evQoFixYgJ49e6K0tBQhISGYM2cO3nzzTY1R73fffRe2trb45ptvcO/ePTg6OqJz5844efIk7O2rnx/21Vdfab0MU1BQAE9PT3AcB3t7ezRt2hQvvvgiZs6cWanPffv2wdPTEwKBAE5OToiMjMTixYvx4osvVjnSERERAWtra7zzzjt49OgRxGIxQkNDsWLFCrzwwgsa8bVr1w4///wzli5dCqVSieDgYDzzzDN48cUXa/2cc6yqGS1GMHHiRKSnp6szqdzcXPz0009YsmQJjhw5gqioKIwaNQrHjh3D//73P/Tp0wcFBQX4+eefsXLlSmzZsgUjR44EAJSVlSE6OhopKSlYtGgROnXqhPT0dCxYsAAHDx7EoUOH0Lmzag7Bf+tgFBQUYODAgcjMzMTRo0fh41N9UZxaubAeyLynfz+EVODxge6TATs3nZvGlNzD/rzTBgvFgW+LHvbtEGal/dpztQoLgEsXgYcPDBZPo1RDGXZoKbz0JIXinxGQqhIQI13htXNRLRUm5sfkRjAqsjJAddkiPDwcW7ZsQXR0NABg8+bN+OGHH/Ddd99h+vTpEIvF6NKlC44ePYru3f9d7iiRSHDkyBEsXLgQs2fPxsOHD2FnZ4devXrh3LlzaNGi6n0A7O3tsX//fgwaNEg9kuHr66vfiUmqKC1ISF0Fda1TclGqKMPxgksGDSVfUYTducfhXeyOKPv28BC51r6xnT3Qq4+qfsXF81VX8STVKy/7txS7NhIrrZde1FVQ+XzwbVVl1bVRyKvehE5aVn9TzETmtQiPPMGkRjAs2t2TQPwxY0dBLIWNM9BjSp2Wpe7LPY3Y0vodTQu3CkQP+7aw4+s4N4Qx4P494MpFVdEs0nBqKMNe00zLijLs/92ATt8y7B7BQJOai58SE2RyIxgWy7rqapiE6KxF3WpeJJWn1XtyAQC3Sx8goSwJbW0i0NG2BUS6FOoKDlHt2hp7C7h5HZCZ6OQAS2OgMuyorgx7FStgZKVVT8OhEQzzRSMYDSX3MXBmVc3HEVIT71ZA6xE6N5MzBX7P+Au5ioadbGzNk6CrXWu0sA4BT9eN/0pLgKuXgbvxpl+oqzHjOMDGRnsCYmcHWNvUuD+OrLxy0iEtU41gVLV3DDFtlGA0lPJi4NC3xo6CmDuhFRA9TbXsWUdnCq7hXJHxtu12FTgiyr49/CV1WP6dm6Oan5GSbPjASP2rqgx7RQJiZV2nDfqIaaMEoyHt+9J014IR89BqOOAbWfNx/5Ejy8fvmX/VeVmqIQWIvRFl3w4uQkfdGz9+BFw6D+iwoyMxAzw+YGvzROLxT/Lh6Kgq0kbMEiUYDenEUqCQZsiTOnL2B7poL6BTHcYYNmcfQLI0vR6CqhsOHFpah6KrXWtY83W8yK5UAvG3VYW6yspqPp6YLy9voP8gY0dB6sjktmu3aDTRk9QVj6/azKwOYkoTTCq5AAAGhhsl8ViZsR0XCm9BznRYYsDjAeERwNNjgBatVM8NsUz2OpSjJyaHEoyGRAkGqavgboCtDrUl/lGiKMOJ/Mv1EJBhSJkMpwqvYHXGTtwp1bHQlkgEtO8IPPUMEKD7Rm/EDNjR7E5zRglGQ7J2NnYExBzZuAAh3Ws+TovjBZdQxkx/E4oCRRH25J7Ehsy/kSLV8TKinR0Q3RsYPAxwc6+fAIlx1FBym5g2SjAakn2Tmo8h5L9aDqnTZYCk8lTEld6vh4DqT6osExuz/saenBPIlxfp1ti9CTBkOBDVSzVB0EiSc3Px/LIVcHn9TVhPmY7Wn3yGy4kPqzw+NS8Pzy39FU0//Ai8l1/Fm+s3VjrmYEwswj6YA4dpM/Diryshlf9bNjO/pARhH8xBUnZ2vZyPUVGCYdYowWhI9k0A0FIsogOfSMBF9/095EyBQ3nn6iGghnGnLBGrM3bgRMFllCt1HIEJDAaeGg206wAIDbRTVi3lFhej2/yvIBTw8ffbMxE7/zMsGjcGjtZV7MEOoFwuh5udHeYMHYxI38r7HimVSoxftgKv9YrCmTnv48KDB/j1+En1/e9v2YrXekXBz8XCVltwHF0iMXNUybMhCUSqEs/FFvhJgxieyBpo1q9OTc8X3kCeotDAATUsBZS4VBSDmJJ76GoXiZbWobUv1MXnAy0jgdAw4OoV1aqTBlgw99XeffB1dsKqSS+pbwtwrX7uTICrK34YPw4AsPJk5Q3osoqKkFlYiGm9e0EiFGJ460jEpqQAAE7fTcClxIf4+YXxBjwLE1GL8uTEtNFPr6E5eBg7AmIumvUFRFV/8q1KtiwPl4pi6iEg4yhVluFw/nn8nvkX7pc91q2xxAro0g0Y8TTgbYBdkWuw69p1tA8MwOifl8J9xttoM3cefj1+Qq8+3ezs4OnogAO3YlAqleJkfAJa+fhAKpdj6to/sHTC8+Bb4h9iWkFi9izwVWni7CnBILXgEqi6PKIjxhgO5Z8ziYJahpYtz8eOnCPYmn0QWbJc3Ro7OgH9Bqq+nOpvNdf9jEwsOXIMoU3csf+dN/FadBRmrNuItafP1LlPjuOweeoUfL5rNyLmfII2/r54uUc3fLnnb/SJaAYrkRDd5n+Jph9+hJ8OHTHg2RgZTdg1e3SJpKFRgkFqwhMALetWXOhmyV0kS7VsVmVBHpan4vfM3WhhHYKudq1hw9dhlMfbB/D0AhLigSuXgbJSg8amZAztAwKw4JmnAQBt/P0Qk5KCJUePY0K3rnXut3tYKC7O/Uj9fXxaGn4/cw5XP/sYPRf+D2/274OBLVugxUefomfTMLTSMpfD7LhTgmHuaASjodElElKTkO6qpak6KlGU4mTBlXoIyPQwMNwsuYtVGTtwvvCG7oW6wsKBUaOBVpGq+RoG4unogAgvT43bmnl6Iik7x2CPwRjDq6t/x6Jxo6FkDFeTkvBM+3Zwt7dHVNMwHL9zx2CPZTQcRyMYFoASjIYmsgYkNDOaVMHWFQiu2yfdYwWXUG4GNS8MScpkOF14DasydiCu5D502vlAKALadlCtOAkKNkg83UJCcCctTeO2+PR0+BtwhcdvJ07BxdYWw9u0huKfPc5lCoX6X4XSAnZ/cHRU/XyIWaMEwxhoFINUpY41LxLLUnBb10qYFqRQUYy/805hfdZeJJfrWBbd1hbo2QsYOkJVS0MPb/Xvi3P3H2DB7j1ISM/A+rPnsfzYCUzvE60+5sMt2zDh19802l1LSsK1pCQUlZcjs7AQ15KSEJucUqn/jIICfPHXHiz+Z9WJk40Nmnl54vsDh3A24R4Ox8Wha4hhkiWjcqOaQZaANjszhvvngLiDxo6CmBrfNkCroTo3kzE51mbsQr5Cx8JUFixU4oce9u3gKLDTvXHiA+DyBaCwbst8d1+7jg//3I676ekIdHPF2wP6YXJUT/X9E1esRGJWNo598J76Nu6lyZX68XdxQeI3X2rc9uzS5egWEoLX+/ZW33bh/gO8uGIlMgoKMbNfH3wyYlid4jYp3aOAkFBjR0H0RAmGMeSnAqdWGDsKYkpENkD0VECo+7LUkwVXcLHoVj0EZd744KG1TTg62bWChKfjcLtCAcTFADeuAdLGddnJJDw9mpapWgC6RGIM9h6AUMctqolli+hXp+QiS5aLy0Wx9RCQ+VNAicvFsViZsR1Xi+KgZDos3eXzVTu1Pj1GtXMrRxV4G4xEQsmFhaAEwxg4DnDWvfwzsVCuQYB3S52bMcZwKO8clBZY88KQypTlOFpwEWsyd+Fe2SPdGkskQOeuwMhRgK9f/QRINNHqEYtBCYaxuAQYOwJiCngCoOXgOjW9URKPFJmOO482YrnyAuzMOYotWQeQIdNx2aiDI9CnPzBgMOBsYXt+mBo9J9oS00EJhrHUYQMrYoFCewDWuleWLFaU4lTB1XoIyPI9kqZhXeYe7M89jSJFiW6NPb2AYSOBbj0AK+t6ia/RowTDYlAlT2Oxc1fVxJDq+AZHLIedGxDUpU5Nj+VfbHQ1LwyJgSGm9B7iyx6ivW1ztLdpDiGvlm+HHAeENgUCgoBbN4CYm8AT26cTPfB4gEv1m8MR80EjGMbCcYAzXdNt1FrUrebFg7Jk3ClLNHw8jZCMyXG28DpWZexATMk9HQt1CYE27VSFuoJpSaVBOLsAAvrcaykowTAml0BjR0CMxa8t4OyrczOZUo7D+efrIaDGrUhZgv15p7E+ay8elafV3OBJNjZAjyhg6EigCRXR0wtdHrEolGAYk3uIsSMgxiC2BcL71Knp2aLrKKCCWvUmXZaNLdkHsDPnKHLlBbo1dnUFBg0FevUF7Gk7gDqhBMOi0FiUMVk7qmpiFOj4iYmYt4h+daqDkinLxRWqedEg7pU9woOyZETaNEVnu1aw4olr39g/QLWkNS4WuH4VkJbXW5wWhccDvLyNHQUxIBrBMDaPcGNHQBqSWzDg1ULnZqqaF2ehBBXebShKKHG1OA4r07fjclEsFLoU6uLxgOYtgFFjgIgWqu9J9Ty8ABFtcGZJ6FVvbJRgNB58IdCibjUvrpfcQaosy8ABkdooZ1IcL7iENRk7cbc0SbfGYjHQsbOqUJcfLU2vFj0/FocSDGOzcwNsnI0dBWkIoT1Ul8V0VKQooZoXJiBPUYi/co9hc9Z+pEuzdWts7wD07gcMHAIYcOt2i0IJhsWhBMMU0CiG5bNzBwLrVvPiaP5FSJnMwAGRunosTce6rD3Yl3sKhboW6vLwVK026R4FWFOhLjVXN3o+LBAlGKagCSUYlo0DWg6p03X4+2WPcbfsYT3ERPQVW3ofqzJ24HTBNciUOiSAHKfaivzpMUDrtlT3AQD8AowdAakHlGCYAkcvQGJn7ChIffFrCzj56NxMppThCNW8MGlyJsf5ohtYmbEDN4vv6laoSyBQJRhPjwFCwxr3jq16XB4ZNmwY+vbtq/W+s2fPguM4XLlyBRzH4dq1awCAxMREcByn/rKzs0Pz5s0xffp03L17V6OP1atXaxxb8SWRaK4Ee/ToESZNmgQvLy+IRCL4+/tj5syZyM7WvJwWHR2t7kMsFsPb2xvDhg3Dtm3bKsXPcRx27Nih/v7o0aPo1asXnJ2dYW1tjdDQULz44ouQP1FJljGG5cuXo1OnTrC1tYWjoyPat2+P77//HiUlDVs5mhIMU8BxNIphqcS2QHjvOjU9U3gdBYpiAwdE6kOxshQH88/ij8zdSCpP1a2xtTXQradqjxNPr3qJz6Q5OgGOjnVuPmnSJBw5cgQPH1Ye6Vu5ciVat24NZ2ft89wOHTqE1NRUXL9+HQsWLEBcXBwiIyNx+PBhjePs7e2Rmpqq8fXk492/fx/t27dHfHw8NmzYgISEBCxduhSHDx9Gly5dkJOjubne5MmTkZqaioSEBGzduhUREREYN24cXn311SrPMyYmBoMGDUKHDh1w4sQJ3Lx5Ez/++COEQiGUyn9XOL3wwgt48803MWLECBw9ehTXrl3Dxx9/jJ07d+LAgQO1ek4NhcbmTIV3S+DhRWNHQQyt+YA61bzIkOXganFcPQRE6lOmPBd/Zh9EkNgHPe3bwVnoUPvGzi6q3VofPQQuXgAK8usvUFMSFKxX86FDh8Ld3R2rV6/G3Llz1beXlJRg06ZNWLBgQZVtXVxc4OGhqr4aFBSEYcOGoU+fPpg0aRLu3bsHPl9Vyp/jOPVx2kyfPh0ikQgHDhyAlZUVAMDPzw9t2rRBcHAw5syZgyVLlqiPt7a2Vvfn6+uLzp07Izw8HC+//DLGjBmjdUTm4MGD8PT0xNdff62+LTg4GAMHDlR/v3nzZqxbtw47duzAiBEj1LcHBARg+PDhKCjQsXicnmgEw1Q4eQO2bsaOghiSeyjgGaFzM8YYDlLNC7N2v/wx1mbuwuG88yhVlunW2Ndftay1UxfVMldLFxikV3OBQIAJEyZg9erVGpeotmzZAqlUivHjx9e6Lx6Ph5kzZ+Lhw4e4fPlyrdrk5ORg//79mDZtmjq5qODh4YHx48dj06ZNNV4+e/HFF+Hk5KT1UklFX6mpqThx4kSVfaxbtw5NmzbVSC4qcBwHBwcdEl4DoATDlPhGGjsCYih8IdB8YM3HaXGt+DbSZTougyQmRwmG6yV3sDJ9By4VxUDBFLVvzOMBzZqr5mc0b2m5hbpc3QA7/cuqv/zyy0hMTMSxY8fUt61cuRJPP/00nJycdOorPFx1uToxMVF9W35+PmxtbTW++vfvDwC4e1c196ZZs2Za+2vWrBlyc3ORmZlZ7ePyeDyEhYVpPO6TRo8ejWeffRZRUVHw9PTEU089hZ9++kljVOLu3bto2rSpDmdbvyz0VWumvFsBHP1ILEJoVJ1qXhQqSnC68JrBwyHGU86kOFFwGaszdiK+NFG3xmIx0KET8NQzgL8Fbo6o5+WRCuHh4ejatStWrlwJALh37x5OnjyJl19+Wee+KkYauCcm3drZ2eHatWsaX6tWrapzf9UdW9VxfD4fq1atwuPHj/H111/Dy8sL8+fPR/PmzZGamlpje2Ogv2amRGyjGlYn5s2+CRDYqU5Nj+ZfoJoXFipfUYTduSewMetvpEp1rMpqZw/06qPaTM3VQi6lchwQoN/lkSdNmjQJW7duRUFBAVatWgV/f3/06aP7poJxcaq5T4GB/yZ0PB4PISEhGl/e3qp9U0JCQsBxHGJjte8TdPv2bTg5OcHV1bXax1UoFLh7967G42rj7e2NF154AT///DNiY2NRVlaGpUuXAgDCwsLU8ZsCSjBMjW9rY0dA9MIBLYfWaUj7XtkjJJTpWIqamJ0UaSY2ZO3F3tyTKJDruDNuEw9gyHCgR7Rqm3hz5uFp0OJaY8aMAZ/Px/r167FmzRq89NJLOn+aVyqVWLx4MQIDA9GmTZtatXFxcUG/fv3wyy+/oLS0VOO+tLQ0rFu3DmPHjq0xljVr1iA3NxejRo2qdbxOTk7w9PREcbFqtdlzzz2H+Ph47Ny5s9KxjDHk5zfsxGFaRWJq3ENUSxvLaUtus+TfXlXXREdSqnnR6NwufYC7pUloZ9sMHW1bQsQT1q4hxwHBIapdW2NvATevAzIzHPUKNuxora2tLcaOHYvZs2cjPz8fEydOrLFNdnY20tLSUFJSglu3buH777/HhQsXsGfPHvUKEkD1xzktrfKu1+7u7uDxePjpp5/QtWtXDBgwAF988QUCAwMRExOD9957D97e3pg/f75Gu5KSEqSlpUEulyM5ORnbtm3Dd999h6lTp6JXr15aY122bBmuXbuGp556CsHBwSgrK8PatWsRExODH3/8EYAqydq+fTueffZZfPzxx+jXrx/c3Nxw8+ZNfPfdd3jjjTcwcuTI2j+peqIEw9RwPNWS1ftnjR0J0ZXEDgjX/uZQkzOF13QvO03MngIKXCi6hVslCehq1xotrEPAq+08LIEAaNVaVaTr6mXgbjygS6EvY7Ky0nv1iDaTJk3Cb7/9hv79+8PPz6/G4yuWg1pbW8Pf3x+9evXC8uXLERISonFcQUEBPD09K7VPTU2Fh4cHQkNDcenSJXz66acYO3YssrOz4eHhgZEjR2Lu3LmV6nD8+uuv+PXXXyESieDi4oJ27dph06ZNeOqpp6qMtWPHjjh16hRee+01pKSkwNbWFs2bN8eOHTsQFRUFQDXPY/369Vi+fDlWrlyJL774AgKBAKGhoZgwYQIGDBhQ43NiSBzTqfQcaRDF2cCxX4wdBdFV22cAT+0zyauTLs3G+qy9YLQstdFzETgiyr49AiR1KLiVmwNcPA+kJBs+MENr0w6IrN0lCGK+aA6GKbJxocme5qZJWJ2SCyVT4mD+WUouCAAgW56HbTmHsC37ELJlebo1dnIG+g8C+g7QqzJmvePzgaZUubgxoATDVAXVbedNYgR8kV41LzJkOTUfSBqVxPIUrM38C4fyzqFEUVpzgyf5+ALDnwY6dwUkuleRrXdBIYDEqubjiNmjBMNUufgDDpWv+RETFBYFWOleIa9QUUw1L0iVGBhulMRjZcYOXCi8CbmuhbrCI1SFulq0Anj8mts0lIgWxo6ANBBKMExZUGdjR0BqYu8BBHasU9Mj+echY/KaDySNmpTJcKrwKlZn7MTt0ge6NRaJgPYdVYW6DFhzos68vAEdK2sS80UJhinziKjTJ2PSQDgOaDW0TtVX75Ym4V7Z43oIiliqAkUR9uaexIbMvUiRVl92uhI7OyC6NzB4GODmXj8B1gaNXjQqlGCYMh4PCKjbp2PSAPw71OkyllQpw9H8C/UQEGkMUmVZ2Jj1N3bnHEe+roW63JuoCnVF9QJsbesnwKo4OADePg37mMSoKMEwdX5tAEEj2FHR3EjsgaZ1q3lxqvAqipRU84LoJ77sIVZn7MCJgssoV0p1axwYDDw1GmjXARDWssCXviJaqEb9SKNBCYapE4gBv7bGjoL8V/OBgECkc7M0aRauF9+ph4BIY6SAEpeKYrAyYweuFd+Gkilr35jPB1pGAqPGAE2b1e8ff7HY4JU7iemjBMMcBHZWbf9NTEOTpoCH7lsiK5kSh/LPUc0LYnClyjIcyb+A3zP/wn1d5/ZIrIAu3YART9ffJYym4arKo6RRoQTDHEhsgYAOxo6CAKpRizrWvLhSHEc1L0i9ypbnY0fOEWzNPohMWa5ujR2dgH4DVV+GXOlRsWSWNDqUYJiL4K40F8MUhPUCrOx1blYgL8LZwuv1EBAhlT0sT8UfmbtxIO8MinUt1OXtAwx7Cuja3TAFsQICAWsz3/mV1AklGOZCaEXVPY3NwbPOI0mHqeYFaWAMDLdKErAyYzvOF97Q7fXH4wFh4cCo0UCrSNV8jbpq3rLubYlZowTDnAR2AkT0ScAoOA5oOaROE+HiSx/iQbkZbEBFLJKMyXG68BpWZ+xAbMl96LS/pVAEtO2gWnESFKz7gwcGAS6uurcjFoESDHMiEAEh3YwdReMU0KlONS/KlVKqeUFMQqGiBPvyTmF91l4kl6fr1tjWFujZCxg6QlVLozZ4PKBte90DJRaDEgxz49eOqns2NCsH1X4jdXCq4CqKlTpeAyekHqXLsrEpez925RxDnrxQt8aubqpqoNF9VNVBq9M0HLDTfb4SsRyUYJgbvgAI6WHsKBqXOta8SJVm4kZJfD0ERIj+EsqSsCZjJ47nX0KZroW6AgKBkc+o9jkRafndEAqByDaGCZSYLUowzJFvJGBL1zUbhEc40CRM52ZKpsTBPKp5QUybAkpcLo7FyoztuFIUp3uhrhatVDu2hkdozk9q0Yq2ZCfgmE4zfojJyLoPnF9n7Cgsm0AMRE0FJDUMBWtxsfAWThZeqYegCKk/TgJ79LRvh2CJr+6N8/OASxeArExV0tFQJciJyaIEw5xd2gykU9npetN8YJ2WpebLi7AmcxfktCyVmClfkQeiHNrDXeise+PSUsCKRi8IXSIxbxH9AR6V360Xjt6Af91mwB/OP0/JBTFrj6RpWJe5B/tzT6NIoePGfJRckH9QgmHOrB1VFT6JYXE8oOXgOtW8uFP6AIlU84JYAAaGmNJ7WJWxA2cLr0OmpKSZ6IYSDHMX3A2wrsMwJqlaYCfA3kPnZuVKKY7lX6qHgAgxHhmT42zhdazK2IGYkgTdCnWRRo0SDHPHFwAt6rb5FtHCyrHONS9OFlyhmhfEYhUpS7A/7wzWZe3Bo/I0Y4dDzAAlGJbALRjwpN0KDaLFIICv++z3FKp5QRqJDFkOtmQfwOG888YOhZg4SjAsRUR/QCAxdhTmzTMCcA/RuZmCKXEw72w9BESI6fIWuxs7BGLiKMGwFBI7oPkAY0dhvgRiIKJuz9/lohhky/MMGw8hJsxL5IZwq0Bjh0FMHCUYlsSnlaryJNFdeB9AYqtzszx5Ic4V3aiHgAgxXdH2uteHIY0PJRiWpuUQQExbuuvE0Qfwa1unpqqaFwoDB0SI6WppHQoPEW1VQGpGCYalEVmrkgxSO3rUvLhd8gAPy1PqIShCTJMNzwo97NsZOwxiJijBsERNmgI+kcaOwjwEdQbsm+jcrExZjmMFF+shIEJMV7RDe0h4uu8sTBonSjAsVcQAwMrB2FGYNmsnILRnnZqeLLiCEmWZgQMixHQFir3RlCZ2Eh1QgmGphGKg1XBjR2Ha6ljzIrk8HTdL7tZDQISYJiEnQB+HTsYOg5gZ2inLkrkGAEFdgPtUo6ESr+aqAmU6UjAlDuWfq4eATM/hH//Czb8vIyMhFUKJEP7tQzF09hi4h3iqj9nw5q+4tOWURju/NsGYufuTavs+8et+nFl7BLkp2bBxskPkkPYY/OFoCCWq4ffL285gz4ItkJaWo9O4nhj28Th125xHmVj27P/w1t+fQWJHG2s1hC52kbAX6L7KijRulGBYuqa9gbxkICfJ2JGYDqFEVZisDi4V3UK2PN/AAZmme+fuoOuLfeDXOhBKuRJ7v/oTy5/7H947thBia7H6uPBeLTH221fU3wuE1b+tXN52BnsWbsHYRZMQ0D4EmffTsPGtFQCAEZ+NR1FOITa/txLjvp0MF383/DbhWwR3CUdE39YAgK0frsGQ2WMouWgg7kJntLVpZuwwiBmiBMPS8XhAm1HAqV+B8iJjR2MawvsAYt0/jeXKC3Cu8GY9BGSaXl33rsb34757BXNbvYHHNx4guPO/9Vb4IiHs3R1r3e/DywkIaB+Ktk91AQA4+7qhzYjOSLp2HwCQ8zADVnbWaDNCNSQf3LUZ0u+mIKJva1zZfhZ8oQCtBrfX8+xIbfDBwwDHbuBxdDWd6I5eNY2BxBZoO0q1JLOxc/IFfNvUqenhvPNQoPHWvCgrUG3kZu2omZzdO3sbc1u9joXdZ2HzeytRmFVQbT+BHcPw+GYikq7eAwBkP8xA3JHraNZHtfLJNdAD0tJyPL71ECW5RXh0/QE8m/miJLcI+77Zhqe+eKEezo5o092+LdyETsYOg5gpjtHeu43H/bNA3CFjR2E8HA/o8Spg56Zz09iS+9iXd6rmAy0UYwwrX/oepfkleH37HPXtV3eeh9hGDCcfV+QkZWLf/7ZBqVDgrb8/g0Bc9QTakysP4q95G8AYoJQr0HVCb4xa+KL6/pt/X8K+b7ZDViZFu6e7YsA7T2Hj2yvgFeEH7xZ+2PHJOijlCvR/+ylEDqWqkvXBT+SJUS59wdWhRgwhAF0iaVyCugC5j4G028aOxDiCutQpuShVluN4waV6CMh8bJvzO1LjHmskFwDUlzEAwDPcB76Rgfii09uIPXy9yssYCWficHjxX3h6wQT4twlGVmI6dnyyDvbujuj31ggAQMtB7dFyUHuNNmm3H+Pp+S9gYbdZeP7nqbBzc8APQz9DUOemsHO1r4ezbrwknAgDnLpRckH0QglGYxM5HCjMBIqzjR1Jw7J2rnPNixMFl1HaiGtebPvod8QcuIrp22bD0cu52mPtmzjCydsVWQ/Sqzxm3/+2od2oruj8XDQAwLOZL6Ql5dgyazX6zBwGHk/zUp68XIZts9fiuR+nIOtBOpRyBYK7qOaAuAV5IOnKPTTvX7fLXkS7vo5dYMe3NnYYxMzRRfnGRiAG2o0G+I2sGl/LQQBf93z6cXk6YkoS6iEg08cYw7Y5a3Hz70uYuvl9uPjVPPpTnFOEvNQc2LtXXeRNVloOjqf5yZjj88DAAC0XbA9+vxPhvVrBp2UAlEoGhUKpvk8hU0CpVFZuROoswioIYVb+xg6DWAAawWiM7NxUkz4vbQQawxQc75aAa5DOzRRM0WhqXmizbfZaXNlxDi+vnAmxrQQFGXkAACs7awitRCgvLsP+RdvRanAH2DdxQM6jLOz98k/YONmixaB/96tYP2MZHDydMOTDMQCAiH5tcHz5Pni38IffP5dI9v1vG5r3awMeX/MzT9qdx7i26wLePvg5AKBJsCc4jsP5Dcdh5+aAjHup8Iuk6pKG4sC3RS+HjsYOg1gISjAaK/cQoMVg4OYeY0dSv4RWQLN+dWp6oegWchpJzQttzqw9AgD45ZmFGreP/fYVdBzbAzweD6m3H+Pyn6dRWlACe3dHBHdthheWTIPE9t8aFXkpOeCeuOzRd+ZwgAP+/nor8tNyYetsh4h+bTD4/VEaj8MYw5ZZqzDi0+fUdTeEViI8+91kbJuzFnKpHE998TwcPKu/bENqR8DxMdw5GmLaa4QYCK0iaexuHwbunTF2FPWn5VDAT/fr87nyAqzN2AUFaPidNA4DHbshwlr36raEVIXmYDR2TXurymZbImc/wLd1nZoeyjtHyQVpNCKtwyi5IAZHCUZjx3GqTdGc/YwdiWHx+EDLIarz01FMyT08kqbVQ1CEmB5PoSuiHaiWCDE8SjCIanVF+zGAjYuxIzGcoK6AravOzUoVZTjRyGtekMbDmifBUOdo8Dm+sUMhFogSDKIitAI6PlenPTpMjo0zENK9Tk2PF1xGqbLcwAERYno4cBjs1JPqXZB6QwkG+Ze1I9BpPCAy8zecFkPqVPPiUXkaYkvv1UNAhJie3g4d4Sf2MHYYxIJRgkE02bkDnZ5XjWiYI+9WgGuAzs3kTIFDeY235gVpXNrZRCDSpqmxwyAWjhIMUpl9E9VIhlBi7Eh0I7QCIupY86LwJnIV1e8CSoglCJX4o6d9u5oPJERPlGAQ7Rw8gY7jVaXFzUWzfnW6vJMjy8fFolv1EBAhpsVT6IZBTt1pEzPSICjBIFVz9DKfJMPZH/CN1LkZYwwH86nmBbF8Dnw7jHDuBQGtGCENhBIMUj0nb6DDs6a9OVpFzYs6iClNQLK06p0/CbEEEk6Ep136wJpvZpc9iVmjBIPUzNkX6Pis6Y5kBHcDbHWv4VGiKMOJ/Mv1EBAhpkPICTDSpQ+cBPbGDoU0MpRgkNpx9gM6TzC9Ohk2LnrUvLiEMiY1cECEmA4Bx8dI597wErkZOxTSCFGCQWrPwQPoOhGwNqHdK1sOUV0i0VFSeSriSu/XQ0CEmAY+eBjmFA1fqnVBjIQSDKIbaydVkuHgaexIAJ9IwMVf52ZU84JYOh44DHHqiUCJt7FDIY0YJRhEd2Ib1eUS10DjxSCyVi1LrYPzhTeQpyg0cECEmAYOHAY6dkeIlYVtYEjMDiUYpG4EItXqEmNt9d6sHyDSvdpotiwPl4pi6iEgQkxDX4fOCLc2YvJPyD8owSB1x+MDrZ8CAjs17OO6BAI+rXRuxhjDIap5QSwUBw79HbuipU2osUMhBAAlGERfHAdE9K/zZEud8QRAy8F1anqz5C6SpRkGDogQ4+ODhyFOPdHCOsTYoRCiRgkGMQy/tkCnF+p/GWtId9V27DoqUZTiZMGVegiIEOMScAKMcO6FMCvdJzwTUp8owSCG4+wLdH8FcKynmeu2rkBw1zo1PVZwCeVU84JYGBEnxCjnPgig1SLEBFGCQQxLYqdaYeLT2vB91/EyTGJZCm6XPjB8PIQYkRVPjNEu/eEtbmLsUAjRihIMYnh8ARA5DGg+EOAM9BLzbaOqJqojGZPjcD7VvCCWxY5vgzEuA9BEpHuJfEIaisDYARALFtABsHMHrm4Fyovr3o/IBmjWp05NzxfeQL6iqO6PTYiJ8RC6YoRzL9jwdV+mTUhDohEMUr9c/IEeUwB3PZbORfQDhLq/mWbJcnGpKLbuj0uIiQmV+GO0a39KLohZoASD1D+xDdBhnOqSCU/HQTPXIMC7pc4PyRjDobxzUFLNC2IhOti2wFCnnhByNPBMzAO9UknDCegAuAQA17YDBek1H69nzYsUWWad2hJiSnjgoa9jZ6pxQcwOjWCQhmXnBnSbBAR2rvnY0B6qzdV0VEw1L4iFkHAijHLpS8kFMUs0gkEaHo+vmlfhHgxc2wWUa9l4zM4NCOpSp+6P5V+kmhfE7LkLnTHMKRoOgnouXkdIPaERDGI8rkFAz1e1z7FoUbeaFw/KknGnLFH/2AgxouZWwRjnOoiSC2LWaASDGJfIGmg9UpVk3NwLlOapyo47++rclUwpx+H88wYPkZCGwgcfvRw6oJVNmLFDIURvHGOMGTsIQgAAcilw77Tq0ohQonPzEwWXaSt2Yrac+PYY6hwFN6Hu844IMUWUYBCLkCnLxbrM3VCCXs7E/DS1CkA/hy4Q8YTGDoUQg6FLJMTsqWpenKXkgpgdMSdCH4dOCLcONHYohBgcJRjE7F0vuYNUWZaxwyBEJ/5iT/R37AY7vrWxQyGkXlCCQcxakaIEpwquGjsMQmpNwAnQ074tIq2bguM4Y4dDSL2hBIOYtaP5FyFlMmOHQUiteAhdMcipO5wE9sYOhZB6RwkGMVv3yx7jbtlDY4dBSI0EHB+dbVuhvW1z8DgqP0QaB0owiFmSKeU4QjUviBkIFHujt0NHOAjsjB0KIQ2KlqkSs8QYQ0xpAk4UXEGZstzY4RBSiS3PGtEOHRBm5W/sUAgxCkowiFkrVZbhRMEVxJQkGDsUQgAAHDi0sQlHV7vWVNeCNGqUYBCLkCLNxPH8S0ilLdqJEXkJ3dDbsRPchc7GDoUQo6MEg1iU+NJEnCy4gnxFkbFDIY2II98OPezbIpQuhxCiRgkGsTgKpsC14js4V3iDtm0n9cqKJ0EXu1ZoZR1Gq0MI+Q9KMIjFKlWW41zhDVwvvgMllMYOh1gQAcdHW5sIdLBtDjFPZOxwCDFJlGAQi5cvL8T5opuILblPiQbRCw88RFgHoYtdJOz4NsYOhxCTRgkGaTQK5EW4UHQLMSUJUFCiQXTABx8trEPQ0a4FJRaE1BIlGKTRKVQU40LhLdwquUuJBqmWkBOglXUY2tlGwJY2JSNEJ5RgkEarSFGCS0UxuFWSQPuZEA0iTojWNuFoZ9MMVnyJscMhxCxRgkEavXKlFDEl93C1+DbyFYXGDocYkSPfDq1twtHcOpgmbxKiJ0owCPkHYwz3yx/jatFtJElTjR0OaUCBYm+0tglHgNiLtlAnxEAowSBEiyxZHq4V30Zc6X3ImNzY4ZB6IOaEaG4dgkibprR9OiH1gBIMQqohVcpwt+whYkru4bE03djhEAPwETVBhHUQmkoCIKS9QgipN5RgEFJL+fIixJbeQ2zJPSpFbmacBPaIsApCM6sg2AtsjR0OIY0CJRiE6IgxhmRpBmJL7yGh7BFtF2+iJDwxmkoCEGEdDE+Rq7HDIaTRoQSDED0omRKPpelIKEtCQukjFClLjB1So2bHt0awxBfBEl/4iDzAp/1BCDEaSjAIMRDGGNJl2apko+wRcuT5xg6pUXATOCFY4osQK1+4C12MHQ4h5B+UYBBST3LlBXhYnoKk8jQ8Kk+jnV0NRMQJ4StuAj+RJ4IkvnCgORWEmCRKMAhpABWjG0nlaXgkTUWyNANypjB2WGZByAngJXKDj6gJfMWe8BC60NbohJgBSjAIMQI5UyBdmoU0WTbSZFlIk2bRypR/OPDt0EToDA+RK7xE7pRQEGKmKMEgxESUKsuQLs1WJR3SLGTIcix+0qg93xZNhC5oInRGE5ELmghdIOGJjR0WIcQAKMEgxISVK6XIlucjW5aHHHk+cuUFyFUUIF9eBKWZ7AQr5ARw5NvBSWD/z5eD+v8S2u+DEItFCQYhZkjJlChUlKBIUYJiperfQkUJipQlKFaU/nN7ab2XORdzItjwrWDDs1L/a8u3Vv/fUWAHW5417e9BSCNECQYhFowxBimTQcpkKFeq/pUqpZAyGWRMDgaGJ98BGDTfDgScACJOACFPABEnhJATanzP5/gNfEaEEHNBCQYhhBBCDI6mZhNCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQYhHOnDkDPp+PgQMHatx+7NgxcByHvLy8Sm1at26NTz/9VP19QEAAOI4Dx3GwsrJCQEAAxowZgyNHjmi0S0xMBMdxuHbtmsbta9asQceOHWFjYwM7Ozv07NkTu3fv1hrPk4/TvHlzLF++XOs5DR48GE5OTpBIJGjZsiUWLVoEhaJyFdjdu3cjOjoadnZ2sLa2RocOHbB69eoa4y4sLER0dDTCw8Px6NGjSv0SUleUYBBCLMLKlSvxxhtv4NSpU0hKSqpzP/PmzUNqairu3LmDtWvXwtHREX379sX8+fOrbffuu+9iypQpGDNmDK5fv44LFy6gR48eGDFiBH766adKx9+5cwepqamIjY3FlClTMHXqVBw+fFh9//bt2xEVFQUfHx8cPXoUt2/fxsyZMzF//nyMGzcOT87P//HHHzFixAh07doV58+fx40bNzBu3Di89tprePfdd6uMOTMzE7169UJRURFOnToFX1/fOjxjhFSBEUKImSsqKmJ2dnbs9u3bbOzYseyzzz5T33f06FEGgOXm5lZqFxkZyebOnav+3t/fn3333XeVjvvkk08Yj8djt2/fZowx9uDBAwaAXb16lTHG2NmzZxkAtnjx4kpt3377bSYUCllSUlK18QQFBbGvv/5afT4uLi7s6aefrtTfrl27GAC2ceNGxhhjSUlJTCgUsrfffrvSsYsXL2YA2Llz5yrFnZSUxJo2bcqio6NZQUFBpbaE6ItGMAghZm/Tpk1o2rQpmjZtiueffx6rVq3S+ISvr5kzZ4Ixhp07d2q9f8OGDbC1tcWUKVMq3ffOO+9AJpNh69atWtsyxrBv3z48evQInTp1AgAcOHAA2dnZWkcfhg0bhrCwMGzYsAEA8Oeff0Imk2k9dsqUKbC1tVUfW+HOnTvo1q0bwsPDsW/fPtjZ2VX/BBBSB5RgEELM3m+//Ybnn38eADBw4EAUFRVpXG7Ql7OzM9zd3ZGYmKj1/vj4eAQHB0Mkqlz63MvLCw4ODoiPj9e43cfHB7a2thCJRBgyZAjmzp2Lnj17qvsDgGbNmml9vPDwcPUx8fHxcHBwgKenZ6XjRCIRgoKCKj32hAkTEBwcjK1bt0Ispr1fSP2gBIMQYtbu3LmDCxcuYNy4cQAAgUCAsWPHYuXKlQZ9HMZYnUuea2t78uRJXLt2DdeuXcOKFSuwYMECLFmypFI7fWPRduyIESNw6tSpKkdVCDEEgbEDIIQQffz222+Qy+Xw9vZW38YYg1AoRG5uLuzt7QEA+fn5cHR01Gibl5cHBweHGh8jOzsbmZmZCAwM1Hp/WFgYTp06BalUWmkUIyUlBQUFBQgNDdW4PTAwUB1P8+bNcf78ecyfPx9Tp05FWFgYACAuLg5du3at9Hi3b99GRESE+rHz8/ORkpICLy8vjeOkUinu37+P3r17a9w+e/ZstGrVCuPHjwdjDGPHjq3xOSBEVzSCQQgxW3K5HGvXrsWiRYvUowHXrl3D9evX4e/vj3Xr1iE0NBQ8Hg8XL17UaJuamork5GQ0bdq0xsf54YcfwOPxMHLkSK33jxs3DkVFRVi2bFml+7755hsIhUKMGjWq2sfg8/koLS0FAPTv3x/Ozs5YtGhRpeN27dqFu3fv4tlnnwUAjBo1CgKBQOuxS5cuRXFxsfrYJ3300Uf4/PPPMX78+EpzNAgxCGPNLiWEEH1t376diUQilpeXV+m+2bNns9atWzPGGJs6dSrz8/Nj27dvZ/fv32enTp1iUVFRrGXLlkwmk6nb+Pv7s3nz5rHU1FSWlJTEjh8/ziZPnsw4jmNffvml+rj/riJhjLGZM2cysVjMvvnmG5aQkMDi4uLYnDlzGI/H01hdUrGK5M6dOyw1NZUlJiayzZs3Mzs7O/bSSy+pj9uyZQvj8/ls8uTJ7Pr16+zBgwdsxYoVzMnJiT3zzDNMqVSqj/32228Zj8djs2fPZnFxcSwhIYEtWrSIicVi9s4771Qb99dff834fD77448/6vZDIKQKlGAQQszW0KFD2eDBg7Xed/nyZQaAXb58mZWVlbF58+axZs2aMSsrK+bv788mTpzIUlNTNdr4+/szAAwAE4lEzM/Pj40ZM4YdOXJE4zhtf6gZY+y3335j7du3Z1ZWVsza2pp1796d7dq1S+OYigSj4ksgELDAwED27rvvsqKiIo1jT5w4wQYOHMgcHByYSCRiERER7JtvvmFyubzS+e7cuZP16NGD2djYMIlEwtq1a8dWrlxZq7gXLVrE+Hw+W7t2rdbnkpC6oN1UCSGEEGJwNAeDEEIIIQZHCQYhhBBCDI4SDEIIIYQYHCUYhBBCCDE4SjAIIYQQYnCUYBBCCCHE4CjBIIQQQojBUYJBCCGEEIOjBIMQQgghBkcJBiGEEEIMjhIMQgghhBgcJRiEEEIIMbj/AzYCPTiqbnXwAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import boto3\n",
+    "import duckdb\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns \n",
+    "\n",
+    "# get information about the table\n",
+    "s3_tables_client = boto3.client('s3tables')\n",
+    "tbs = s3_tables_client.list_table_buckets(prefix=table_name)\n",
+    "tb = tbs['tableBuckets'][0]\n",
+    "\n",
+    "s3_tables_arn = tb['arn']\n",
+    "\n",
+    "table_bucket = s3_tables_client.get_table(tableBucketARN=s3_tables_arn, namespace=namespace, name=table_name)\n",
+    "metadata_location = table_bucket['metadataLocation']\n",
+    "aws_region = s3_tables_arn.split(':')[3]\n",
+    "\n",
+    "con = duckdb.connect(database=':memory:', read_only=False)\n",
+    "\n",
+    "# install plugins, load, then setup aws credentials information\n",
+    "setup_sql = f\"\"\"\n",
+    "INSTALL iceberg;\n",
+    "INSTALL aws;\n",
+    "INSTALL httpfs;\n",
+    "\n",
+    "LOAD iceberg;\n",
+    "LOAD aws;\n",
+    "LOAD httpfs;\n",
+    "\n",
+    "CREATE SECRET (\n",
+    "    TYPE s3,\n",
+    "    PROVIDER credential_chain,\n",
+    "    ENDPOINT 's3.{aws_region}.amazonaws.com'\n",
+    ");\n",
+    "\"\"\"\n",
+    "con.execute(setup_sql)\n",
+    "\n",
+    "# fetch data from S3 Tables\n",
+    "s3tables_df = con.execute(f\"SELECT * FROM iceberg_scan('{metadata_location}');\").fetchdf()\n",
+    "# display(s3tables_df.head(5))\n",
+    "\n",
+    "# run a query against the data\n",
+    "aggregation_df = s3tables_df.groupby('materialtype').agg(\n",
+    "    total_records=('materialtype', 'count'),\n",
+    "    total_checkouts=('checkouts', 'sum')\n",
+    ").sort_values('total_checkouts', ascending=False).reset_index().nlargest(5, \"total_checkouts\")\n",
+    "\n",
+    "plt.pie(aggregation_df['total_checkouts'], \n",
+    "        labels=aggregation_df['materialtype'],\n",
+    "        autopct='%1.1f%%',\n",
+    "        colors=sns.color_palette('pastel'),\n",
+    "        explode=[0.05] * 5\n",
+    "       )\n",
+    "plt.axis('equal')\n",
+    "plt.title('Distribution of Checkouts by Media Type', pad=20, size=14)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d061f87b-9b14-40f4-8079-5e4d479c9e1b",
+   "metadata": {},
+   "source": [
+    "# S3 Tables Maintenance\n",
+    "\n",
+    "Let's look at S3 Tables optimizations tasks. S3 Tables' continual table optimization automatically scans and rewrites table data in the background."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e81e6dcb-b561-4886-986c-669d4a577c89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# split dataframe, then append to the table\n",
+    "dfs = library_checkout.randomSplit([1.0] * 10)\n",
+    "for df in dfs:\n",
+    "    df.writeTo(full_table_name).using(\"Iceberg\").append()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "2a4e36d4-6a81-49c3-9e77-104fc088b3ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='category', ylabel='Number of entities'>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjMAAAGwCAYAAABcnuQpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAsPklEQVR4nO3deXSU9aHG8WdIwhDIgixZkBBAApWlICBosJGwGqkVgTZulYAgHnYRgdQKxCoICuKKlfYmYBGlLF5U1gIBEVkSCFTIRcSwVEiBCFlYApL3/uFh2jEkzMRJZn74/ZzznpP5vcs8yTkhD793GZtlWZYAAAAMVc3bAQAAAH4KygwAADAaZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNH8vR2gspWUlOj48eMKDg6WzWbzdhwAAOACy7JUWFioBg0aqFq18udebvgyc/z4cUVFRXk7BgAAqIBjx46pYcOG5W5zw5eZ4OBgST/8MEJCQrycBgAAuKKgoEBRUVGOv+PlueHLzNVTSyEhIZQZAAAM48olIlwADAAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADCav7cD3CiW7Djl7QiAzxnQqb63IwD4GWBmBgAAGI0yAwAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADAaZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNG8WmamT5+u22+/XcHBwQoLC1Pfvn114MABp22SkpJks9mcljvuuMNLiQEAgK/xapnZtGmTRowYoW3btmndunX6/vvv1atXL507d85pu3vuuUcnTpxwLCtXrvRSYgAA4Gv8vfnmq1evdnqdmpqqsLAwZWZmKi4uzjFut9sVERFR1fEAAIABfOqamfz8fElSnTp1nMbT09MVFham5s2ba+jQoTp58mSZxyguLlZBQYHTAgAAblw+U2Ysy9K4ceN01113qXXr1o7xhIQELVy4UBs2bNCsWbO0c+dOdevWTcXFxdc8zvTp0xUaGupYoqKiqupbAAAAXmCzLMvydghJGjFihD799FNt2bJFDRs2LHO7EydOKDo6Wh988IH69etXan1xcbFT0SkoKFBUVJTy8/MVEhJSKdklacmOU5V2bMBUAzrV93YEAIYqKChQaGioS3+/vXrNzFWjRo3SihUrtHnz5nKLjCRFRkYqOjpaBw8evOZ6u90uu91eGTEBAIAP8mqZsSxLo0aN0vLly5Wenq4mTZpcd5+8vDwdO3ZMkZGRVZAQAAD4Oq9eMzNixAj97W9/0/vvv6/g4GDl5uYqNzdXFy5ckCQVFRVp/Pjx+uKLL3T48GGlp6frvvvuU7169fTAAw94MzoAAPARXp2ZmTt3riSpa9euTuOpqalKSkqSn5+f/vnPf2rBggU6e/asIiMjFR8frw8//FDBwcFeSAwAAHyN108zlScwMFBr1qypojQAAMBEPnNrNgAAQEVQZgAAgNEoMwAAwGiUGQAAYDTKDAAAMBplBgAAGI0yAwAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADAaZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNEoMwAAwGiUGQAAYDTKDAAAMBplBgAAGI0yAwAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADAaZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNEoMwAAwGiUGQAAYDTKDAAAMBplBgAAGM2rZWb69Om6/fbbFRwcrLCwMPXt21cHDhxw2sayLE2dOlUNGjRQYGCgunbtqn379nkpMQAA8DVeLTObNm3SiBEjtG3bNq1bt07ff/+9evXqpXPnzjm2mTlzpmbPnq0333xTO3fuVEREhHr27KnCwkIvJgcAAL7CZlmW5e0QV506dUphYWHatGmT4uLiZFmWGjRooLFjx2rixImSpOLiYoWHh2vGjBkaNmzYdY9ZUFCg0NBQ5efnKyQkpNKyL9lxqtKODZhqQKf63o4AwFDu/P32qWtm8vPzJUl16tSRJOXk5Cg3N1e9evVybGO323X33Xdr69at1zxGcXGxCgoKnBYAAHDj8pkyY1mWxo0bp7vuukutW7eWJOXm5kqSwsPDnbYNDw93rPux6dOnKzQ01LFERUVVbnAAAOBVPlNmRo4cqb1792rRokWl1tlsNqfXlmWVGrsqOTlZ+fn5juXYsWOVkhcAAPgGf28HkKRRo0ZpxYoV2rx5sxo2bOgYj4iIkPTDDE1kZKRj/OTJk6Vma66y2+2y2+2VGxgAAPgMr87MWJalkSNHatmyZdqwYYOaNGnitL5JkyaKiIjQunXrHGOXLl3Spk2bFBsbW9VxAQCAD/LqzMyIESP0/vvv63//938VHBzsuA4mNDRUgYGBstlsGjt2rKZNm6aYmBjFxMRo2rRpqlmzph5++GFvRgcAAD7Cq2Vm7ty5kqSuXbs6jaempiopKUmSNGHCBF24cEHDhw/XmTNn1LlzZ61du1bBwcFVnBYAAPgin3rOTGXgOTOA9/CcGQAVZexzZgAAANxFmQEAAEajzAAAAKNRZgAAgNEoMwAAwGiUGQAAYDTKDAAAMJrbZWb+/Pn69NNPHa8nTJig2rVrKzY2VkeOHPFoOAAAgOtxu8xMmzZNgYGBkqQvvvhCb775pmbOnKl69erpqaee8nhAAACA8rj9cQbHjh1Ts2bNJEkfffSRBgwYoCeeeEJdunQp9bEEAAAAlc3tmZmgoCDl5eVJktauXasePXpIkmrUqKELFy54Nh0AAMB1uD0z07NnTw0ZMkS33XabvvrqK/Xp00eStG/fPjVu3NjT+QAAAMrl9szMW2+9pTvvvFOnTp3S0qVLVbduXUlSZmamHnroIY8HBAAAKA+fmu0hfGo2UBqfmg2goir9U7M/++wzPfroo4qNjdW3334rSXrvvfe0ZcuWihwOAACgwtwuM0uXLlXv3r0VGBioXbt2qbi4WJJUWFioadOmeTwgAABAedwuMy+88ILeeecdzZs3TwEBAY7x2NhY7dq1y6PhAAAArsftMnPgwAHFxcWVGg8JCdHZs2c9kQkAAMBlbpeZyMhIff3116XGt2zZoqZNm3okFAAAgKvcLjPDhg3TmDFjtH37dtlsNh0/flwLFy7U+PHjNXz48MrICAAAUCa3H5o3YcIE5efnKz4+XhcvXlRcXJzsdrvGjx+vkSNHVkZGAACAMlX4OTPnz5/X/v37VVJSopYtWyooKMjT2TyC58wA3sNzZgBUlDt/v92embmqZs2a6tixY0V3BwAA8AiXyky/fv2UlpamkJAQ9evXr9xtly1b5pFgAAAArnCpzISGhspms0n64Rbsq18DAAB4m0tlJjU11fF1WlpaZWUBAABwm9u3Znfr1u2aD8crKChQt27dPJEJAADAZW6XmfT0dF26dKnU+MWLF/XZZ595JBQAAICrXL6bae/evY6v9+/fr9zcXMfrK1euaPXq1br55ps9mw4AAOA6XC4z7dq1k81mk81mu+bppMDAQL3xxhseDQcAAHA9LpeZnJwcWZalpk2baseOHapf/z8Pw6pevbrCwsLk5+dXKSEBAADK4nKZiY6OliSVlJRUWhgAAAB3uVRmVqxYoYSEBAUEBGjFihXlbvub3/zGI8EAAABc4VKZ6du3r3JzcxUWFqa+ffuWuZ3NZtOVK1c8lQ0AAOC6XCoz/31qidNMAADAl7j9nJkFCxaouLi41PilS5e0YMECj4QCAABwldtlZtCgQcrPzy81XlhYqEGDBnkkFAAAgKvcLjOWZV3zgyb/9a9/KTQ01COhAAAAXOXyrdm33Xab46F53bt3l7//f3a9cuWKcnJydM8991RKSAAAgLK4XGau3sWUlZWl3r17KygoyLGuevXqaty4sfr37+/xgAAAAOVxucxMmTJFktS4cWMlJiaqRo0alRYKAADAVS6XmasGDhwo6Ye7l06ePFnqVu1GjRp5JhkAAIAL3C4zBw8e1ODBg7V161an8asXBvPQPAAAUJXcLjNJSUny9/fXJ598osjIyGve2QQAAFBV3C4zWVlZyszM1C9+8YvKyAMAAOAWt58z07JlS50+fboysgAAALjN7TIzY8YMTZgwQenp6crLy1NBQYHTAgAAUJXcPs3Uo0cPSVL37t2dxrkAGAAAeIPbZWbjxo2VkQMAAKBC3C4zd999d2XkAAAAqBC3r5mRpM8++0yPPvqoYmNj9e2330qS3nvvPW3ZssWj4QAAAK7H7TKzdOlS9e7dW4GBgdq1a5eKi4slSYWFhZo2bZrHAwIAAJTH7TLzwgsv6J133tG8efMUEBDgGI+NjdWuXbs8Gg4AAOB63C4zBw4cUFxcXKnxkJAQnT171hOZAAAAXOZ2mYmMjNTXX39danzLli1q2rSpR0IBAAC4yu0yM2zYMI0ZM0bbt2+XzWbT8ePHtXDhQo0fP17Dhw9361ibN2/WfffdpwYNGshms+mjjz5yWp+UlCSbzea03HHHHe5GBgAANzC3b82eMGGC8vPzFR8fr4sXLyouLk52u13jx4/XyJEj3TrWuXPn1LZtWw0aNEj9+/e/5jb33HOPUlNTHa+rV6/ubmQAAHADc7vMSNKLL76oZ599Vvv371dJSYlatmypoKAgt4+TkJCghISEcrex2+2KiIhw+ZjFxcWOO6wk8RELAADc4Cr0nBlJqlmzpjp27KhOnTpVqMi4Kj09XWFhYWrevLmGDh2qkydPlrv99OnTFRoa6liioqIqLRsAAPC+CpeZqpCQkKCFCxdqw4YNmjVrlnbu3Klu3bo5zbz8WHJysvLz8x3LsWPHqjAxAACoahU6zVRVEhMTHV+3bt1aHTt2VHR0tD799FP169fvmvvY7XbZ7faqiggAALzMp2dmfiwyMlLR0dE6ePCgt6MAAAAf4VKZad++vc6cOSNJev7553X+/PlKDVWWvLw8HTt2TJGRkV55fwAA4HtcKjPZ2dk6d+6cJCklJUVFRUUeefOioiJlZWUpKytLkpSTk6OsrCwdPXpURUVFGj9+vL744gsdPnxY6enpuu+++1SvXj098MADHnl/AABgPpeumWnXrp0GDRqku+66S5Zl6ZVXXinzDqbJkye7/OYZGRmKj493vB43bpwkaeDAgZo7d67++c9/asGCBTp79qwiIyMVHx+vDz/8UMHBwS6/BwAAuLHZLMuyrrfRgQMHNGXKFB06dEi7du1Sy5Yt5e9fugfZbDaf+7DJgoIChYaGKj8/XyEhIZX2Pkt2nKq0YwOmGtCpvrcjADCUO3+/XZqZadGihT744ANJUrVq1bR+/XqFhYX99KQAAAA/kdu3ZpeUlFRGDgAAgAqp0HNmDh06pDlz5ig7O1s2m0233nqrxowZo1tuucXT+QAAAMrl9nNm1qxZo5YtW2rHjh365S9/qdatW2v79u1q1aqV1q1bVxkZAQAAyuT2zMykSZP01FNP6aWXXio1PnHiRPXs2dNj4QAAAK7H7ZmZ7OxsPf7446XGBw8erP3793skFAAAgKvcLjP169d3POTuv2VlZXGHEwAAqHJun2YaOnSonnjiCX3zzTeKjY2VzWbTli1bNGPGDD399NOVkREAAKBMbpeZ5557TsHBwZo1a5aSk5MlSQ0aNNDUqVM1evRojwcEAAAoj0tPAC5LYWGhJPn0xwvwBGDAe3gCMICK8vgTgMviyyUGAAD8PLh9ATAAAIAvocwAAACjUWYAAIDR3Cozly9fVnx8vL766qvKygMAAOAWt8pMQECAvvzyS9lstsrKAwAA4Ba3TzM99thj+utf/1oZWQAAANzm9q3Zly5d0l/+8hetW7dOHTt2VK1atZzWz54922PhAAAArsftMvPll1+qffv2klTq2hlOPwEAgKrmdpnZuHFjZeQAAACokArfmv31119rzZo1unDhgiTpJ3wqAgAAQIW5XWby8vLUvXt3NW/eXPfee69OnDghSRoyZAifmg0AAKqc22XmqaeeUkBAgI4ePaqaNWs6xhMTE7V69WqPhgMAALget6+ZWbt2rdasWaOGDRs6jcfExOjIkSMeCwYAAOAKt2dmzp075zQjc9Xp06dlt9s9EgoAAMBVbpeZuLg4LViwwPHaZrOppKREL7/8suLj4z0aDgAA4HrcPs308ssvq2vXrsrIyNClS5c0YcIE7du3T999950+//zzysgIAABQJrdnZlq2bKm9e/eqU6dO6tmzp86dO6d+/fpp9+7duuWWWyojIwAAQJncnpmRpIiICKWkpHg6CwAAgNsqVGbOnDmjv/71r8rOzpbNZtOtt96qQYMGqU6dOp7OBwAAUC63TzNt2rRJTZo00euvv64zZ87ou+++0+uvv64mTZpo06ZNlZERAACgTG7PzIwYMUK/+93vNHfuXPn5+UmSrly5ouHDh2vEiBH68ssvPR4SALzp7Oo3vB0B8Dm17xnl7QgObs/MHDp0SE8//bSjyEiSn5+fxo0bp0OHDnk0HAAAwPW4XWbat2+v7OzsUuPZ2dlq166dJzIBAAC4zKXTTHv37nV8PXr0aI0ZM0Zff/217rjjDknStm3b9NZbb+mll16qnJQAAABlcKnMtGvXTjabTZZlOcYmTJhQaruHH35YiYmJnksHAABwHS6VmZycnMrOAQAAUCEulZno6OjKzgEAAFAhFXpo3rfffqvPP/9cJ0+eVElJidO60aNHeyQYAACAK9wuM6mpqXryySdVvXp11a1bVzabzbHOZrNRZgAAQJVyu8xMnjxZkydPVnJysqpVc/vObgAAAI9yu42cP39eDz74IEUGAAD4BLcbyeOPP66///3vlZEFAADAbW6fZpo+fbp+/etfa/Xq1WrTpo0CAgKc1s+ePdtj4QAAAK7H7TIzbdo0rVmzRi1atJCkUhcAAwAAVCW3y8zs2bP1P//zP0pKSqqEOAAAAO5x+5oZu92uLl26VEYWAAAAt7ldZsaMGaM33nijMrIAAAC4ze3TTDt27NCGDRv0ySefqFWrVqUuAF62bJnHwgEAAFyP22Wmdu3a6tevX2VkAQAAcFuFPs4AAADAV/AYXwAAYDS3Z2aaNGlS7vNkvvnmm58UCAAAwB1ul5mxY8c6vb58+bJ2796t1atX65lnnvFULgAAAJe4XWbGjBlzzfG33npLGRkZbh1r8+bNevnll5WZmakTJ05o+fLl6tu3r2O9ZVlKSUnRu+++qzNnzqhz585666231KpVK3djAwCAG5THrplJSEjQ0qVL3drn3Llzatu2rd58881rrp85c6Zmz56tN998Uzt37lRERIR69uypwsJCT0QGAAA3ALdnZsqyZMkS1alTx619EhISlJCQcM11lmVpzpw5evbZZx23gs+fP1/h4eF6//33NWzYsGvuV1xcrOLiYsfrgoICtzIBAACzuF1mbrvtNqcLgC3LUm5urk6dOqW3337bY8FycnKUm5urXr16Ocbsdrvuvvtubd26tcwyM336dKWkpHgsBwAA8G1ul5n/vqZFkqpVq6b69eura9eu+sUvfuGpXMrNzZUkhYeHO42Hh4fryJEjZe6XnJyscePGOV4XFBQoKirKY7kAAIBvcbvMTJkypTJylOnHt4FbllXureF2u112u72yYwEAAB/hsw/Ni4iIkPSfGZqrTp48WWq2BgAA/Hy5XGaqVasmPz+/chd/f49dT6wmTZooIiJC69atc4xdunRJmzZtUmxsrMfeBwAAmM3l9rF8+fIy123dulVvvPGGLMty682Lior09ddfO17n5OQoKytLderUUaNGjTR27FhNmzZNMTExiomJ0bRp01SzZk09/PDDbr0PAAC4cblcZu6///5SY//3f/+n5ORkffzxx3rkkUf0pz/9ya03z8jIUHx8vOP11Qt3Bw4cqLS0NE2YMEEXLlzQ8OHDHQ/NW7t2rYKDg916HwAAcOOq0Hmh48ePa8qUKZo/f7569+6trKwstW7d2u3jdO3atdzZHJvNpqlTp2rq1KkViQkAAH4G3LoAOD8/XxMnTlSzZs20b98+rV+/Xh9//HGFigwAAIAnuDwzM3PmTM2YMUMRERFatGjRNU87AQAAVDWXy8ykSZMUGBioZs2aaf78+Zo/f/41t1u2bJnHwgEAAFyPy2XmscceK/dhdQAAAN7gcplJS0urxBgAAAAV47NPAAYAAHAFZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNEoMwAAwGiUGQAAYDTKDAAAMBplBgAAGI0yAwAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADAaZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNEoMwAAwGiUGQAAYDTKDAAAMBplBgAAGI0yAwAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADCaT5eZqVOnymazOS0RERHejgUAAHyIv7cDXE+rVq30j3/8w/Haz8/Pi2kAAICv8fky4+/vz2wMAAAok0+fZpKkgwcPqkGDBmrSpIkefPBBffPNN+VuX1xcrIKCAqcFAADcuHy6zHTu3FkLFizQmjVrNG/ePOXm5io2NlZ5eXll7jN9+nSFhoY6lqioqCpMDAAAqppPl5mEhAT1799fbdq0UY8ePfTpp59KkubPn1/mPsnJycrPz3csx44dq6q4AADAC3z+mpn/VqtWLbVp00YHDx4scxu73S673V6FqQAAgDf59MzMjxUXFys7O1uRkZHejgIAAHyET5eZ8ePHa9OmTcrJydH27ds1YMAAFRQUaODAgd6OBgAAfIRPn2b617/+pYceekinT59W/fr1dccdd2jbtm2Kjo72djQAAOAjfLrMfPDBB96OAAAAfJxPn2YCAAC4HsoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADAaZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNEoMwAAwGiUGQAAYDTKDAAAMBplBgAAGI0yAwAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAAGA0ygwAADAaZQYAABiNMgMAAIxGmQEAAEajzAAAAKNRZgAAgNEoMwAAwGiUGQAAYDTKDAAAMBplBgAAGI0yAwAAjEaZAQAARqPMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABGo8wAAACjGVFm3n77bTVp0kQ1atRQhw4d9Nlnn3k7EgAA8BE+X2Y+/PBDjR07Vs8++6x2796tX/3qV0pISNDRo0e9HQ0AAPgAny8zs2fP1uOPP64hQ4bo1ltv1Zw5cxQVFaW5c+d6OxoAAPAB/t4OUJ5Lly4pMzNTkyZNchrv1auXtm7des19iouLVVxc7Hidn58vSSooKKi8oJLOFxVW6vEBExUU2L0dwSMKzl3wdgTA51Sr5L+rV/9uW5Z13W19usycPn1aV65cUXh4uNN4eHi4cnNzr7nP9OnTlZKSUmo8KiqqUjICAPDzNLFK3qWwsFChoaHlbuPTZeYqm83m9NqyrFJjVyUnJ2vcuHGO1yUlJfruu+9Ut27dMvfBjaOgoEBRUVE6duyYQkJCvB0HgAfx+/3zYlmWCgsL1aBBg+tu69Nlpl69evLz8ys1C3Py5MlSszVX2e122e3OU9u1a9eurIjwUSEhIfxjB9yg+P3++bjejMxVPn0BcPXq1dWhQwetW7fOaXzdunWKjY31UioAAOBLfHpmRpLGjRun3//+9+rYsaPuvPNOvfvuuzp69KiefPJJb0cDAAA+wOfLTGJiovLy8vT888/rxIkTat26tVauXKno6GhvR4MPstvtmjJlSqlTjQDMx+83ymKzXLnnCQAAwEf59DUzAAAA10OZAQAARqPMAAAAo1FmYJyuXbtq7NixjteNGzfWnDlzvJYHgG9ISkpS3759vR0DXkCZgc9KSkqSzWYrtcycOVN/+tOfvB0P+Fk5efKkhg0bpkaNGslutysiIkK9e/fWF1984e1oHpWWlsaDVg3k87dm4+ftnnvuUWpqqtNY/fr15efn56VEwM9T//79dfnyZc2fP19NmzbVv//9b61fv17fffedt6MBzMzAt139H+B/L927d3c6zfRj+fn5euKJJxQWFqaQkBB169ZNe/bscazfs2eP4uPjFRwcrJCQEHXo0EEZGRlV8N0AZjp79qy2bNmiGTNmKD4+XtHR0erUqZOSk5PVp08fST98ht5f/vIXPfDAA6pZs6ZiYmK0YsUKxzGuXLmixx9/XE2aNFFgYKBatGih1157zel9rp4mSklJcfz+Dhs2TJcuXXJss2TJErVp00aBgYGqW7euevTooXPnzjkd55VXXlFkZKTq1q2rESNG6PLly451Z86c0WOPPaabbrpJNWvWVEJCgg4ePChJSk9P16BBg5Sfn++YCZ46daok6e2331ZMTIxq1Kih8PBwDRgwwKM/Y/w0lBncUCzLUp8+fZSbm6uVK1cqMzNT7du3V/fu3R3/g3zkkUfUsGFD7dy5U5mZmZo0aZICAgK8nBzwXUFBQQoKCtJHH32k4uLiMrdLSUnR7373O+3du1f33nuvHnnkEcfvXUlJiRo2bKjFixdr//79mjx5sv7whz9o8eLFTsdYv369srOztXHjRi1atEjLly9XSkqKJOnEiRN66KGHNHjwYGVnZys9PV39+vXTfz8ubePGjTp06JA2btyo+fPnKy0tTWlpaY71SUlJysjI0IoVK/TFF1/Isizde++9unz5smJjYzVnzhyFhIToxIkTOnHihMaPH6+MjAyNHj1azz//vA4cOKDVq1crLi7Ogz9h/GQW4KMGDhxo+fn5WbVq1XIsAwYMsO6++25rzJgxju2io6OtV1991bIsy1q/fr0VEhJiXbx40elYt9xyi/XnP//ZsizLCg4OttLS0qrq2wBuCEuWLLFuuukmq0aNGlZsbKyVnJxs7dmzx7FekvXHP/7R8bqoqMiy2WzWqlWryjzm8OHDrf79+zteDxw40KpTp4517tw5x9jcuXOtoKAg68qVK1ZmZqYlyTp8+PA1jzdw4EArOjra+v777x1jv/3tb63ExETLsizrq6++siRZn3/+uWP96dOnrcDAQGvx4sWWZVlWamqqFRoa6nTcpUuXWiEhIVZBQUF5PyJ4ETMz8Gnx8fHKyspyLK+//nq522dmZqqoqEh169Z1/G8yKChIOTk5OnTokKQfPu9ryJAh6tGjh1566SXHOICy9e/fX8ePH9eKFSvUu3dvpaenq3379k6zHr/85S8dX9eqVUvBwcE6efKkY+ydd95Rx44dVb9+fQUFBWnevHk6evSo0/u0bdtWNWvWdLy+8847VVRUpGPHjqlt27bq3r272rRpo9/+9reaN2+ezpw547R/q1atnK6pi4yMdGTIzs6Wv7+/Onfu7Fhft25dtWjRQtnZ2WV+7z179lR0dLSaNm2q3//+91q4cKHOnz/v4k8OVYEyA59Wq1YtNWvWzLFERkaWu31JSYkiIyOdClBWVpYOHDigZ555RpI0depU7du3T3369NGGDRvUsmVLLV++vCq+HcBoNWrUUM+ePTV58mRt3bpVSUlJmjJlimP9j0/X2mw2lZSUSJIWL16sp556SoMHD9batWuVlZWlQYMGOV0PUx6bzSY/Pz+tW7dOq1atUsuWLfXGG2+oRYsWysnJcSmDVcan91iWJZvNVuZ7BwcHa9euXVq0aJEiIyM1efJktW3bVmfPnnUpOyofZQY3lPbt2ys3N1f+/v5OJahZs2aqV6+eY7vmzZvrqaee0tq1a9WvX79Sd0wBuL6WLVuWuvi2LJ999pliY2M1fPhw3XbbbWrWrNk1Z0X37NmjCxcuOF5v27ZNQUFBatiwoaQfykmXLl2UkpKi3bt3q3r16i7/Z6Rly5b6/vvvtX37dsdYXl6evvrqK916662SpOrVq+vKlSul9vX391ePHj00c+ZM7d27V4cPH9aGDRtcel9UPsoMbig9evTQnXfeqb59+2rNmjU6fPiwtm7dqj/+8Y/KyMjQhQsXNHLkSKWnp+vIkSP6/PPPtXPnTsc/ZABKy8vLU7du3fS3v/1Ne/fuVU5Ojv7+979r5syZuv/++106RrNmzZSRkaE1a9boq6++0nPPPaedO3eW2u7SpUt6/PHHtX//fq1atUpTpkzRyJEjVa1aNW3fvl3Tpk1TRkaGjh49qmXLlunUqVMu//7GxMTo/vvv19ChQ7Vlyxbt2bNHjz76qG6++WbH99G4cWMVFRVp/fr1On36tM6fP69PPvlEr7/+urKysnTkyBEtWLBAJSUlatGihes/RFQqnjODG4rNZtPKlSv17LPPavDgwTp16pQiIiIUFxen8PBw+fn5KS8vT4899pj+/e9/q169eurXr5/jbgkApQUFBalz58569dVXdejQIV2+fFlRUVEaOnSo/vCHP7h0jCeffFJZWVlKTEyUzWbTQw89pOHDh2vVqlVO23Xv3l0xMTGKi4tTcXGxHnzwQcft0SEhIdq8ebPmzJmjgoICRUdHa9asWUpISHD5e0lNTdWYMWP061//WpcuXVJcXJxWrlzpOD0VGxurJ598UomJicrLy9OUKVPUo0cPLVu2TFOnTtXFixcVExOjRYsWqVWrVi6/LyqXzSrrJCIAAFUoKSlJZ8+e1UcffeTtKDAMp5kAAIDRKDMAAMBonGYCAABGY2YGAAAYjTIDAACMRpkBAABGo8wAAACjUWYAAIDRKDMAAMBolBkAPmHq1Klq166dt2MAMBBlBgCu4fLly96OAMBFlBkAHlNSUqIZM2aoWbNmstvtatSokV588UVJ0sSJE9W8eXPVrFlTTZs21XPPPecoDGlpaUpJSdGePXtks9lks9mUlpYmScrPz9cTTzyhsLAwhYSEqFu3btqzZ4/T+77wwgsKCwtTcHCwhgwZokmTJjnN8pSUlOj5559Xw4YNZbfb1a5dO61evdqx/vDhw7LZbFq8eLG6du2qGjVq6N1331VISIiWLFni9F4ff/yxatWqpcLCwkr4CQKoCMoMAI9JTk7WjBkz9Nxzz2n//v16//33FR4eLkkKDg5WWlqa9u/fr9dee03z5s3Tq6++KklKTEzU008/rVatWunEiRM6ceKEEhMTZVmW+vTpo9zcXK1cuVKZmZlq3769unfvru+++06StHDhQr344ouaMWOGMjMz1ahRI82dO9cp12uvvaZZs2bplVde0d69e9W7d2/95je/0cGDB522mzhxokaPHq3s7Gw98MADevDBB5Wamuq0TWpqqgYMGKDg4ODK+jECcJcFAB5QUFBg2e12a968eS5tP3PmTKtDhw6O11OmTLHatm3rtM369eutkJAQ6+LFi07jt9xyi/XnP//ZsizL6ty5szVixAin9V26dHE6VoMGDawXX3zRaZvbb7/dGj58uGVZlpWTk2NJsubMmeO0zfbt2y0/Pz/r22+/tSzLsk6dOmUFBARY6enpLn2PAKoGMzMAPCI7O1vFxcXq3r37NdcvWbJEd911lyIiIhQUFKTnnntOR48eLfeYmZmZKioqUt26dRUUFORYcnJydOjQIUnSgQMH1KlTJ6f9/vt1QUGBjh8/ri5dujht06VLF2VnZzuNdezYsdRxWrVqpQULFkiS3nvvPTVq1EhxcXHl5gZQtfy9HQDAjSEwMLDMddu2bdODDz6olJQU9e7dW6Ghofrggw80a9asco9ZUlKiyMhIpaenl1pXu3Ztx9c2m81pnXWNz8+91jY/HqtVq1ap/YYMGaI333xTkyZNUmpqqgYNGlRqPwDexcwMAI+IiYlRYGCg1q9fX2rd559/rujoaD377LPq2LGjYmJidOTIEadtqlevritXrjiNtW/fXrm5ufL391ezZs2clnr16kmSWrRooR07djjtl5GR4fg6JCREDRo00JYtW5y22bp1q2699dbrfl+PPvqojh49qtdff1379u3TwIEDr7sPgKrFzAwAj6hRo4YmTpyoCRMmqHr16urSpYtOnTqlffv2qVmzZjp69Kg++OAD3X777fr000+1fPlyp/0bN26snJwcZWVlqWHDhgoODlaPHj105513qm/fvpoxY4ZatGih48ePa+XKlerbt686duyoUaNGaejQoerYsaNiY2P14Ycfau/evWratKnj2M8884ymTJmiW265Re3atVNqaqqysrK0cOHC635fN910k/r166dnnnlGvXr1UsOGDT3+swPwE3n7oh0AN44rV65YL7zwghUdHW0FBARYjRo1sqZNm2ZZlmU988wzVt26da2goCArMTHRevXVV63Q0FDHvhcvXrT69+9v1a5d25JkpaamWpb1w4XFo0aNsho0aGAFBARYUVFR1iOPPGIdPXrUse/zzz9v1atXzwoKCrIGDx5sjR492rrjjjuccqWkpFg333yzFRAQYLVt29ZatWqVY/3VC4B37959ze9r/fr1liRr8eLFnvthAfAYm2Vd4+QyABisZ8+eioiI0HvvveeR4y1cuFBjxozR8ePHVb16dY8cE4DncJoJgNHOnz+vd955R71795afn58WLVqkf/zjH1q3bp1Hjp2Tk6Pp06dr2LBhFBnAR3EBMACj2Ww2rVy5Ur/61a/UoUMHffzxx1q6dKl69Ojxk489c+ZMtWvXTuHh4UpOTvZAWgCVgdNMAADAaMzMAAAAo1FmAACA0SgzAADAaJQZAABgNMoMAAAwGmUGAAAYjTIDAACMRpkBAABG+3+GF9QamerlSQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "fdf = spark.sql(\"SELECT * FROM s3tablesbucket.demo.demo.files\")\n",
+    "sdf = spark.sql(\"SELECT * FROM s3tablesbucket.demo.demo.snapshots\")\n",
+    "df = pd.DataFrame({'category': ['Files', 'Snapshots'], 'Count': [fdf.count(), sdf.count()]})\n",
+    "display(sns.barplot(data=df, x='category', y='Count', palette='pastel', hue='category'))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "657f1661-dfe1-46fa-93f2-acbf12a927da",
+   "metadata": {},
+   "source": [
+    "## Automatic maintenance\n",
+    "\n",
+    "Once S3 Tables maintenance tasks run, we observe reduced number of files due to compaction.\n",
+    "\n",
+    "You can get the status and configurations of maintenance tasks by running the following command:\n",
+    "\n",
+    "```bash\n",
+    "aws s3tables get-table-maintenance-job-status --table-bucket-arn arn:aws:s3tables:us-west-2:ACC:bucket/demo --namespace demo --name demo\n",
+    "```\n",
+    "\n",
+    "Example output:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"tableARN\": \"arn:aws:s3tables:us-west-2:ACC:bucket/demo/table/415f4796-36de\",\n",
+    "    \"status\": {\n",
+    "        \"icebergCompaction\": {\n",
+    "            \"status\": \"Successful\",\n",
+    "            \"lastRunTimestamp\": \"2025-03-03T07:26:40.624000+00:00\"\n",
+    "        },\n",
+    "        \"icebergUnreferencedFileRemoval\": {\n",
+    "            \"status\": \"Successful\",\n",
+    "            \"lastRunTimestamp\": \"2025-03-02T19:27:13.823000+00:00\"\n",
+    "        },\n",
+    "        \"icebergSnapshotManagement\": {\n",
+    "            \"status\": \"Successful\",\n",
+    "            \"lastRunTimestamp\": \"2025-03-02T19:32:26.288000+00:00\"\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "799b3168-ca0a-4146-9727-5364b784e98b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2025-03-03 18:07:31,613] INFO @ line 161: NumExpr defaulting to 16 threads.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='category', ylabel='Count'>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjMAAAGwCAYAAABcnuQpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAlA0lEQVR4nO3dfVjV9f3H8dcJ8HgDBxUTIRE1yYmVpmhLm9NEzazlzKbNyptsNk0t93PKzBvclOlVSumy6a6BbWk5l81tahnKrKwmGLjMaTkMrpQ0bzjiDRJ8fn/s8lydIYgInO/Hno/r+l6X37tz3ofrQp9+zxeOyxhjBAAAYKnrAj0AAADA1SBmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGC14EAPUNfKy8t1+PBhhYWFyeVyBXocAABQDcYYnT59WtHR0bruuqqvvVzzMXP48GHFxMQEegwAAFADBQUFat26dZXHXPMxExYWJum/XwyPxxPgaQAAQHV4vV7FxMT4/h2vyjUfMxffWvJ4PMQMAACWqc4tItwADAAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasGBHgAAnO7UlmWBHgFwnKZ3Tw70CD5cmQEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDVAhozO3bs0H333afo6Gi5XC698cYbvn2lpaWaMWOGbrnlFjVp0kTR0dF69NFHdfjw4cANDAAAHCegMXPmzBl16dJFy5cvr7Dv7Nmz2r17t2bPnq3du3fr9ddf14EDB/SDH/wgAJMCAACnCg7kkw8ePFiDBw++5L7w8HBt3brVb9uyZcvUs2dP5efnq02bNvUxIgAAcLiAxsyVKioqksvlUtOmTSs9pqSkRCUlJb51r9dbD5MBAIBAseYG4PPnz2vmzJn68Y9/LI/HU+lxKSkpCg8P9y0xMTH1OCUAAKhvVsRMaWmpRo4cqfLycr344otVHpuUlKSioiLfUlBQUE9TAgCAQHD820ylpaX60Y9+pLy8PG3btq3KqzKS5Ha75Xa762k6AAAQaI6OmYsh8+mnn2r79u2KiIgI9EgAAMBhAhozxcXF+uyzz3zreXl5ysnJUfPmzRUdHa3hw4dr9+7d+tvf/qaysjIVFhZKkpo3b64GDRoEamwAAOAgAY2ZrKws9evXz7c+bdo0SdLo0aM1b948bdy4UZLUtWtXv/O2b9+uvn371teYAADAwQIaM3379pUxptL9Ve0DAACQLPlpJgAAgMoQMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwWkBjZseOHbrvvvsUHR0tl8ulN954w2+/MUbz5s1TdHS0GjVqpL59+2rv3r2BGRYAADhSQGPmzJkz6tKli5YvX37J/YsXL9aSJUu0fPly7dq1S61atdKAAQN0+vTpep4UAAA4VXAgn3zw4MEaPHjwJfcZY5SamqpZs2Zp2LBhkqTVq1crMjJSa9as0YQJE+pzVAAA4FCOvWcmLy9PhYWFGjhwoG+b2+3W97//fe3cubPS80pKSuT1ev0WAABw7XJszBQWFkqSIiMj/bZHRkb69l1KSkqKwsPDfUtMTEydzgkAAALLsTFzkcvl8ls3xlTY9k1JSUkqKiryLQUFBXU9IgAACKCA3jNTlVatWkn67xWaqKgo3/ajR49WuFrzTW63W263u87nAwAAzuDYKzPt2rVTq1attHXrVt+2Cxcu6B//+Id69eoVwMkAAICTBPTKTHFxsT777DPfel5ennJyctS8eXO1adNGTz31lBYuXKi4uDjFxcVp4cKFaty4sX784x8HcGoAAOAkAY2ZrKws9evXz7c+bdo0SdLo0aOVnp6un//85zp37pwmTpyokydP6vbbb9dbb72lsLCwQI0MAAAcxmWMMYEeoi55vV6Fh4erqKhIHo8n0OMAsNCpLcsCPQLgOE3vnlynj38l/3479p4ZAACA6iBmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1R8fM119/rWeeeUbt2rVTo0aN1L59e82fP1/l5eWBHg0AADhEcKAHqMqiRYv00ksvafXq1ercubOysrI0duxYhYeHa+rUqYEeDwAAOICjY+b999/X/fffryFDhkiS2rZtq7Vr1yorKyvAkwEAAKdw9NtMd955pzIyMnTgwAFJUm5urt59913dc889lZ5TUlIir9frtwAAgGuXo6/MzJgxQ0VFRfrOd76joKAglZWVacGCBXrooYcqPSclJUXJycn1OCUAAAgkR1+Zee211/THP/5Ra9as0e7du7V69Wo9++yzWr16daXnJCUlqaioyLcUFBTU48QAAKC+OfrKzPTp0zVz5kyNHDlSknTLLbfo888/V0pKikaPHn3Jc9xut9xud32OCQAAAsjRV2bOnj2r667zHzEoKIgfzQYAAD6OvjJz3333acGCBWrTpo06d+6sjz76SEuWLNG4ceMCPRoAAHAIR8fMsmXLNHv2bE2cOFFHjx5VdHS0JkyYoDlz5gR6NAAA4BCOjpmwsDClpqYqNTU10KMAAACHcvQ9MwAAAJdDzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAajWKmfbt2+v48eMVtp86dUrt27e/6qEAAACqq0Yxc+jQIZWVlVXYXlJSoi+++OKqhwIAAKiuK/oNwBs3bvT9+c0331R4eLhvvaysTBkZGWrbtm2tDQcAAHA5VxQzQ4cOlSS5XC6NHj3ab19ISIjatm2r5557rtaGAwAAuJwripny8nJJUrt27bRr1y61aNGiToYCAACorhp90GReXl5tzwEAAFAjNf7U7IyMDGVkZOjo0aO+KzYX/f73v7/qwQAAAKqjRjGTnJys+fPnKyEhQVFRUXK5XLU9FwAAQLXUKGZeeuklpaen65FHHqnteQAAAK5IjX7PzIULF9SrV6/angUAAOCK1Shmxo8frzVr1tT2LAAAAFesRm8znT9/XitXrtTbb7+tW2+9VSEhIX77lyxZUivDAQAAXE6NYmbPnj3q2rWrJOnjjz/228fNwAAAoD7VKGa2b99e23MAAADUSI3umQEAAHCKGl2Z6devX5VvJ23btq3GAwEAAFyJGsXMxftlLiotLVVOTo4+/vjjCh9ACQAAUJdqFDNLly695PZ58+apuLj4qgYCAAC4ErV6z8zDDz/M5zIBAIB6Vasx8/7776thw4a1+ZAAAABVqtHbTMOGDfNbN8boyJEjysrK0uzZs2tlMAAAgOqoUcyEh4f7rV933XXq2LGj5s+fr4EDB9bKYAAAANVRo5hJS0ur7TkAAABqpEYxc1F2drb27dsnl8ul+Ph43XbbbbU1FwAAQLXUKGaOHj2qkSNHKjMzU02bNpUxRkVFRerXr59effVVXX/99bU9JwAAwCXV6KeZJk+eLK/Xq7179+rEiRM6efKkPv74Y3m9Xk2ZMqW2ZwQAAKhUja7MbNmyRW+//bY6derk2xYfH6/f/OY33AAMAADqVY2uzJSXlyskJKTC9pCQEJWXl1/1UAAAANVVo5i56667NHXqVB0+fNi37YsvvtDTTz+t/v3719pwAAAAl1OjmFm+fLlOnz6ttm3b6sYbb1SHDh3Url07nT59WsuWLavtGQEAACpVo3tmYmJitHv3bm3dulX//ve/ZYxRfHy8EhMTa3s+AACAKl3RlZlt27YpPj5eXq9XkjRgwABNnjxZU6ZMUY8ePdS5c2e98847dTIoAADApVxRzKSmpurxxx+Xx+OpsC88PFwTJkzQkiVLam04AACAy7mimMnNzdXdd99d6f6BAwcqOzv7qocCAACoriuKmS+//PKSP5J9UXBwsI4dO3bVQwEAAFTXFcXMDTfcoH/961+V7t+zZ4+ioqKueigAAIDquqKYueeeezRnzhydP3++wr5z585p7ty5uvfee2ttOAAAgMu5oph55plndOLECd10001avHix/vKXv2jjxo1atGiROnbsqBMnTmjWrFm1OuAXX3yhhx9+WBEREWrcuLG6du3KfTkAAMDnin7PTGRkpHbu3Kmf/vSnSkpKkjFGkuRyuTRo0CC9+OKLioyMrLXhTp48qd69e6tfv37avHmzWrZsqYMHD6pp06a19hwAAMBuV/xL82JjY7Vp0yadPHlSn332mYwxiouLU7NmzWp9uEWLFikmJkZpaWm+bW3btq3ynJKSEpWUlPjWL/5OHAAAcG2q0ccZSFKzZs3Uo0cP9ezZs05CRpI2btyohIQEPfjgg2rZsqVuu+02rVq1qspzUlJSFB4e7ltiYmLqZDYAAOAMNY6Z+vCf//xHK1asUFxcnN5880098cQTmjJlil5++eVKz0lKSlJRUZFvKSgoqMeJAQBAfavRZzPVl/LyciUkJGjhwoWSpNtuu0179+7VihUr9Oijj17yHLfbLbfbXZ9jAgCAAHL0lZmoqCjFx8f7bevUqZPy8/MDNBEAAHAaR8dM7969tX//fr9tBw4cUGxsbIAmAgAATuPomHn66af1wQcfaOHChfrss8+0Zs0arVy5UpMmTQr0aAAAwCEcHTM9evTQhg0btHbtWt1888365S9/qdTUVI0aNSrQowEAAIdw9A3AknTvvffyEQkAAKBSjr4yAwAAcDnEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsZlXMpKSkyOVy6amnngr0KAAAwCGsiZldu3Zp5cqVuvXWWwM9CgAAcBArYqa4uFijRo3SqlWr1KxZsyqPLSkpkdfr9VsAAMC1y4qYmTRpkoYMGaLExMTLHpuSkqLw8HDfEhMTUw8TAgCAQHF8zLz66qvavXu3UlJSqnV8UlKSioqKfEtBQUEdTwgAAAIpONADVKWgoEBTp07VW2+9pYYNG1brHLfbLbfbXceTAQAAp3B0zGRnZ+vo0aPq3r27b1tZWZl27Nih5cuXq6SkREFBQQGcEAAABJqjY6Z///7617/+5bdt7Nix+s53vqMZM2YQMgAAwNkxExYWpptvvtlvW5MmTRQREVFhOwAA+HZy/A3AAAAAVXH0lZlLyczMDPQIAADAQbgyAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBqwYEe4Fqx/p/HAj0C4DjDe14f6BEAfAtwZQYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDVHB0zKSkp6tGjh8LCwtSyZUsNHTpU+/fvD/RYAADAQRwdM//4xz80adIkffDBB9q6dau+/vprDRw4UGfOnAn0aAAAwCGCAz1AVbZs2eK3npaWppYtWyo7O1t9+vQJ0FQAAMBJHB0z/6uoqEiS1Lx580qPKSkpUUlJiW/d6/XW+VwAACBwHP020zcZYzRt2jTdeeeduvnmmys9LiUlReHh4b4lJiamHqcEAAD1zZqYefLJJ7Vnzx6tXbu2yuOSkpJUVFTkWwoKCuppQgAAEAhWvM00efJkbdy4UTt27FDr1q2rPNbtdsvtdtfTZAAAINAcHTPGGE2ePFkbNmxQZmam2rVrF+iRAACAwzg6ZiZNmqQ1a9boL3/5i8LCwlRYWChJCg8PV6NGjQI8HQAAcAJH3zOzYsUKFRUVqW/fvoqKivItr732WqBHAwAADuHoKzPGmECPAAAAHM7RV2YAAAAuh5gBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWIGQAAYDViBgAAWI2YAQAAViNmAACA1YgZAABgNWIGAABYjZgBAABWI2YAAIDViBkAAGA1YgYAAFiNmAEAAFYjZgAAgNWsiJkXX3xR7dq1U8OGDdW9e3e98847gR4JAAA4hONj5rXXXtNTTz2lWbNm6aOPPtL3vvc9DR48WPn5+YEeDQAAOIDjY2bJkiV67LHHNH78eHXq1EmpqamKiYnRihUrAj0aAABwgOBAD1CVCxcuKDs7WzNnzvTbPnDgQO3cufOS55SUlKikpMS3XlRUJEnyer11N6iks8Wn6/TxARt5ve5Aj1ArvGfOBXoEwHGuq+N/Vy/+u22Mueyxjo6Zr776SmVlZYqMjPTbHhkZqcLCwkuek5KSouTk5ArbY2Ji6mRGAAC+nWbUy7OcPn1a4eHhVR7j6Ji5yOVy+a0bYypsuygpKUnTpk3zrZeXl+vEiROKiIio9BxcO7xer2JiYlRQUCCPxxPocQDUIr6/v12MMTp9+rSio6Mve6yjY6ZFixYKCgqqcBXm6NGjFa7WXOR2u+V2+1/abtq0aV2NCIfyeDz8ZQdco/j+/va43BWZixx9A3CDBg3UvXt3bd261W/71q1b1atXrwBNBQAAnMTRV2Ykadq0aXrkkUeUkJCgO+64QytXrlR+fr6eeOKJQI8GAAAcwPExM2LECB0/flzz58/XkSNHdPPNN2vTpk2KjY0N9GhwILfbrblz51Z4qxGA/fj+RmVcpjo/8wQAAOBQjr5nBgAA4HKIGQAAYDViBgAAWI2YgXX69u2rp556yrfetm1bpaamBmweAM4wZswYDR06NNBjIACIGTjWmDFj5HK5KiyLFy/WL3/5y0CPB3yrHD16VBMmTFCbNm3kdrvVqlUrDRo0SO+//36gR6tV6enp/KJVCzn+R7Px7Xb33XcrLS3Nb9v111+voKCgAE0EfDs98MADKi0t1erVq9W+fXt9+eWXysjI0IkTJwI9GsCVGTjbxf8BfnPp37+/39tM/6uoqEg/+clP1LJlS3k8Ht11113Kzc317c/NzVW/fv0UFhYmj8ej7t27Kysrqx5eDWCnU6dO6d1339WiRYvUr18/xcbGqmfPnkpKStKQIUMk/fcz9H73u9/phz/8oRo3bqy4uDht3LjR9xhlZWV67LHH1K5dOzVq1EgdO3bU888/7/c8F98mSk5O9n3/TpgwQRcuXPAds379et1yyy1q1KiRIiIilJiYqDNnzvg9zrPPPquoqChFRERo0qRJKi0t9e07efKkHn30UTVr1kyNGzfW4MGD9emnn0qSMjMzNXbsWBUVFfmuBM+bN0+S9OKLLyouLk4NGzZUZGSkhg8fXqtfY1wdYgbXFGOMhgwZosLCQm3atEnZ2dnq1q2b+vfv7/sf5KhRo9S6dWvt2rVL2dnZmjlzpkJCQgI8OeBcoaGhCg0N1RtvvKGSkpJKj0tOTtaPfvQj7dmzR/fcc49GjRrl+74rLy9X69attW7dOn3yySeaM2eOfvGLX2jdunV+j5GRkaF9+/Zp+/btWrt2rTZs2KDk5GRJ0pEjR/TQQw9p3Lhx2rdvnzIzMzVs2DB989elbd++XQcPHtT27du1evVqpaenKz093bd/zJgxysrK0saNG/X+++/LGKN77rlHpaWl6tWrl1JTU+XxeHTkyBEdOXJE//d//6esrCxNmTJF8+fP1/79+7Vlyxb16dOnFr/CuGoGcKjRo0eboKAg06RJE98yfPhw8/3vf99MnTrVd1xsbKxZunSpMcaYjIwM4/F4zPnz5/0e68YbbzS//e1vjTHGhIWFmfT09Pp6GcA1Yf369aZZs2amYcOGplevXiYpKcnk5ub69ksyzzzzjG+9uLjYuFwus3nz5kofc+LEieaBBx7wrY8ePdo0b97cnDlzxrdtxYoVJjQ01JSVlZns7GwjyRw6dOiSjzd69GgTGxtrvv76a9+2Bx980IwYMcIYY8yBAweMJPPee+/59n/11VemUaNGZt26dcYYY9LS0kx4eLjf4/75z382Ho/HeL3eqr5ECCCuzMDR+vXrp5ycHN/ywgsvVHl8dna2iouLFRER4fvfZGhoqPLy8nTw4EFJ//28r/HjxysxMVG//vWvfdsBVO6BBx7Q4cOHtXHjRg0aNEiZmZnq1q2b31WPW2+91ffnJk2aKCwsTEePHvVte+mll5SQkKDrr79eoaGhWrVqlfLz8/2ep0uXLmrcuLFv/Y477lBxcbEKCgrUpUsX9e/fX7fccosefPBBrVq1SidPnvQ7v3Pnzn731EVFRflm2Ldvn4KDg3X77bf79kdERKhjx47at29fpa99wIABio2NVfv27fXII4/olVde0dmzZ6v5lUN9IGbgaE2aNFGHDh18S1RUVJXHl5eXKyoqyi+AcnJytH//fk2fPl2SNG/ePO3du1dDhgzRtm3bFB8frw0bNtTHywGs1rBhQw0YMEBz5szRzp07NWbMGM2dO9e3/3/frnW5XCovL5ckrVu3Tk8//bTGjRunt956Szk5ORo7dqzf/TBVcblcCgoK0tatW7V582bFx8dr2bJl6tixo/Ly8qo1g6nk03uMMXK5XJU+d1hYmHbv3q21a9cqKipKc+bMUZcuXXTq1KlqzY66R8zgmtKtWzcVFhYqODjYL4I6dOigFi1a+I676aab9PTTT+utt97SsGHDKvzEFIDLi4+Pr3DzbWXeeecd9erVSxMnTtRtt92mDh06XPKqaG5urs6dO+db/+CDDxQaGqrWrVtL+m+c9O7dW8nJyfroo4/UoEGDav9nJD4+Xl9//bU+/PBD37bjx4/rwIED6tSpkySpQYMGKisrq3BucHCwEhMTtXjxYu3Zs0eHDh3Stm3bqvW8qHvEDK4piYmJuuOOOzR06FC9+eabOnTokHbu3KlnnnlGWVlZOnfunJ588kllZmbq888/13vvvaddu3b5/iIDUNHx48d111136Y9//KP27NmjvLw8/elPf9LixYt1//33V+sxOnTooKysLL355ps6cOCAZs+erV27dlU47sKFC3rsscf0ySefaPPmzZo7d66efPJJXXfddfrwww+1cOFCZWVlKT8/X6+//rqOHTtW7e/fuLg43X///Xr88cf17rvvKjc3Vw8//LBuuOEG3+to27atiouLlZGRoa+++kpnz57V3/72N73wwgvKycnR559/rpdfflnl5eXq2LFj9b+IqFP8nhlcU1wulzZt2qRZs2Zp3LhxOnbsmFq1aqU+ffooMjJSQUFBOn78uB599FF9+eWXatGihYYNG+b7aQkAFYWGhur222/X0qVLdfDgQZWWliomJkaPP/64fvGLX1TrMZ544gnl5ORoxIgRcrlceuihhzRx4kRt3rzZ77j+/fsrLi5Offr0UUlJiUaOHOn78WiPx6MdO3YoNTVVXq9XsbGxeu655zR48OBqv5a0tDRNnTpV9957ry5cuKA+ffpo06ZNvrenevXqpSeeeEIjRozQ8ePHNXfuXCUmJur111/XvHnzdP78ecXFxWnt2rXq3LlztZ8XdctlKnsTEQCAejRmzBidOnVKb7zxRqBHgWV4mwkAAFiNmAEAAFbjbSYAAGA1rswAAACrETMAAMBqxAwAALAaMQMAAKxGzAAAAKsRMwAAwGrEDABHmDdvnrp27RroMQBYiJgBgEsoLS0N9AgAqomYAVBrysvLtWjRInXo0EFut1tt2rTRggULJEkzZszQTTfdpMaNG6t9+/aaPXu2LxjS09OVnJys3NxcuVwuuVwupaenS5KKior0k5/8RC1btpTH49Fdd92l3Nxcv+f91a9+pZYtWyosLEzjx4/XzJkz/a7ylJeXa/78+WrdurXcbre6du2qLVu2+PYfOnRILpdL69atU9++fdWwYUOtXLlSHo9H69ev93uuv/71r2rSpIlOnz5dB19BADVBzACoNUlJSVq0aJFmz56tTz75RGvWrFFkZKQkKSwsTOnp6frkk0/0/PPPa9WqVVq6dKkkacSIEfrZz36mzp0768iRIzpy5IhGjBghY4yGDBmiwsJCbdq0SdnZ2erWrZv69++vEydOSJJeeeUVLViwQIsWLVJ2drbatGmjFStW+M31/PPP67nnntOzzz6rPXv2aNCgQfrBD36gTz/91O+4GTNmaMqUKdq3b59++MMfauTIkUpLS/M7Ji0tTcOHD1dYWFhdfRkBXCkDALXA6/Uat9ttVq1aVa3jFy9ebLp37+5bnzt3runSpYvfMRkZGcbj8Zjz58/7bb/xxhvNb3/7W2OMMbfffruZNGmS3/7evXv7PVZ0dLRZsGCB3zE9evQwEydONMYYk5eXZySZ1NRUv2M+/PBDExQUZL744gtjjDHHjh0zISEhJjMzs1qvEUD94MoMgFqxb98+lZSUqH///pfcv379et15551q1aqVQkNDNXv2bOXn51f5mNnZ2SouLlZERIRCQ0N9S15eng4ePChJ2r9/v3r27Ol33jfXvV6vDh8+rN69e/sd07t3b+3bt89vW0JCQoXH6dy5s15++WVJ0h/+8Ae1adNGffr0qXJuAPUrONADALg2NGrUqNJ9H3zwgUaOHKnk5GQNGjRI4eHhevXVV/Xcc89V+Zjl5eWKiopSZmZmhX1Nmzb1/dnlcvntM5f4/NxLHfO/25o0aVLhvPHjx2v58uWaOXOm0tLSNHbs2ArnAQgsrswAqBVxcXFq1KiRMjIyKux77733FBsbq1mzZikhIUFxcXH6/PPP/Y5p0KCBysrK/LZ169ZNhYWFCg4OVocOHfyWFi1aSJI6duyof/7zn37nZWVl+f7s8XgUHR2td9991++YnTt3qlOnTpd9XQ8//LDy8/P1wgsvaO/evRo9evRlzwFQv7gyA6BWNGzYUDNmzNDPf/5zNWjQQL1799axY8e0d+9edejQQfn5+Xr11VfVo0cP/f3vf9eGDRv8zm/btq3y8vKUk5Oj1q1bKywsTImJibrjjjs0dOhQLVq0SB07dtThw4e1adMmDR06VAkJCZo8ebIef/xxJSQkqFevXnrttde0Z88etW/f3vfY06dP19y5c3XjjTeqa9euSktLU05Ojl555ZXLvq5mzZpp2LBhmj59ugYOHKjWrVvX+tcOwFUK9E07AK4dZWVl5le/+pWJjY01ISEhpk2bNmbhwoXGGGOmT59uIiIiTGhoqBkxYoRZunSpCQ8P9517/vx588ADD5imTZsaSSYtLc0Y898biydPnmyio6NNSEiIiYmJMaNGjTL5+fm+c+fPn29atGhhQkNDzbhx48yUKVPMd7/7Xb+5kpOTzQ033GBCQkJMly5dzObNm337L94A/NFHH13ydWVkZBhJZt26dbX3xQJQa1zGXOLNZQCw2IABA9SqVSv94Q9/qJXHe+WVVzR16lQdPnxYDRo0qJXHBFB7eJsJgNXOnj2rl156SYMGDVJQUJDWrl2rt99+W1u3bq2Vx87Ly1NKSoomTJhAyAAOxQ3AAKzmcrm0adMmfe9731P37t3117/+VX/+85+VmJh41Y+9ePFide3aVZGRkUpKSqqFaQHUBd5mAgAAVuPKDAAAsBoxAwAArEbMAAAAqxEzAADAasQMAACwGjEDAACsRswAAACrETMAAMBq/w8pIzjVdon/rQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "fdf = spark.sql(\"SELECT * FROM s3tablesbucket.demo.demo.files\")\n",
+    "sdf = spark.sql(\"SELECT * FROM s3tablesbucket.demo.demo.snapshots\")\n",
+    "df = pd.DataFrame({'category': ['Files', 'Snapshots'], 'Count': [fdf.count(), sdf.count()]})\n",
+    "display(sns.barplot(data=df, x='category', y='Count', palette='pastel', hue='category'))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### What does this PR do?

This adds an example of using S3 Tables with Spark and DuckDB in a Jupyter Notebook.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

The current example is bare and need more expanding.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
