### PR TITLE
fix: Update s3tables examples to use iceberg rest catalog api

### DIFF
--- a/analytics/terraform/spark-k8s-operator/examples/s3-tables/s3table-iceberg-pyspark.ipynb
+++ b/analytics/terraform/spark-k8s-operator/examples/s3-tables/s3table-iceberg-pyspark.ipynb
@@ -3,15 +3,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6e966091-0998-449f-9dcd-a2032fa39f36",
+   "id": "41ea5a6d-f7cf-4d60-a093-4947b9b7f9b8",
    "metadata": {},
    "outputs": [],
    "source": [
     "import logging\n",
     "import sys\n",
+    "import os\n",
     "from datetime import datetime\n",
-    "\n",
+    "from decimal import Decimal\n",
+    "from IPython.display import display, HTML\n",
     "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql.types import StructType, StructField, StringType, IntegerType, FloatType, DecimalType, LongType\n",
+    "\n",
     "\n",
     "# Logging configuration\n",
     "formatter = logging.Formatter('[%(asctime)s] %(levelname)s @ line %(lineno)d: %(message)s')\n",
@@ -25,39 +29,30 @@
     "\n",
     "# Application-specific variables\n",
     "dt_string = datetime.now().strftime(\"%Y_%m_%d_%H_%M_%S\")\n",
-    "AppName = \"EmployeeDataS3TableJob\"\n",
+    "AppName = \"Demo\"\n",
+    "# AWS specific variables\n",
+    "region = os.environ.get('AWS_REGION', 'us-east-1')\n",
     "\n",
     "# Replace S3_BUCKET and ACCOUNT_NUMBER with your own values\n",
     "input_csv_path = \"s3a://<S3_BUCKET>/s3table-example/input/\"\n",
-    "s3table_arn = \"arn:aws:s3tables:us-west-2:<ACCOUNT_NUMBER>:bucket/doeks-spark-s3-tables\"\n",
+    "# Ensure this table bucket exists\n",
+    "s3table_arn = f\"arn:aws:s3tables:{region}:<ACCOUNT_NUMBER>:bucket/doeks-spark-s3-tables\"\n",
     "namespace = \"doeks_namespace\"\n",
     "table_name = \"employee_s3_table\"\n",
-    "full_table_name = f\"s3tablesbucket.{namespace}.{table_name}\"\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "d38e589b-b0ab-41b6-a339-07f5026a7262",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2025-01-13 19:47:18,917] INFO @ line 22: Spark session initialized successfully\n"
-     ]
-    }
-   ],
-   "source": [
+    "full_table_name = f\"s3tablesbucket.{namespace}.{table_name}\"\n",
     "\n",
     "spark = (SparkSession\n",
     "    .builder\n",
     "    .appName(f\"{AppName}_{dt_string}\")\n",
     "    .config(\"spark.sql.extensions\", \"org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions\")\n",
     "    .config(\"spark.sql.catalog.s3tablesbucket\", \"org.apache.iceberg.spark.SparkCatalog\")\n",
-    "    .config(\"spark.sql.catalog.s3tablesbucket.catalog-impl\", \"software.amazon.s3tables.iceberg.S3TablesCatalog\")\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.type\", \"rest\")\n",
     "    .config(\"spark.sql.catalog.s3tablesbucket.warehouse\", s3table_arn)\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.uri\", f\"https://s3tables.{region}.amazonaws.com/iceberg\")\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.rest.sigv4-enabled\", \"true\")\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.rest.signing-name\", \"s3tables\")\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.rest.signing-region\", region)\n",
+    "    .config(\"spark.sql.catalog.s3tablesbucket.io-impl\", \"org.apache.iceberg.aws.s3.S3FileIO\")\n",
     "    .config('spark.hadoop.fs.s3.impl', \"org.apache.hadoop.fs.s3a.S3AFileSystem\")\n",
     "    .config(\"spark.sql.defaultCatalog\", \"s3tablesbucket\")\n",
     "    .config(\"spark.hadoop.fs.s3a.connection.timeout\", \"1200000\") \\\n",
@@ -68,163 +63,157 @@
     "    .config(\"spark.hadoop.fs.s3a.input.fadvise\", \"random\") \\\n",
     "    .config(\"spark.hadoop.fs.s3a.aws.credentials.provider.mapping\", \"com.amazonaws.auth.WebIdentityTokenCredentialsProvider=software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider\") \\\n",
     "    .config(\"spark.hadoop.fs.s3a.aws.credentials.provider\", \"software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider\")\n",
-    "    .getOrCreate())\n",
-    "\n",
-    "spark.sparkContext.setLogLevel(\"DEBUG\")\n",
-    "logger.info(\"Spark session initialized successfully\")\n"
+    "    .getOrCreate())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "3c157786-d661-44e0-af6a-05b94a9e9b0e",
+   "execution_count": 2,
+   "id": "baca6897-37d8-4374-b632-caac952cef07",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2025-01-13 19:47:18,923] INFO @ line 6: Creating namespace: doeks_namespace\n",
-      "[2025-01-13 19:47:21,093] INFO @ line 10: Reading employee data from input CSV: s3a://<S3_BUCKET>/s3table-example/input/\n",
-      "[2025-01-13 19:47:24,560] INFO @ line 13: Previewing employee data schema\n",
-      "root\n",
-      " |-- id: integer (nullable = true)\n",
-      " |-- name: string (nullable = true)\n",
-      " |-- level: string (nullable = true)\n",
-      " |-- salary: double (nullable = true)\n",
-      "\n",
-      "[2025-01-13 19:47:24,564] INFO @ line 16: Previewing first 10 records from the input data\n",
-      "+---+-----------+------+--------+\n",
-      "|id |name       |level |salary  |\n",
-      "+---+-----------+------+--------+\n",
-      "|1  |Employee_1 |Exec  |101000.0|\n",
-      "|2  |Employee_2 |Exec  |149000.0|\n",
-      "|3  |Employee_3 |Junior|86000.0 |\n",
-      "|4  |Employee_4 |Exec  |147500.0|\n",
-      "|5  |Employee_5 |Exec  |74000.0 |\n",
-      "|6  |Employee_6 |Exec  |66500.0 |\n",
-      "|7  |Employee_7 |Junior|69500.0 |\n",
-      "|8  |Employee_8 |Exec  |116000.0|\n",
-      "|9  |Employee_9 |Mid   |56000.0 |\n",
-      "|10 |Employee_10|Exec  |186500.0|\n",
-      "+---+-----------+------+--------+\n",
-      "only showing top 10 rows\n",
-      "\n",
-      "[2025-01-13 19:47:24,799] INFO @ line 19: Source data count:\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "100"
+       "DataFrame[]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "namespace = \"doeks_namespace\"\n",
-    "table_name = \"employee_s3_table\"\n",
-    "full_table_name = f\"s3tablesbucket.{namespace}.{table_name}\"\n",
-    "\n",
-    "# Step 1: Create namespace if not exists\n",
-    "logger.info(f\"Creating namespace: {namespace}\")\n",
-    "spark.sql(f\"CREATE NAMESPACE IF NOT EXISTS s3tablesbucket.{namespace}\")\n",
-    "\n",
-    "# Step 2: Read input CSV data\n",
-    "logger.info(f\"Reading employee data from input CSV: {input_csv_path}\")\n",
-    "employee_df = spark.read.csv(input_csv_path, header=True, inferSchema=True)\n",
-    "\n",
-    "logger.info(\"Previewing employee data schema\")\n",
-    "employee_df.printSchema()\n",
-    "\n",
-    "logger.info(\"Previewing first 10 records from the input data\")\n",
-    "employee_df.show(10, truncate=False)\n",
-    "\n",
-    "logger.info(\"Source data count:\")\n",
-    "employee_df.count()\n",
-    "\n"
+    "# Create namespace if not exists\n",
+    "spark.sql(f\"CREATE NAMESPACE IF NOT EXISTS s3tablesbucket.{namespace}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "0fe0e464-22f2-43e8-8cfe-36e108359a62",
+   "execution_count": 3,
+   "id": "e2c2d161-27d0-4519-af19-853e1cdded8e",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-01-13 19:47:25,207] INFO @ line 2: Creating/Replacing and writing data to table: s3tablesbucket.doeks_namespace.employee_s3_table\n",
-      "[2025-01-13 19:47:27,861] INFO @ line 8: Reading data back from Iceberg table: s3tablesbucket.doeks_namespace.employee_s3_table\n",
-      "[2025-01-13 19:47:28,079] INFO @ line 11: Previewing first 10 records from the Iceberg table\n",
-      "+---+-----------+------+--------+\n",
-      "|id |name       |level |salary  |\n",
-      "+---+-----------+------+--------+\n",
-      "|1  |Employee_1 |Exec  |101000.0|\n",
-      "|2  |Employee_2 |Exec  |149000.0|\n",
-      "|3  |Employee_3 |Junior|86000.0 |\n",
-      "|4  |Employee_4 |Exec  |147500.0|\n",
-      "|5  |Employee_5 |Exec  |74000.0 |\n",
-      "|6  |Employee_6 |Exec  |66500.0 |\n",
-      "|7  |Employee_7 |Junior|69500.0 |\n",
-      "|8  |Employee_8 |Exec  |116000.0|\n",
-      "|9  |Employee_9 |Mid   |56000.0 |\n",
-      "|10 |Employee_10|Exec  |186500.0|\n",
-      "+---+-----------+------+--------+\n",
-      "only showing top 10 rows\n",
-      "\n",
-      "[2025-01-13 19:47:28,794] INFO @ line 15: Total records in Iceberg table (DataFrame API):\n",
-      "DataFrame count: 100\n",
-      "[2025-01-13 19:47:29,153] INFO @ line 19: List the s3table snapshot versions:\n",
-      "+--------------------+-------------------+---------+-------------------+\n",
-      "|     made_current_at|        snapshot_id|parent_id|is_current_ancestor|\n",
-      "+--------------------+-------------------+---------+-------------------+\n",
-      "|2025-01-13 19:45:...| 271131297078418895|     NULL|              false|\n",
-      "|2025-01-13 19:47:...|1268450705309139006|     NULL|               true|\n",
-      "+--------------------+-------------------+---------+-------------------+\n",
-      "\n",
-      "[2025-01-13 19:47:29,349] INFO @ line 23: Stopping Spark Session\n"
+      "root\n",
+      " |-- id: integer (nullable = true)\n",
+      " |-- name: string (nullable = true)\n",
+      " |-- level: string (nullable = true)\n",
+      " |-- salary: double (nullable = true)\n",
+      "\n"
      ]
     }
    ],
    "source": [
-    "# Step 3: Create or replace table and write data in one operation\n",
-    "logger.info(f\"Creating/Replacing and writing data to table: {full_table_name}\")\n",
-    "(employee_df.writeTo(full_table_name)\n",
-    "            .using(\"iceberg\")\n",
-    "            .createOrReplace())\n",
-    "\n",
-    "# Step 4: Read data back from the Iceberg table\n",
-    "logger.info(f\"Reading data back from Iceberg table: {full_table_name}\")\n",
-    "iceberg_data_df = spark.read.format(\"iceberg\").load(full_table_name)\n",
-    "\n",
-    "logger.info(\"Previewing first 10 records from the Iceberg table\")\n",
-    "iceberg_data_df.show(10, truncate=False)\n",
-    "\n",
-    "# Count records using both DataFrame API and SQL\n",
-    "logger.info(\"Total records in Iceberg table (DataFrame API):\")\n",
-    "print(f\"DataFrame count: {iceberg_data_df.count()}\")\n",
-    "\n",
-    "# List the table snapshots\n",
-    "logger.info(\"List the s3table snapshot versions:\")\n",
-    "spark.sql(f\"SELECT * FROM {full_table_name}.history LIMIT 10\").show()\n",
-    "\n",
-    "# Stop Spark session\n",
-    "logger.info(\"Stopping Spark Session\")\n",
-    "spark.stop()"
+    "# Read input CSV data\n",
+    "employee_df = spark.read.csv(input_csv_path, header=True, inferSchema=True)\n",
+    "employee_df.printSchema()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a41ac2c9-96a0-420a-b270-8d720a0e094b",
+   "execution_count": 4,
+   "id": "d2ed084f-4ae5-45aa-91d7-a79f9254954a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a table\n",
+    "spark.sql(f\"\"\"\n",
+    "    CREATE TABLE IF NOT EXISTS {full_table_name} (\n",
+    "        id INT,\n",
+    "        name STRING,\n",
+    "        level STRING,\n",
+    "        salary DOUBLE\n",
+    "    )\n",
+    "    USING iceberg\n",
+    "    OPTIONS ('format-version'='2')\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9bbfb7b8-0022-40cd-aab3-ce9cb8d65a0f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Write to the table\n",
+    "employee_df.writeTo(full_table_name).using('iceberg').append()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e8631bea-26f5-4326-8d7e-e385350a98a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read back from S3 Tables\n",
+    "iceberg_data_df = spark.read.format(\"iceberg\").load(full_table_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a04dac5b-6d41-470e-87f3-e888ff8e3958",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+-----------+------+--------+\n",
+      "|id |name       |level |salary  |\n",
+      "+---+-----------+------+--------+\n",
+      "|1  |Employee_1 |Senior|197000.0|\n",
+      "|2  |Employee_2 |Mid   |117500.0|\n",
+      "|3  |Employee_3 |Senior|54500.0 |\n",
+      "|4  |Employee_4 |Mid   |110000.0|\n",
+      "|5  |Employee_5 |Junior|59000.0 |\n",
+      "|6  |Employee_6 |Mid   |165500.0|\n",
+      "|7  |Employee_7 |Senior|137000.0|\n",
+      "|8  |Employee_8 |Junior|71000.0 |\n",
+      "|9  |Employee_9 |Exec  |140000.0|\n",
+      "|10 |Employee_10|Senior|129500.0|\n",
+      "+---+-----------+------+--------+\n",
+      "only showing top 10 rows\n",
+      "\n",
+      "DataFrame count: 700\n",
+      "+--------------------+-------------------+-------------------+-------------------+\n",
+      "|     made_current_at|        snapshot_id|          parent_id|is_current_ancestor|\n",
+      "+--------------------+-------------------+-------------------+-------------------+\n",
+      "|2025-04-14 17:04:...|1247367129977964401|               NULL|               true|\n",
+      "|2025-04-14 17:04:...|2293528557878885471|1247367129977964401|               true|\n",
+      "|2025-04-14 17:29:...|8156129775284340201|2293528557878885471|               true|\n",
+      "|2025-04-14 17:39:...|7353788801766500304|8156129775284340201|               true|\n",
+      "|2025-04-14 17:41:...|8234500388044211909|7353788801766500304|               true|\n",
+      "|2025-04-14 17:47:...|5976269847974860656|8234500388044211909|               true|\n",
+      "|2025-04-14 18:30:...|2240011576343306175|5976269847974860656|               true|\n",
+      "+--------------------+-------------------+-------------------+-------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# List the table snapshots\n",
+    "iceberg_data_df.show(10, truncate=False)\n",
+    "print(f\"DataFrame count: {iceberg_data_df.count()}\")\n",
+    "spark.sql(f\"SELECT * FROM {full_table_name}.history LIMIT 10\").show()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This updates the S3 Tables examples to use Apache Iceberg REST APIs because this is now the recommended approach to using S3 Tables.

### Motivation

I would like to keep the examples in-line with recommendations.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
