### PR TITLE
feat: Add changes to include SQS interruption queue for Karpenter and related Event Bridge rules

### DIFF
--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -812,6 +812,7 @@ module "eks_blueprints_addons" {
   #---------------------------------------
   enable_karpenter                  = true
   karpenter_enable_spot_termination = true
+  karpenter_sqs                     = aws_sqs_queue.this[0].name
   karpenter_node = {
     iam_role_additional_policies = {
       AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"

--- a/analytics/terraform/spark-k8s-operator/karpenter-sqs.tf
+++ b/analytics/terraform/spark-k8s-operator/karpenter-sqs.tf
@@ -1,0 +1,123 @@
+################################################################################
+# Node Termination Queue
+################################################################################
+
+resource "aws_sqs_queue" "this" {
+  count = local.enable_spot_termination ? 1 : 0
+
+  name                              = local.queue_name
+  message_retention_seconds         = 300
+  sqs_managed_sse_enabled           = var.queue_managed_sse_enabled ? var.queue_managed_sse_enabled : null
+  kms_master_key_id                 = var.queue_kms_master_key_id
+  kms_data_key_reuse_period_seconds = var.queue_kms_data_key_reuse_period_seconds
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "queue" {
+  count = local.enable_spot_termination ? 1 : 0
+
+  statement {
+    sid       = "SqsWrite"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.this[0].arn]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "sqs.amazonaws.com",
+      ]
+    }
+  }
+  statement {
+    sid    = "DenyHTTP"
+    effect = "Deny"
+    actions = [
+      "sqs:*"
+    ]
+    resources = [aws_sqs_queue.this[0].arn]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+    principals {
+      type = "*"
+      identifiers = [
+        "*"
+      ]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "this" {
+  count = local.enable_spot_termination ? 1 : 0
+
+  queue_url = aws_sqs_queue.this[0].url
+  policy    = data.aws_iam_policy_document.queue[0].json
+}
+
+################################################################################
+# Node Termination Event Rules
+################################################################################
+
+locals {
+  events = {
+    health_event = {
+      name        = "HealthEvent"
+      description = "Karpenter interrupt - AWS health event"
+      event_pattern = {
+        source      = ["aws.health"]
+        detail-type = ["AWS Health Event"]
+      }
+    }
+    spot_interrupt = {
+      name        = "SpotInterrupt"
+      description = "Karpenter interrupt - EC2 spot instance interruption warning"
+      event_pattern = {
+        source      = ["aws.ec2"]
+        detail-type = ["EC2 Spot Instance Interruption Warning"]
+      }
+    }
+    instance_rebalance = {
+      name        = "InstanceRebalance"
+      description = "Karpenter interrupt - EC2 instance rebalance recommendation"
+      event_pattern = {
+        source      = ["aws.ec2"]
+        detail-type = ["EC2 Instance Rebalance Recommendation"]
+      }
+    }
+    instance_state_change = {
+      name        = "InstanceStateChange"
+      description = "Karpenter interrupt - EC2 instance state-change notification"
+      event_pattern = {
+        source      = ["aws.ec2"]
+        detail-type = ["EC2 Instance State-change Notification"]
+      }
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "this" {
+  for_each = { for k, v in local.events : k => v if local.enable_spot_termination }
+
+  name_prefix   = "${var.rule_name_prefix}${each.value.name}-"
+  description   = each.value.description
+  event_pattern = jsonencode(each.value.event_pattern)
+
+  tags = merge(
+    { "ClusterName" : local.name },
+    local.tags,
+  )
+}
+
+resource "aws_cloudwatch_event_target" "this" {
+  for_each = { for k, v in local.events : k => v if local.enable_spot_termination }
+
+  rule      = aws_cloudwatch_event_rule.this[each.key].name
+  target_id = "KarpenterInterruptionQueueTarget"
+  arn       = aws_sqs_queue.this[0].arn
+}

--- a/analytics/terraform/spark-k8s-operator/main.tf
+++ b/analytics/terraform/spark-k8s-operator/main.tf
@@ -57,6 +57,10 @@ locals {
   s3_express_zone_id   = local.s3_express_az_ids[0]
   s3_express_zone_name = local.s3_express_azs[0]
 
+  enable_spot_termination = var.enable_spot_termination
+
+  queue_name = coalesce(var.queue_name, "Karpenter-${local.name}")
+
   tags = {
     Blueprint  = local.name
     GithubRepo = "github.com/awslabs/data-on-eks"

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -95,3 +95,46 @@ variable "spark_benchmark_ssd_desired_size" {
   type        = number
   default     = 0
 }
+
+################################################################################
+# Node Termination Queue
+################################################################################
+
+variable "enable_spot_termination" {
+  description = "Determines whether to enable native spot termination handling"
+  type        = bool
+  default     = true
+}
+
+variable "queue_name" {
+  description = "Name of the SQS queue"
+  type        = string
+  default     = null
+}
+
+variable "queue_managed_sse_enabled" {
+  description = "Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys"
+  type        = bool
+  default     = true
+}
+
+variable "queue_kms_master_key_id" {
+  description = "The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK"
+  type        = string
+  default     = null
+}
+
+variable "queue_kms_data_key_reuse_period_seconds" {
+  description = "The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again"
+  type        = number
+  default     = null
+}
+################################################################################
+# Event Bridge Rules
+################################################################################
+
+variable "rule_name_prefix" {
+  description = "Prefix used for all event bridge rules"
+  type        = string
+  default     = "Karpenter"
+}


### PR DESCRIPTION
### What does this PR do?

This PR creates a SQS queue and node termination event rules for Karpenter. Karpenter requires these to be added so that it can forward interruption events from AWS services to the SQS queue for better node handling.

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Issue #819 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
