### PR TITLE
fix: Updated the Labs 2 thru 5 to run the Spark drivers on EC2 on-demand instances (Spark on eks workshop)

### DIFF
--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -521,6 +521,53 @@ module "eks_data_addons" {
       EOT
       ]
     }
+    spark-compute-graviton-on-demand = {
+      values = [
+        <<-EOT
+      name: spark-compute-graviton-on-demand
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkGravitonOnDemand
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["on-demand"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["arm64"]
+          - key: "karpenter.k8s.aws/instance-category"
+            operator: In
+            values: ["m", "c", "r"]
+          - key: "karpenter.k8s.aws/instance-cpu"
+            operator: In
+            values: ["4", "8", "16", "32"]
+          - key: "karpenter.k8s.aws/instance-hypervisor"
+            operator: In
+            values: ["nitro"]
+          - key: "karpenter.k8s.aws/instance-generation"
+            operator: Gt
+            values: ["2"]
+        limits:
+          cpu: 2000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
     spark-compute-graviton = {
       values = [
         <<-EOT

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -521,6 +521,42 @@ module "eks_data_addons" {
       EOT
       ]
     }
+    spark-compute-graviton-ondemand = {
+      values = [
+        <<-EOT
+      name: spark-compute-graviton-ondemand
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkComputeGravitonOnDemand
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["on-demand"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["arm64"]
+        limits:
+          cpu: 2000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
     spark-compute-graviton = {
       values = [
         <<-EOT

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -521,53 +521,6 @@ module "eks_data_addons" {
       EOT
       ]
     }
-    spark-compute-graviton-on-demand = {
-      values = [
-        <<-EOT
-      name: spark-compute-graviton-on-demand
-      clusterName: ${module.eks.cluster_name}
-      ec2NodeClass:
-        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
-        subnetSelectorTerms:
-          tags:
-            Name: "${module.eks.cluster_name}-private*"
-        securityGroupSelectorTerms:
-          tags:
-            Name: ${module.eks.cluster_name}-node
-        instanceStorePolicy: RAID0
-      nodePool:
-        labels:
-          - type: karpenter
-          - NodeGroupType: SparkGravitonOnDemand
-          - multiArch: Spark
-        requirements:
-          - key: "karpenter.sh/capacity-type"
-            operator: In
-            values: ["on-demand"]
-          - key: "kubernetes.io/arch"
-            operator: In
-            values: ["arm64"]
-          - key: "karpenter.k8s.aws/instance-category"
-            operator: In
-            values: ["m", "c", "r"]
-          - key: "karpenter.k8s.aws/instance-cpu"
-            operator: In
-            values: ["4", "8", "16", "32"]
-          - key: "karpenter.k8s.aws/instance-hypervisor"
-            operator: In
-            values: ["nitro"]
-          - key: "karpenter.k8s.aws/instance-generation"
-            operator: Gt
-            values: ["2"]
-        limits:
-          cpu: 2000
-        disruption:
-          consolidationPolicy: WhenEmptyOrUnderutilized
-          consolidateAfter: 1m
-        weight: 100
-      EOT
-      ]
-    }
     spark-compute-graviton = {
       values = [
         <<-EOT

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -521,10 +521,10 @@ module "eks_data_addons" {
       EOT
       ]
     }
-    spark-compute-graviton-ondemand = {
+    spark-compute-graviton-od-memory = {
       values = [
         <<-EOT
-      name: spark-compute-graviton-ondemand
+      name: spark-compute-graviton-od-memory
       clusterName: ${module.eks.cluster_name}
       ec2NodeClass:
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
@@ -539,7 +539,7 @@ module "eks_data_addons" {
       nodePool:
         labels:
           - type: karpenter
-          - NodeGroupType: SparkComputeGravitonOnDemand
+          - NodeGroupType: SparkComputeGravitonODMemory
           - multiArch: Spark
         requirements:
           - key: "karpenter.sh/capacity-type"
@@ -548,6 +548,18 @@ module "eks_data_addons" {
           - key: "kubernetes.io/arch"
             operator: In
             values: ["arm64"]
+          - key: "karpenter.k8s.aws/instance-category"
+            operator: In
+            values: ["r"]
+          - key: "karpenter.k8s.aws/instance-cpu"
+            operator: In
+            values: ["4", "8", "16", "32"]
+          - key: "karpenter.k8s.aws/instance-hypervisor"
+            operator: In
+            values: ["nitro"]
+          - key: "karpenter.k8s.aws/instance-generation"
+            operator: Gt
+            values: ["2"]
         limits:
           cpu: 2000
         disruption:

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -511,7 +511,7 @@ module "eks_data_addons" {
             values: ["r"]
           - key: karpenter.k8s.aws/instance-family
             operator: In
-            values: ["r5","r5n"]
+            values: ["r5","r5n", "r6i", "r6in", "r7i"]
         limits:
           cpu: 2000
         disruption:

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -633,7 +633,7 @@ module "eks_data_addons" {
         requirements:
           - key: "karpenter.sh/capacity-type"
             operator: In
-            values: ["spot", "on-demand"]
+            values: ["on-demand"]
           - key: "kubernetes.io/arch"
             operator: In
             values: ["amd64"]

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -633,7 +633,7 @@ module "eks_data_addons" {
         requirements:
           - key: "karpenter.sh/capacity-type"
             operator: In
-            values: ["on-demand"]
+            values: ["spot", "on-demand"]
           - key: "kubernetes.io/arch"
             operator: In
             values: ["amd64"]

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
@@ -144,7 +144,7 @@ spec:
     labels:
       version: 3.2.1
     nodeSelector:
-      NodeGroupType: "SparkComputeGravitonOnDemand"
+      NodeGroupType: "SparkComputeGravitonODMemory"
   executor:
     podSecurityContext:
       # runAsUser: 1000

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
@@ -144,7 +144,7 @@ spec:
     labels:
       version: 3.2.1
     nodeSelector:
-      NodeGroupType: "SparkGravitonMemoryOptimized"
+      NodeGroupType: "SparkGravitonOnDemand"
   executor:
     podSecurityContext:
       # runAsUser: 1000

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
@@ -144,7 +144,7 @@ spec:
     labels:
       version: 3.2.1
     nodeSelector:
-      NodeGroupType: "SparkGravitonOnDemand"
+      NodeGroupType: "SparkGravitonMemoryOptimized"
   executor:
     podSecurityContext:
       # runAsUser: 1000

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
@@ -144,7 +144,7 @@ spec:
     labels:
       version: 3.2.1
     nodeSelector:
-      NodeGroupType: "SparkGravitonMemoryOptimized"
+      NodeGroupType: "SparkComputeGravitonOnDemand"
   executor:
     podSecurityContext:
       # runAsUser: 1000

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-nvme.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-nvme.yaml
@@ -144,7 +144,7 @@ spec:
     labels:
       version: 3.2.1
     nodeSelector:
-      NodeGroupType: "SparkComputeNitroNvme"
+      NodeGroupType: "SparkComputeOnDemand"
   executor:
     podSecurityContext:
       # runAsUser: 1000

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-cmr.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-cmr.yaml
@@ -142,7 +142,7 @@ spec:
     labels:
       version: 3.2.1
     nodeSelector:
-      NodeGroupType: "SparkComputeSpotCMR"
+      NodeGroupType: "SparkComputeOnDemand"
   executor:
     podSecurityContext:
       # runAsUser: 1000

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-r.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-r.yaml
@@ -144,7 +144,7 @@ spec:
     labels:
       version: 3.2.1
     nodeSelector:
-      NodeGroupType: "SparkComputeSpotR"
+      NodeGroupType: "SparkComputeOnDemand"
   executor:
     podSecurityContext:
       # runAsUser: 1000


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Spark on eks workshopUpdated the Labs 2 through 5 to run the Spark drivers on EC2 on-demand instances.

EC2 Spot best practices for running Spark workloads is to schedule the Spark drivers on EC2 On-Demand and schedule the Spark executors on a mix of EC2 mOn-Demand and Spot instances. This PR adds a following:

- A new NodePool - SparkComputeGravitonODMemory- that runs On-Demand Graviton memory optimized EC2 instances
- Updated NodePool - SparkComputeSpotR- to run r5, r5n, r6i, r6in and r7i EC2 families
- Updated the Spark job in Flexible Fleet Optimizer (Lab) to run Spark drivers on SparkComputeOnDemand NodePool
- Updated the Spark job in Memory-Intensive Analytics (Lab) to run Spark drivers on SparkComputeOnDemand NodePool
- Updated the Spark job in High-Speed I/O Express (Lab) to run Spark drivers on SparkComputeOnDemand NodePool
- Updated the Spark job in ARM-Powered Performance (Lab) to run Spark drivers on SparkComputeGravitonODMemory NodePool

### Motivation

https://aws.amazon.com/blogs/compute/running-cost-optimized-spark-workloads-on-kubernetes-using-ec2-spot-instances/

<!-- What inspired you to submit this pull request? -->

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
