### PR TITLE
fix: Generate multiple input files for spark workshop

### DIFF
--- a/analytics/scripts/order-execute.sh
+++ b/analytics/scripts/order-execute.sh
@@ -26,4 +26,7 @@ INPUT_DATA_S3_PATH="s3://${S3_DIRECTORY_BUCKET}/order/input"
 aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key scripts/pyspark-order.py --body pyspark-order.py --region ${REGION}
 
 # Copy Test Input data to S3 bucket
-aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order.parquet --body order.parquet --region ${REGION}
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order1.parquet --body order.parquet --region ${REGION}
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order2.parquet --body order.parquet --region ${REGION}
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order3.parquet --body order.parquet --region ${REGION}
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order4.parquet --body order.parquet --region ${REGION}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This is to generate multiple input files for the Spark workshop labs. The current 7M records file wasn't sufficient enough to make jobs run longer. This PR would copy the same file four times so making it 25M+ records for the labs.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
