### PR TITLE
fix: Added and updated commands in the spark-yunikorn example for proper execution

### DIFF
--- a/website/docs/blueprints/data-analytics/_taxi_trip_exec.md
+++ b/website/docs/blueprints/data-analytics/_taxi_trip_exec.md
@@ -7,7 +7,7 @@ require a relatively fast internet connection.
 ```bash
 cd ${DOEKS_HOME}/analytics/scripts/
 chmod +x taxi-trip-execute.sh
-taxi-trip-execute.sh ${S3_BUCKET} YOUR_REGION_HERE
+./taxi-trip-execute.sh ${S3_BUCKET} YOUR_REGION_HERE
 ```
 
 You can return to the blueprint directory and continue with the example

--- a/website/docs/blueprints/data-analytics/spark-operator-yunikorn.md
+++ b/website/docs/blueprints/data-analytics/spark-operator-yunikorn.md
@@ -139,7 +139,16 @@ echo $S3_BUCKET
 
 <CollapsibleContent header={<h2><span>Execute Sample Spark job with Karpenter</span></h2>}>
 
-Navigate to example directory and submit the Spark job.
+Navigate to example directory. You will need to replace the <S3_BUCKET> placeholders in this file with the name of the bucket created earlier. You can get that value by running echo $S3_BUCKET.
+
+To do this automatically you can run the following, which will create a .old backup file and do the replacement for you.
+
+
+```bash
+sed -i.old s/\<S3_BUCKET\>/${S3_BUCKET}/g ./pyspark-pi-job.yaml
+```
+
+Submit the Spark Job
 
 ```bash
 cd ${DOEKS_HOME}/analytics/terraform/spark-k8s-operator/examples/karpenter
@@ -155,7 +164,7 @@ kubectl get pods -n spark-team-a -w
 
 You can check the status of the SparkApplication if the pods are already completed:
 ```bash
-kubectl kubectl describe sparkapplication pyspark-pi-karpenter -n spark-team-a
+kubectl describe sparkapplication pyspark-pi-karpenter -n spark-team-a
 ```
 
 You can try the following examples to leverage multiple Karpenter Nodepools, EBS as Dynamic PVC instead of SSD and YuniKorn Gang Scheduling.


### PR DESCRIPTION

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

- Added a sed command to update the S3_BUCKET placeholder in the pyspark-pi-job.yaml to succesfully run the SparkApplication
-  Added `./` in the `_taxi_trip_exec.md` for successful execution of the script

### Motivation

<!-- What inspired you to submit this pull request? -->

- The `pyspark-pi-job.yaml` execution fails as we are logging spark events in an S3 bucket `"spark.eventLog.dir": "s3a://<S3_BUCKET>/spark-event-logs"`. This leads to the continuous errors in the spark driver and the SparkApplication does not complete succesfully

- The current command `taxi-trip-execute.sh ${S3_BUCKET} YOUR_REGION_HERE` leads to error of `taxi-trip-execute command not found`. Hence, added `./` in the beginning of the command.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->


cc: @alanty and @mccloman