### PR TITLE
feat: Merge changes from spark-on-eks-workshop branch into main branch

### DIFF
--- a/analytics/scripts/order-execute.sh
+++ b/analytics/scripts/order-execute.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This job copies Sample PySpark script and some test data to your S3 Directory bucket which will enable you to run Spark Operator scripts
+
+# Prerequisites for running this shell script
+#     1/ Execute the Python script generate-order-data.py to generate order.parquet input file
+#     2/ Execute the shell script with the required arguments
+#         ./your_script.sh <S3_DIRECTORY_BUCKET> <REGION>
+#     3/ Ensure <S3_DIRECTORY_BUCKET> is replaced in "spark-app-*.yaml" files
+#     4/ Execute the shell script which creates the input data in your S3 Directory bucket
+#     5/ Run `kubectl apply -f spark-app-*.yaml` to trigger the Spark job
+#     6/ Monitor the Spark job using "kubectl get pods -n spark-s3-express -w"
+
+# Script usage ./order-execute my-s3-directory-bucket us-west-2
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <S3_DIRECTORY_BUCKET> <REGION>"
+  exit 1
+fi
+
+S3_DIRECTORY_BUCKET="$1"
+REGION="$2"
+
+INPUT_DATA_S3_PATH="s3://${S3_DIRECTORY_BUCKET}/order/input"
+
+# Copy PySpark Script to S3 bucket
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key scripts/pyspark-order.py --body pyspark-order.py --region ${REGION}
+
+# Copy Test Input data to S3 bucket
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order1.parquet --body order.parquet --region ${REGION}
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order2.parquet --body order.parquet --region ${REGION}
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order3.parquet --body order.parquet --region ${REGION}
+aws s3api put-object --bucket ${S3_DIRECTORY_BUCKET} --key order/input/order4.parquet --body order.parquet --region ${REGION}

--- a/analytics/scripts/pyspark-order.py
+++ b/analytics/scripts/pyspark-order.py
@@ -1,0 +1,78 @@
+import logging
+import sys
+from datetime import datetime
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import *
+from pyspark.sql import functions as f
+from pyspark.sql.functions import year
+from pyspark.sql.functions import col
+from pyspark.sql.functions import month
+from pyspark.sql.functions import dayofmonth
+
+# Logging configuration
+formatter = logging.Formatter('[%(asctime)s] %(levelname)s @ line %(lineno)d: %(message)s')
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.INFO)
+handler.setFormatter(formatter)
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+
+dt_string = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+AppName = "OrderData"
+
+
+def main(args):
+
+    raw_input_folder = args[1]
+    transform_output_folder = args[2]
+
+    # Create Spark Session
+    spark = SparkSession \
+        .builder \
+        .appName(AppName + "_" + str(dt_string)) \
+        .getOrCreate()
+
+    spark.sparkContext.setLogLevel("INFO")
+    logger.info("Starting spark application")
+
+    logger.info("Reading Parquet file from S3")
+    order_df = spark.read.parquet(raw_input_folder)
+
+    # Add additional columns to the DF
+    #final_order_df = order_df.withColumn("current_date", f.lit(datetime.now()))
+
+    # split order date into year month and date columns
+    final_order_df = order_df.withColumn('year', year('order_date'))
+    final_order_df = final_order_df.withColumn('month', month('order_date'))
+    final_order_df = final_order_df.withColumn('day', dayofmonth('order_date'))
+
+    # delete order date column
+    final_order_df = final_order_df.drop('order_date')
+
+    logger.info("Order data schema preview")
+    final_order_df.printSchema()
+
+    logger.info("Previewing order data sample")
+    final_order_df.show(20, truncate=False)
+
+    logger.info("Total number of records: " + str(final_order_df.count()))
+
+    logger.info("Write order data to S3 transform table")
+    final_order_df.repartition(2).write.mode("overwrite").parquet(transform_output_folder)
+
+    logger.info("Ending spark application")
+    # end spark code
+    spark.stop()
+
+    return None
+
+
+if __name__ == "__main__":
+    print(len(sys.argv))
+    if len(sys.argv) != 3:
+        print("Usage: spark-etl [input-folder] [output-folder]")
+        sys.exit(0)
+
+    main(sys.argv)

--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -6,7 +6,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0 |

--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -33,6 +33,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="module_eks_data_addons"></a> [eks\_data\_addons](#module\_eks\_data\_addons) | aws-ia/eks-data-addons/aws | 1.35 |
 | <a name="module_jupyterhub_single_user_irsa"></a> [jupyterhub\_single\_user\_irsa](#module\_jupyterhub\_single\_user\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.52.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.6 |
+| <a name="module_s3_csi_driver_irsa"></a> [s3\_csi\_driver\_irsa](#module\_s3\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.34 |
 | <a name="module_spark_team_irsa"></a> [spark\_team\_irsa](#module\_spark\_team\_irsa) | aws-ia/eks-blueprints-addon/aws | ~> 1.1 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.19 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.19 |
@@ -44,12 +45,14 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 |------|------|
 | [aws_eks_access_entry.karpenter_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_entry) | resource |
 | [aws_iam_policy.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_irsa_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3tables_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.spark](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.cloudwatch_observability_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_observability_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_prometheus_workspace.amp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_workspace) | resource |
+| [aws_s3_directory_bucket.spark_data_bucket_express](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_directory_bucket) | resource |
 | [aws_s3_object.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_secretsmanager_secret.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
@@ -106,5 +109,8 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
 | <a name="output_s3_bucket_id_spark_history_server"></a> [s3\_bucket\_id\_spark\_history\_server](#output\_s3\_bucket\_id\_spark\_history\_server) | Spark History server logs S3 bucket ID |
 | <a name="output_s3_bucket_region_spark_history_server"></a> [s3\_bucket\_region\_spark\_history\_server](#output\_s3\_bucket\_region\_spark\_history\_server) | Spark History server logs S3 bucket ID |
+| <a name="output_s3directory_bucket_name"></a> [s3directory\_bucket\_name](#output\_s3directory\_bucket\_name) | s3 directory bucket name |
+| <a name="output_s3directory_bucket_region"></a> [s3directory\_bucket\_region](#output\_s3directory\_bucket\_region) | s3 directory bucket region |
+| <a name="output_s3directory_bucket_zone"></a> [s3directory\_bucket\_zone](#output\_s3directory\_bucket\_zone) | s3 directory bucket availability zone |
 | <a name="output_subnet_ids_starting_with_100"></a> [subnet\_ids\_starting\_with\_100](#output\_subnet\_ids\_starting\_with\_100) | Secondary CIDR Private Subnet IDs for EKS Data Plane |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -404,6 +404,275 @@ module "eks_data_addons" {
       EOT
       ]
     }
+    spark-compute-ondemand = {
+      values = [
+        <<-EOT
+      name: spark-compute-ondemand
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkComputeOnDemand
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["on-demand"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["amd64"]
+        limits:
+          cpu: 2000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
+    spark-compute-spot-cmr = {
+      values = [
+        <<-EOT
+      name: spark-compute-spot-cmr
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkComputeSpotCMR
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["spot"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["amd64"]
+          - key: "karpenter.k8s.aws/instance-category"
+            operator: In
+            values: ["c","m","r"]
+        limits:
+          cpu: 2000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
+    spark-compute-spot-r = {
+      values = [
+        <<-EOT
+      name: spark-compute-spot-r
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkComputeSpotR
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["spot"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["amd64"]
+          - key: "karpenter.k8s.aws/instance-category"
+            operator: In
+            values: ["r"]
+          - key: karpenter.k8s.aws/instance-family
+            operator: In
+            values: ["r5","r5n", "r6i", "r6in", "r7i"]
+        limits:
+          cpu: 2000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
+    spark-compute-graviton-od-memory = {
+      values = [
+        <<-EOT
+      name: spark-compute-graviton-od-memory
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkComputeGravitonODMemory
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["on-demand"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["arm64"]
+          - key: "karpenter.k8s.aws/instance-category"
+            operator: In
+            values: ["r"]
+          - key: "karpenter.k8s.aws/instance-cpu"
+            operator: In
+            values: ["4", "8", "16", "32"]
+          - key: "karpenter.k8s.aws/instance-hypervisor"
+            operator: In
+            values: ["nitro"]
+          - key: "karpenter.k8s.aws/instance-generation"
+            operator: Gt
+            values: ["2"]
+        limits:
+          cpu: 2000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
+    spark-compute-graviton = {
+      values = [
+        <<-EOT
+      name: spark-compute-graviton
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkGravitonMemoryOptimized
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["spot", "on-demand"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["arm64"]
+          - key: "karpenter.k8s.aws/instance-category"
+            operator: In
+            values: ["r"]
+          - key: "karpenter.k8s.aws/instance-family"
+            operator: In
+            values: ["r6gd"]
+          - key: "karpenter.k8s.aws/instance-cpu"
+            operator: In
+            values: ["4", "8", "16", "32"]
+          - key: "karpenter.k8s.aws/instance-hypervisor"
+            operator: In
+            values: ["nitro"]
+          - key: "karpenter.k8s.aws/instance-generation"
+            operator: Gt
+            values: ["2"]
+        limits:
+          cpu: 2000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
+    spark-compute-nitro-nvme = {
+      values = [
+        <<-EOT
+      name: spark-compute-nitro-nvme
+      clusterName: ${module.eks.cluster_name}
+      ec2NodeClass:
+        amiFamily: AL2023
+        amiSelectorTerms:
+          - alias: al2023@latest # Amazon Linux 2023
+        karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
+        subnetSelectorTerms:
+          tags:
+            Name: "${module.eks.cluster_name}-private*"
+        securityGroupSelectorTerms:
+          tags:
+            Name: ${module.eks.cluster_name}-node
+        instanceStorePolicy: RAID0
+
+      nodePool:
+        labels:
+          - type: karpenter
+          - NodeGroupType: SparkComputeNitroNvme
+          - multiArch: Spark
+        requirements:
+          - key: "karpenter.sh/capacity-type"
+            operator: In
+            values: ["spot", "on-demand"]
+          - key: "kubernetes.io/arch"
+            operator: In
+            values: ["amd64"]
+          - key: "karpenter.k8s.aws/instance-category"
+            operator: In
+            values: ["c"]
+          - key: "karpenter.k8s.aws/instance-family"
+            operator: In
+            values: ["c5d"]
+          - key: "karpenter.k8s.aws/instance-size"
+            operator: In
+            values: ["4xlarge", "9xlarge", "12xlarge", "18xlarge", "24xlarge"]
+          - key: "karpenter.k8s.aws/instance-hypervisor"
+            operator: In
+            values: ["nitro"]
+          - key: "karpenter.k8s.aws/instance-generation"
+            operator: Gt
+            values: ["2"]
+        limits:
+          cpu: 1000
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 1m
+        weight: 100
+      EOT
+      ]
+    }
   }
 
   #---------------------------------------------------------------
@@ -449,6 +718,7 @@ module "eks_data_addons" {
             - spark-team-a
             - spark-team-b
             - spark-team-c
+            - spark-s3-express
           serviceAccount:
             # -- Specifies whether to create a service account for the controller.
             create: false
@@ -494,7 +764,7 @@ module "eks_data_addons" {
   # Spark history server is required only when EMR Spark Operator is enabled
   enable_spark_history_server = true
   spark_history_server_helm_config = {
-    chart_version = "1.2.0"
+    version = "1.2.0"
     values = [
       <<-EOT
       sparkHistoryOpts: "-Dspark.history.fs.logDirectory=s3a://${module.s3_bucket.s3_bucket_id}/${aws_s3_object.this.key}"
@@ -507,7 +777,7 @@ module "eks_data_addons" {
   #---------------------------------------------------------------
   enable_kubecost = true
   kubecost_helm_config = {
-    chart_version       = "2.6.2"
+    version             = "2.7.0"
     values              = [templatefile("${path.module}/helm-values/kubecost-values.yaml", {})]
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password

--- a/analytics/terraform/spark-k8s-operator/eks.tf
+++ b/analytics/terraform/spark-k8s-operator/eks.tf
@@ -40,6 +40,10 @@ module "eks" {
       most_recent              = true
     }
 
+    aws-mountpoint-s3-csi-driver = {
+      service_account_role_arn = module.s3_csi_driver_irsa.iam_role_arn
+    }
+
     metrics-server = {}
     amazon-cloudwatch-observability = {
       preserve                 = true
@@ -335,4 +339,51 @@ module "ebs_csi_driver_irsa" {
     }
   }
   tags = local.tags
+}
+
+#---------------------------------------------------------------
+# IRSA for Mountpoint S3 CSI Driver
+#---------------------------------------------------------------
+module "s3_csi_driver_irsa" {
+  source           = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version          = "~> 5.34"
+  role_name_prefix = format("%s-%s-", local.name, "s3-csi-driver")
+  role_policy_arns = {
+    # WARNING: Demo purpose only. Bring your own IAM policy with least privileges
+    s3_access = aws_iam_policy.s3_irsa_access_policy.arn
+    #kms_access = "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser"
+  }
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:s3-csi-driver-sa"]
+    }
+  }
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "s3_irsa_access_policy" {
+  name        = "${local.name}-S3Access"
+  path        = "/"
+  description = "S3 Access for Nodes"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  # checkov:skip=CKV_AWS_288: Demo purpose IAM policy
+  # checkov:skip=CKV_AWS_290: Demo purpose IAM policy
+  # checkov:skip=CKV_AWS_289: Demo purpose IAM policy
+  # checkov:skip=CKV_AWS_355: Demo purpose IAM policy
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:*",
+          "s3express:*"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-graviton.yaml
@@ -1,0 +1,172 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: spark-s3-mount-graviton-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - uid=1001
+    - gid=185
+    - allow-other
+    - allow-delete
+    - allow-overwrite
+    # replace with S3 Directory bucket region from Terraform output
+    - region <S3_DIRECTORY_BUCKET_REGION>
+  csi:
+    driver: s3.csi.aws.com # required
+    volumeHandle: s3-csi-driver-volume
+    volumeAttributes:
+      # replace with S3 Directory bucket name from Terraform output
+      bucketName: <S3_DIRECTORY_BUCKET_NAME>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            # replace with S3 Directory bucket availability zone from Terraform output
+            - <S3_DIRECTORY_BUCKET_AZ>
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spark-s3-mount-graviton-pvc
+  namespace: spark-s3-express
+spec:
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # required for static provisioning
+  resources:
+    requests:
+      storage: 5Gi # ignored, required
+  volumeName: spark-s3-mount-graviton-pv
+---
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "order-graviton"
+  namespace: spark-s3-express
+  labels:
+    app: "order-graviton"
+    applicationId: "order-ebs"
+    queue: root.test
+spec:
+
+  type: Python
+  sparkVersion: "3.2.1"
+  pythonVersion: "3"
+  mode: cluster
+  image: "public.ecr.aws/data-on-eks/spark3.3.1-hadoop3.2-aws-java-sdk-bundle-1.12.647:latest"
+  imagePullPolicy: IfNotPresent
+  mainApplicationFile: "local:///data1/scripts/pyspark-order.py"
+  arguments:
+    - "/data1/order/input/"
+    - "/data1/order/output/graviton/"
+  hadoopConf:
+    "fs.s3a.aws.credentials.provider": "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"
+    "fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    "mapreduce.fileoutputcommitter.algorithm.version": "2"
+  sparkConf:
+    "spark.app.name": "order-graviton"
+    "spark.kubernetes.driver.pod.name": "order-graviton-driver"
+    "spark.kubernetes.executor.podNamePrefix": "order-graviton-executor"
+    "spark.local.dir": "/data2"
+    "spark.driver.extraJavaOptions": "-Divy.cache.dir=/tmp -Divy.home=/tmp"
+    "spark.kubernetes.file.upload.path": "/data1/spark-upload"
+    "spark.speculation": "false"
+    "spark.network.timeout": "2400"
+    "spark.hadoop.fs.s3a.connection.timeout": "1200000"
+    "spark.hadoop.fs.s3a.path.style.access": "true"
+    "spark.hadoop.fs.s3a.connection.maximum": "200"
+    "spark.hadoop.fs.s3a.fast.upload": "true"
+    "spark.hadoop.fs.s3a.readahead.range": "256K"
+    "spark.hadoop.fs.s3a.input.fadvise": "random"
+    "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "/data1/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+#    "spark.history.fs.eventLog.rolling.maxFilesToRetain": 100
+
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/path": "/metrics/executors/prometheus/"
+    "spark.kubernetes.driver.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/path": "/metrics/driver/prometheus/"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.label.spark_role": "driver"
+    "spark.kubernetes.executor.service.label.spark_role": "driver"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.*.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.master.sink.prometheusServlet.path": "/metrics/master/prometheus/"
+    "spark.metrics.conf.applications.sink.prometheusServlet.path": "/metrics/applications/prometheus/"
+
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
+  volumes:
+    - name: spark-s3-mount
+      persistentVolumeClaim:
+        claimName: spark-s3-mount-graviton-pvc
+  driver:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "4200m"
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkComputeGravitonODMemory"
+  executor:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "2000m"
+    instances: 4
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkGravitonMemoryOptimized"

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-nvme.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-nvme.yaml
@@ -1,0 +1,172 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: spark-s3-mount-nvme-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - uid=1001
+    - gid=185
+    - allow-other
+    - allow-delete
+    - allow-overwrite
+    # replace with S3 Directory bucket region from Terraform output
+    - region <S3_DIRECTORY_BUCKET_REGION>
+  csi:
+    driver: s3.csi.aws.com # required
+    volumeHandle: s3-csi-driver-volume
+    volumeAttributes:
+      # replace with S3 Directory bucket name from Terraform output
+      bucketName: <S3_DIRECTORY_BUCKET_NAME>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            # replace with S3 Directory bucket availability zone from Terraform output
+            - <S3_DIRECTORY_BUCKET_AZ>
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spark-s3-mount-nvme-pvc
+  namespace: spark-s3-express
+spec:
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # required for static provisioning
+  resources:
+    requests:
+      storage: 5Gi # ignored, required
+  volumeName: spark-s3-mount-nvme-pv
+---
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "order-nvme"
+  namespace: spark-s3-express
+  labels:
+    app: "order-nvme"
+    applicationId: "order-ebs"
+    queue: root.test
+spec:
+
+  type: Python
+  sparkVersion: "3.2.1"
+  pythonVersion: "3"
+  mode: cluster
+  image: "public.ecr.aws/data-on-eks/spark3.3.1-hadoop3.2-aws-java-sdk-bundle-1.12.647:latest"
+  imagePullPolicy: IfNotPresent
+  mainApplicationFile: "local:///data1/scripts/pyspark-order.py"
+  arguments:
+    - "/data1/order/input/"
+    - "/data1/order/output/nvme/"
+  hadoopConf:
+    "fs.s3a.aws.credentials.provider": "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"
+    "fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    "mapreduce.fileoutputcommitter.algorithm.version": "2"
+  sparkConf:
+    "spark.app.name": "order-nvme"
+    "spark.kubernetes.driver.pod.name": "order-nvme-driver"
+    "spark.kubernetes.executor.podNamePrefix": "order-nvme-executor"
+    "spark.local.dir": "/data2"
+    "spark.driver.extraJavaOptions": "-Divy.cache.dir=/tmp -Divy.home=/tmp"
+    "spark.kubernetes.file.upload.path": "/data1/spark-upload"
+    "spark.speculation": "false"
+    "spark.network.timeout": "2400"
+    "spark.hadoop.fs.s3a.connection.timeout": "1200000"
+    "spark.hadoop.fs.s3a.path.style.access": "true"
+    "spark.hadoop.fs.s3a.connection.maximum": "200"
+    "spark.hadoop.fs.s3a.fast.upload": "true"
+    "spark.hadoop.fs.s3a.readahead.range": "256K"
+    "spark.hadoop.fs.s3a.input.fadvise": "random"
+    "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "/data1/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+#    "spark.history.fs.eventLog.rolling.maxFilesToRetain": 100
+
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/path": "/metrics/executors/prometheus/"
+    "spark.kubernetes.driver.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/path": "/metrics/driver/prometheus/"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.label.spark_role": "driver"
+    "spark.kubernetes.executor.service.label.spark_role": "driver"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.*.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.master.sink.prometheusServlet.path": "/metrics/master/prometheus/"
+    "spark.metrics.conf.applications.sink.prometheusServlet.path": "/metrics/applications/prometheus/"
+
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
+  volumes:
+    - name: spark-s3-mount
+      persistentVolumeClaim:
+        claimName: spark-s3-mount-nvme-pvc
+  driver:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "4200m"
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkComputeOnDemand"
+  executor:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "2000m"
+    instances: 4
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkComputeNitroNvme"

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-ondemand.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-ondemand.yaml
@@ -1,0 +1,170 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: spark-s3-mount-ondemand-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - uid=1001
+    - gid=185
+    - allow-other
+    - allow-delete
+    - allow-overwrite
+    # replace with S3 Directory bucket region from Terraform output
+    - region <S3_DIRECTORY_BUCKET_REGION>
+  csi:
+    driver: s3.csi.aws.com # required
+    volumeHandle: s3-csi-driver-volume
+    volumeAttributes:
+      # replace with S3 Directory bucket name from Terraform output
+      bucketName: <S3_DIRECTORY_BUCKET_NAME>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            # replace with S3 Directory bucket availability zone from Terraform output
+            - <S3_DIRECTORY_BUCKET_AZ>
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spark-s3-mount-ondemand-pvc
+  namespace: spark-s3-express
+spec:
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # required for static provisioning
+  resources:
+    requests:
+      storage: 5Gi # ignored, required
+  volumeName: spark-s3-mount-ondemand-pv
+---
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "order-ondemand"
+  namespace: spark-s3-express
+  labels:
+    app: "order-ondemand"
+    applicationId: "order-ebs"
+    queue: root.test
+spec:
+  type: Python
+  sparkVersion: "3.5.2"
+  pythonVersion: "3"
+  mode: cluster
+  image: "public.ecr.aws/data-on-eks/spark3.3.1-hadoop3.2-aws-java-sdk-bundle-1.12.647:latest"
+  imagePullPolicy: IfNotPresent
+  mainApplicationFile: "local:///data1/scripts/pyspark-order.py"
+  arguments:
+    - "/data1/order/input/"
+    - "/data1/order/output/ondemand/"
+  hadoopConf:
+    "fs.s3a.aws.credentials.provider": "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"
+    "fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    "mapreduce.fileoutputcommitter.algorithm.version": "2"
+  sparkConf:
+    "spark.app.name": "order-ondemand"
+    "spark.kubernetes.driver.pod.name": "order-ondemand-driver"
+    "spark.kubernetes.executor.podNamePrefix": "order-ondemand-executor"
+    "spark.local.dir": "/data2"
+    "spark.driver.extraJavaOptions": "-Divy.cache.dir=/tmp -Divy.home=/tmp"
+    "spark.kubernetes.file.upload.path": "/data1/spark-upload"
+    "spark.speculation": "false"
+    "spark.network.timeout": "2400"
+    "spark.hadoop.fs.s3a.connection.timeout": "1200000"
+    "spark.hadoop.fs.s3a.path.style.access": "true"
+    "spark.hadoop.fs.s3a.connection.maximum": "200"
+    "spark.hadoop.fs.s3a.fast.upload": "true"
+    "spark.hadoop.fs.s3a.readahead.range": "256K"
+    "spark.hadoop.fs.s3a.input.fadvise": "random"
+    "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "/data1/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/path": "/metrics/executors/prometheus/"
+    "spark.kubernetes.driver.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/path": "/metrics/driver/prometheus/"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.label.spark_role": "driver"
+    "spark.kubernetes.executor.service.label.spark_role": "driver"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.*.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.master.sink.prometheusServlet.path": "/metrics/master/prometheus/"
+    "spark.metrics.conf.applications.sink.prometheusServlet.path": "/metrics/applications/prometheus/"
+
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
+  volumes:
+    - name: spark-s3-mount
+      persistentVolumeClaim:
+        claimName: spark-s3-mount-ondemand-pvc
+  driver:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "4200m"
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.5.3
+    nodeSelector:
+      NodeGroupType: "SparkComputeOnDemand"
+  executor:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "2000m"
+    instances: 4
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.5.3
+    nodeSelector:
+      NodeGroupType: "SparkComputeOnDemand"

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-cmr.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-cmr.yaml
@@ -1,0 +1,170 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: spark-s3-mount-spotcmr-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - uid=1001
+    - gid=185
+    - allow-other
+    - allow-delete
+    - allow-overwrite
+    # replace with S3 Directory bucket region from Terraform output
+    - region <S3_DIRECTORY_BUCKET_REGION>
+  csi:
+    driver: s3.csi.aws.com # required
+    volumeHandle: s3-csi-driver-volume
+    volumeAttributes:
+      # replace with S3 Directory bucket name from Terraform output
+      bucketName: <S3_DIRECTORY_BUCKET_NAME>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            # replace with S3 Directory bucket availability zone from Terraform output
+            - <S3_DIRECTORY_BUCKET_AZ>
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spark-s3-mount-spotcmr-pvc
+  namespace: spark-s3-express
+spec:
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # required for static provisioning
+  resources:
+    requests:
+      storage: 5Gi # ignored, required
+  volumeName: spark-s3-mount-spotcmr-pv
+---
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "order-spot-cmr"
+  namespace: spark-s3-express
+  labels:
+    app: "order-spot-cmr"
+    applicationId: "order-ebs"
+    queue: root.test
+spec:
+  type: Python
+  sparkVersion: "3.2.1"
+  pythonVersion: "3"
+  mode: cluster
+  image: "public.ecr.aws/data-on-eks/spark3.3.1-hadoop3.2-aws-java-sdk-bundle-1.12.647:latest"
+  imagePullPolicy: IfNotPresent
+  mainApplicationFile: "local:///data1/scripts/pyspark-order.py"
+  arguments:
+    - "/data1/order/input/"
+    - "/data1/order/output/spotcmr/"
+  hadoopConf:
+    "fs.s3a.aws.credentials.provider": "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"
+    "fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    "mapreduce.fileoutputcommitter.algorithm.version": "2"
+  sparkConf:
+    "spark.app.name": "order-spot-cmr"
+    "spark.kubernetes.driver.pod.name": "order-spot-cmr-driver"
+    "spark.kubernetes.executor.podNamePrefix": "order-spot-cmr-executor"
+    "spark.local.dir": "/data2"
+    "spark.driver.extraJavaOptions": "-Divy.cache.dir=/tmp -Divy.home=/tmp"
+    "spark.kubernetes.file.upload.path": "/data1/spark-upload"
+    "spark.speculation": "false"
+    "spark.network.timeout": "2400"
+    "spark.hadoop.fs.s3a.connection.timeout": "1200000"
+    "spark.hadoop.fs.s3a.path.style.access": "true"
+    "spark.hadoop.fs.s3a.connection.maximum": "200"
+    "spark.hadoop.fs.s3a.fast.upload": "true"
+    "spark.hadoop.fs.s3a.readahead.range": "256K"
+    "spark.hadoop.fs.s3a.input.fadvise": "random"
+    "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "/data1/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+#    "spark.history.fs.eventLog.rolling.maxFilesToRetain": 100
+
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/path": "/metrics/executors/prometheus/"
+    "spark.kubernetes.driver.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/path": "/metrics/driver/prometheus/"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.label.spark_role": "driver"
+    "spark.kubernetes.executor.service.label.spark_role": "driver"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.*.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.master.sink.prometheusServlet.path": "/metrics/master/prometheus/"
+    "spark.metrics.conf.applications.sink.prometheusServlet.path": "/metrics/applications/prometheus/"
+
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
+  volumes:
+    - name: spark-s3-mount
+      persistentVolumeClaim:
+        claimName: spark-s3-mount-spotcmr-pvc
+  driver:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "4200m"
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkComputeOnDemand"
+  executor:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "2000m"
+    instances: 4
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkComputeSpotCMR"

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-r.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-spot-r.yaml
@@ -1,0 +1,172 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: spark-s3-mount-spotr-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - uid=1001
+    - gid=185
+    - allow-other
+    - allow-delete
+    - allow-overwrite
+    # replace with S3 Directory bucket region from Terraform output
+    - region <S3_DIRECTORY_BUCKET_REGION>
+  csi:
+    driver: s3.csi.aws.com # required
+    volumeHandle: s3-csi-driver-volume
+    volumeAttributes:
+      # replace with S3 Directory bucket name from Terraform output
+      bucketName: <S3_DIRECTORY_BUCKET_NAME>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            # replace with S3 Directory bucket availability zone from Terraform output
+            - <S3_DIRECTORY_BUCKET_AZ>
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spark-s3-mount-spotr-pvc
+  namespace: spark-s3-express
+spec:
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # required for static provisioning
+  resources:
+    requests:
+      storage: 5Gi # ignored, required
+  volumeName: spark-s3-mount-spotr-pv
+---
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "order-spot-r"
+  namespace: spark-s3-express
+  labels:
+    app: "order-spot-r"
+    applicationId: "order-ebs"
+    queue: root.test
+spec:
+
+  type: Python
+  sparkVersion: "3.2.1"
+  pythonVersion: "3"
+  mode: cluster
+  image: "public.ecr.aws/data-on-eks/spark3.3.1-hadoop3.2-aws-java-sdk-bundle-1.12.647:latest"
+  imagePullPolicy: IfNotPresent
+  mainApplicationFile: "local:///data1/scripts/pyspark-order.py"
+  arguments:
+    - "/data1/order/input/"
+    - "/data1/order/output/spotr/"
+  hadoopConf:
+    "fs.s3a.aws.credentials.provider": "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"
+    "fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    "mapreduce.fileoutputcommitter.algorithm.version": "2"
+  sparkConf:
+    "spark.app.name": "order-spot-r"
+    "spark.kubernetes.driver.pod.name": "order-spot-r-driver"
+    "spark.kubernetes.executor.podNamePrefix": "order-spot-r-executor"
+    "spark.local.dir": "/data2"
+    "spark.driver.extraJavaOptions": "-Divy.cache.dir=/tmp -Divy.home=/tmp"
+    "spark.kubernetes.file.upload.path": "/data1/spark-upload"
+    "spark.speculation": "false"
+    "spark.network.timeout": "2400"
+    "spark.hadoop.fs.s3a.connection.timeout": "1200000"
+    "spark.hadoop.fs.s3a.path.style.access": "true"
+    "spark.hadoop.fs.s3a.connection.maximum": "200"
+    "spark.hadoop.fs.s3a.fast.upload": "true"
+    "spark.hadoop.fs.s3a.readahead.range": "256K"
+    "spark.hadoop.fs.s3a.input.fadvise": "random"
+    "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "/data1/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+#    "spark.history.fs.eventLog.rolling.maxFilesToRetain": 100
+
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.annotation.prometheus.io/path": "/metrics/executors/prometheus/"
+    "spark.kubernetes.driver.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/scrape": "true"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/path": "/metrics/driver/prometheus/"
+    "spark.kubernetes.driver.service.annotation.prometheus.io/port": "4040"
+    "spark.kubernetes.driver.service.label.spark_role": "driver"
+    "spark.kubernetes.executor.service.label.spark_role": "driver"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.*.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.master.sink.prometheusServlet.path": "/metrics/master/prometheus/"
+    "spark.metrics.conf.applications.sink.prometheusServlet.path": "/metrics/applications/prometheus/"
+
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
+  volumes:
+    - name: spark-s3-mount
+      persistentVolumeClaim:
+        claimName: spark-s3-mount-spotr-pvc
+  driver:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "4200m"
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkComputeOnDemand"
+  executor:
+    podSecurityContext:
+      # runAsUser: 1000
+      # runAsGroup: 2000
+      fsGroup: 185
+    volumeMounts:
+      - mountPath: "/data1"
+        name: "spark-s3-mount"
+    initContainers:
+      - name: volume-permissions
+        image: nginx
+        command: [ 'sh', '-c', 'mkdir -p /data1/spark-event-logs' ]
+        volumeMounts:
+          - mountPath: "/data1"
+            name: "spark-s3-mount"
+    cores: 2
+    coreLimit: "2000m"
+    instances: 4
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-s3-express
+    labels:
+      version: 3.2.1
+    nodeSelector:
+      NodeGroupType: "SparkComputeSpotR"

--- a/analytics/terraform/spark-k8s-operator/helm-values/kubecost-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kubecost-values.yaml
@@ -55,7 +55,8 @@ kubecostModel:
   image: public.ecr.aws/kubecost/cost-model
 
 forecasting:
-  image: public.ecr.aws/kubecost/kubecost-modeling:v0.1.19
+  image:
+    repository: public.ecr.aws/kubecost/kubecost-modeling
 
 networkCosts:
   # enable networking costs daemonset
@@ -63,7 +64,8 @@ networkCosts:
   config:
     services:
       amazon-web-services: true
-  image: public.ecr.aws/kubecost/kubecost-network-costs:v0.17.6
+  image:
+    repository: public.ecr.aws/kubecost/kubecost-network-costs
 
 clusterController:
   image:

--- a/analytics/terraform/spark-k8s-operator/main.tf
+++ b/analytics/terraform/spark-k8s-operator/main.tf
@@ -40,6 +40,23 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
 
+  s3_express_supported_az_ids = [
+    "use1-az4", "use1-az5", "use1-az6", "usw2-az1", "usw2-az3", "usw2-az4", "apne1-az1", "apne1-az4", "eun1-az1", "eun1-az2", "eun1-az3"
+  ]
+
+  s3_express_az_ids = [
+    for az_id in data.aws_availability_zones.available.zone_ids :
+    az_id if contains(local.s3_express_supported_az_ids, az_id)
+  ]
+
+  s3_express_azs = [for zone_id in local.s3_express_az_ids : [
+    for az in data.aws_availability_zones.available.zone_ids :
+    data.aws_availability_zones.available.names[index(data.aws_availability_zones.available.zone_ids, az)] if az == zone_id
+  ][0]]
+
+  s3_express_zone_id   = local.s3_express_az_ids[0]
+  s3_express_zone_name = local.s3_express_azs[0]
+
   tags = {
     Blueprint  = local.name
     GithubRepo = "github.com/awslabs/data-on-eks"
@@ -114,7 +131,6 @@ data "aws_iam_policy_document" "s3tables_policy" {
       "s3tables:DeleteTableBucket",
       "s3tables:CreateNamespace",
       "s3tables:ListNamespaces",
-      "s3tables:ListTableBuckets",
       "s3tables:GetTableBucket",
       "s3tables:DeleteNamespace",
       "s3tables:GetTableBucketMaintenanceConfiguration",

--- a/analytics/terraform/spark-k8s-operator/outputs.tf
+++ b/analytics/terraform/spark-k8s-operator/outputs.tf
@@ -40,3 +40,23 @@ output "grafana_secret_name" {
   description = "Grafana password secret name"
   value       = aws_secretsmanager_secret.grafana.name
 }
+
+################################################################################
+# S3 Directory Bucket
+################################################################################
+
+
+output "s3directory_bucket_name" {
+  description = "s3 directory bucket name"
+  value       = aws_s3_directory_bucket.spark_data_bucket_express.id
+}
+
+output "s3directory_bucket_region" {
+  description = "s3 directory bucket region"
+  value       = local.region
+}
+
+output "s3directory_bucket_zone" {
+  description = "s3 directory bucket availability zone"
+  value       = local.s3_express_zone_name
+}

--- a/analytics/terraform/spark-k8s-operator/s3-dir-bucket.tf
+++ b/analytics/terraform/spark-k8s-operator/s3-dir-bucket.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_directory_bucket" "spark_data_bucket_express" {
+  bucket        = "${local.name}-${local.account_id}--${local.s3_express_zone_id}--x-s3"
+  force_destroy = true
+
+  location {
+    name = local.s3_express_zone_id
+  }
+}

--- a/analytics/terraform/spark-k8s-operator/spark-team.tf
+++ b/analytics/terraform/spark-k8s-operator/spark-team.tf
@@ -1,5 +1,5 @@
 locals {
-  teams = ["spark-team-a", "spark-team-b", "spark-team-c"] # Add more team names as needed
+  teams = ["spark-team-a", "spark-team-b", "spark-team-c", "spark-s3-express"] # Add more team names as needed
 }
 
 resource "kubernetes_namespace_v1" "spark_team" {

--- a/analytics/terraform/spark-k8s-operator/versions.tf
+++ b/analytics/terraform/spark-k8s-operator/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {

--- a/website/docs/blueprints/distributed-databases/aerospike.md
+++ b/website/docs/blueprints/distributed-databases/aerospike.md
@@ -13,7 +13,7 @@ sidebar_label: Aerospike
 
 * **High Availability and Resilience**: With features like Cross-Datacenter Replication (XDR), Aerospike provides fine-grained control for asynchronous data replication across geographically dispersed clusters. This ensures data availability and compliance with data locality regulations. EKS enhances this resilience by distributing workloads across multiple availability zones.
 
-* **Operational Efficiency**: The Aerospike Kubernetes Operator automates routine tasks such as configuration, scaling, and upgrading Aerospike clusters. This reduces operational complexity and overhead, allowing teams to focus on delivering value rather than managing infrastructure. 
+* **Operational Efficiency**: The Aerospike Kubernetes Operator automates routine tasks such as configuration, scaling, and upgrading Aerospike clusters. This reduces operational complexity and overhead, allowing teams to focus on delivering value rather than managing infrastructure.
 
 * **Cost Optimization**: Leveraging Aerospike’s efficient use of resources and EKS’s flexible infrastructure, organizations can achieve significant cost savings compared to traditional deployments. Aerospike’s ability to deliver high performance with a reduced hardware footprint translates to lower total cost of ownership.
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This PR:
- adds the spark-s3-express examples we use in the workshop to the examples and scripts folders
- adds a s3_directory_bucket which is used for the data and logs for the exmaples
- adds the corresponding Karpenter NodePools for the examples
- adds the Mountpoint S3 CSI Driver and needed IAM resources and permissions
- updates the version defined for the Spark-history-server and kubecost so they use the right helm chart version (resolving #814)

### Motivation

There were a number of changes in the workshop branch that we should add to the main branch, but there were a number of other changes that cluttered the PR (see #824). I merged just the changes to the spark-operator solution without rolling back the recent changes on main.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
Comparing this branch against the latest workshop branch I only see these differences:
- The dashboards under `analytics/terraform/spark-k8s-operator/examples/benchmark/spark-operator-benchmark-kit/` have some differences with scrape intervals and data sources, I kept the version in main for now. 
- There were some changes to the Iceberg examples on main that I kept over the workshop's version which was out of date 
