### PR TITLE
fix: Website build issue with html tag

### DIFF
--- a/website/docs/blueprints/data-analytics/spark-operator-yunikorn.md
+++ b/website/docs/blueprints/data-analytics/spark-operator-yunikorn.md
@@ -139,7 +139,7 @@ echo $S3_BUCKET
 
 <CollapsibleContent header={<h2><span>Execute Sample Spark job with Karpenter</span></h2>}>
 
-Navigate to example directory. You will need to replace the <S3_BUCKET> placeholders in this file with the name of the bucket created earlier. You can get that value by running echo $S3_BUCKET.
+Navigate to example directory. You will need to replace the `<S3_BUCKET>` placeholders in this file with the name of the bucket created earlier. You can get that value by running echo $S3_BUCKET.
 
 To do this automatically you can run the following, which will create a .old backup file and do the replacement for you.
 


### PR DESCRIPTION
### What does this PR do?

This fixes the website deployment issue by escaping the HTML tag properly. 
Here's an example of a failing job: https://github.com/awslabs/data-on-eks/actions/runs/15003304012/job/42221796341



### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
