### PR TITLE
ci: Pre commit fixes

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -59,15 +59,20 @@ jobs:
 
       - name: Config Terraform plugin cache
         if: steps.changes.outputs.src== 'true'
-        run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
+        run: mkdir --parents ${{ env.TF_PLUGIN_CACHE_DIR }}
 
-      - name: Cache Terraform
-        uses: actions/cache@v3
+      - name: Restore Terraform Cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
         if: steps.changes.outputs.src== 'true'
         with:
-          path: ${{ env.TERRAFORM_DOCS_VERSION }}
-          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-          restore-keys: ${{ runner.os }}-terraform-
+          # restore latest matching cache to the tf cache dir
+          # matches exact branch and versions hash, then any cache from the same branch, then any cache from any branch
+          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+          key: ${{ runner.os }}-terraform-${{ github.head_ref }}-${{ hashFiles('**/versions.tf') }}
+          restore-keys: |
+            ${{ runner.os }}-terraform-${{ github.head_ref }}
+            ${{ runner.os }}-terraform-
 
       - name: Terraform min/max versions
         uses: clowdhaus/terraform-min-max@v1.3.2
@@ -112,15 +117,20 @@ jobs:
 
       - name: Config Terraform plugin cache
         if: steps.changes.outputs.src== 'true'
-        run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
+        run: mkdir --parents ${{ env.TF_PLUGIN_CACHE_DIR }}
 
-      - name: Cache Terraform
-        uses: actions/cache@v3
+      - name: Restore Terraform Cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
         if: steps.changes.outputs.src== 'true'
         with:
+          # restore latest matching cache to the tf cache dir
+          # matches exact branch and versions hash, then any cache from the same branch, then any cache from any branch
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-          restore-keys: ${{ runner.os }}-terraform-
+          key: ${{ runner.os }}-terraform-${{ github.head_ref }}-${{ hashFiles('**/versions.tf') }}
+          restore-keys: |
+            ${{ runner.os }}-terraform-${{ github.head_ref }}
+            ${{ runner.os }}-terraform-
 
       - name: Install tfsec
         if: steps.changes.outputs.src== 'true'
@@ -138,3 +148,12 @@ jobs:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
           tflint-version: ${{ env.TFLINT_VERSION }}
+
+      - name: Save Terraform Cache
+        uses: actions/cache/save@v4
+        if: steps.changes.outputs.src== 'true'
+        with:
+          # caches cannot be updated, we can only save this hash once,
+          # after validating all blueprints we should have all plugins in cache.
+          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
+          key: ${{ runner.os }}-terraform-${{ github.head_ref }}-${{ hashFiles('**/versions.tf') }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,10 +10,10 @@ on:
       - '**.yaml'
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.16.0
-  TFSEC_VERSION: v1.22.0
+  TERRAFORM_DOCS_VERSION: v0.20.0
+  TFSEC_VERSION: v1.28.14
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
-  TFLINT_VERSION: v0.50.2
+  TFLINT_VERSION: v0.56.0
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
@@ -27,11 +27,11 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/directories@v1.11.1
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -45,9 +45,9 @@ jobs:
         run: rm -rf $(which terraform)
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           # We only need to check Terraform files for the current directory
@@ -70,14 +70,14 @@ jobs:
           restore-keys: ${{ runner.os }}-terraform-
 
       - name: Terraform min/max versions
-        uses: clowdhaus/terraform-min-max@v1.3.1
+        uses: clowdhaus/terraform-min-max@v1.3.2
         if: steps.changes.outputs.src== 'true'
         id: minMax
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' && steps.changes.outputs.src== 'true' }}
         with:
@@ -85,7 +85,7 @@ jobs:
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' && steps.changes.outputs.src== 'true' }}
         with:
@@ -101,9 +101,9 @@ jobs:
         run: rm -rf $(which terraform)
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
@@ -128,11 +128,11 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.1
+        uses: clowdhaus/terraform-min-max@v1.3.2
         if: steps.changes.outputs.src== 'true'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         if: steps.changes.outputs.src== 'true'
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.90.0
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,8 @@ repos:
           - --args=--only=terraform_unused_required_providers
           - --args=--only=terraform_workspace_remote
       - id: terraform_validate
+        args:
+          # Parallel terraform init can cause problems when using a cache: https://github.com/hashicorp/terraform/issues/31964
+          # this task is running across all of the blueprints in the github checks and can cause failures for missing/corrupted dependencies
+          - --hook-config=--parallelism-limit=1
         exclude: (docs|modules)

--- a/ai-ml/emr-spark-rapids/README.md
+++ b/ai-ml/emr-spark-rapids/README.md
@@ -2,7 +2,7 @@
 
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/amazon-emr-on-eks/emr-spark-rapids) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -80,4 +80,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC Provider if `enable_irsa = true` |
 | <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | S3 bucket for Spark input and output data |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/ai-ml/nvidia-triton-server/README.md
+++ b/ai-ml/nvidia-triton-server/README.md
@@ -1,6 +1,6 @@
 # NVIDIA Triton server Terraform blueprint
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -92,4 +92,4 @@
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | The name of the secret containing the Grafana admin password. |
 | <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | The name of the S3 bucket. |
 | <a name="output_s3_bucket_region"></a> [s3\_bucket\_region](#output\_s3\_bucket\_region) | The AWS region this bucket resides in. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/ai-ml/ray/terraform/README.md
+++ b/ai-ml/ray/terraform/README.md
@@ -3,7 +3,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 ---
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -53,4 +53,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/datahub-on-eks/README.md
+++ b/analytics/terraform/datahub-on-eks/README.md
@@ -1,7 +1,7 @@
 # Deploying DataHub on EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/data-analytics/datahub-on-eks) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -62,4 +62,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_frontend_url"></a> [frontend\_url](#output\_frontend\_url) | URL for datahub frontend |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC Provider if `enable_irsa = true` |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/emr-eks-ack/README.md
+++ b/analytics/terraform/emr-eks-ack/README.md
@@ -11,7 +11,7 @@ If you are using this blueprint in production, please add yourself to the [adopt
 This pattern is used to deploy the EKS Cluster with EMR on EKS ACK Controllers and Crossplane.
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/amazon-emr-on-eks/emr-eks-ack) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -69,4 +69,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_emr_on_eks"></a> [emr\_on\_eks](#output\_emr\_on\_eks) | EMR on EKS |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC Provider if `enable_irsa = true` |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/emr-eks-ack/modules/emr-ack/README.md
+++ b/analytics/terraform/emr-eks-ack/modules/emr-ack/README.md
@@ -1,6 +1,6 @@
 # EMR ACK controllers Terraform Module
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -45,4 +45,4 @@
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/emr-eks-fargate/README.md
+++ b/analytics/terraform/emr-eks-fargate/README.md
@@ -10,7 +10,7 @@ If you are using this blueprint in production, please add yourself to the [adopt
 
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/amazon-emr-on-eks/emr-eks-fargate) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -61,4 +61,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 |------|-------------|
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_emr_on_eks"></a> [emr\_on\_eks](#output\_emr\_on\_eks) | EMR on EKS |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/emr-eks-karpenter/README.md
+++ b/analytics/terraform/emr-eks-karpenter/README.md
@@ -2,7 +2,7 @@
 
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/amazon-emr-on-eks/emr-eks-karpenter) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -102,4 +102,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_emr_s3_bucket_name"></a> [emr\_s3\_bucket\_name](#output\_emr\_s3\_bucket\_name) | S3 bucket for EMR workloads. Scripts,Logs etc. |
 | <a name="output_fsx_s3_bucket_name"></a> [fsx\_s3\_bucket\_name](#output\_fsx\_s3\_bucket\_name) | FSx filesystem sync with S3 bucket |
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/spark-eks-ipv6/README.md
+++ b/analytics/terraform/spark-eks-ipv6/README.md
@@ -1,6 +1,6 @@
 # Spark K8s Operator running on Amazon EKS IPv6 cluster
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -79,4 +79,4 @@
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
 | <a name="output_region"></a> [region](#output\_region) | AWS region were cluster is deployed |
 | <a name="output_s3_bucket_id_spark_event_logs_example_data"></a> [s3\_bucket\_id\_spark\_event\_logs\_example\_data](#output\_s3\_bucket\_id\_spark\_event\_logs\_example\_data) | S3 bucket for Spark Event Logs and Example Data bucket ID |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -1,7 +1,7 @@
 # Spark on K8s Operator with EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/data-analytics/spark-operator-yunikorn) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -107,4 +107,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_s3_bucket_id_spark_history_server"></a> [s3\_bucket\_id\_spark\_history\_server](#output\_s3\_bucket\_id\_spark\_history\_server) | Spark History server logs S3 bucket ID |
 | <a name="output_s3_bucket_region_spark_history_server"></a> [s3\_bucket\_region\_spark\_history\_server](#output\_s3\_bucket\_region\_spark\_history\_server) | Spark History server logs S3 bucket ID |
 | <a name="output_subnet_ids_starting_with_100"></a> [subnet\_ids\_starting\_with\_100](#output\_subnet\_ids\_starting\_with\_100) | Secondary CIDR Private Subnet IDs for EKS Data Plane |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -6,7 +6,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0 |

--- a/analytics/terraform/spark-k8s-operator/versions.tf
+++ b/analytics/terraform/spark-k8s-operator/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.2"
 
   required_providers {
     aws = {

--- a/distributed-databases/cloudnative-postgres/README.md
+++ b/distributed-databases/cloudnative-postgres/README.md
@@ -1,7 +1,7 @@
 # CloudNativePG Operator on EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/distributed-databases/cloudnative-postgres) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -70,4 +70,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_barman_backup_irsa"></a> [barman\_backup\_irsa](#output\_barman\_backup\_irsa) | ARN for Backup IAM ROLE |
 | <a name="output_barman_s3_bucket"></a> [barman\_s3\_bucket](#output\_barman\_s3\_bucket) | Backup bucket |
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/distributed-databases/trino/README.md
+++ b/distributed-databases/trino/README.md
@@ -1,7 +1,7 @@
 # Trino on EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/distributed-databases/trino) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -81,4 +81,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 |------|-------------|
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_data_bucket"></a> [data\_bucket](#output\_data\_bucket) | Name of the S3 bucket to use for example Data |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/schedulers/terraform/argo-workflow/README.md
+++ b/schedulers/terraform/argo-workflow/README.md
@@ -1,7 +1,7 @@
 # Argo Workflows on EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/job-schedulers/argo-workflows-eks) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -102,4 +102,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_s3_bucket_region_spark_history_server"></a> [s3\_bucket\_region\_spark\_history\_server](#output\_s3\_bucket\_region\_spark\_history\_server) | Spark History server logs S3 bucket ID |
 | <a name="output_subnet_ids_starting_with_100"></a> [subnet\_ids\_starting\_with\_100](#output\_subnet\_ids\_starting\_with\_100) | Secondary CIDR Private Subnet IDs for EKS Data Plane |
 | <a name="output_your_event_irsa_arn"></a> [your\_event\_irsa\_arn](#output\_your\_event\_irsa\_arn) | the ARN of IRSA for argo events |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/schedulers/terraform/aws-batch-eks/README.md
+++ b/schedulers/terraform/aws-batch-eks/README.md
@@ -2,7 +2,7 @@
 
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/job-schedulers/aws-batch) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -81,4 +81,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_configure_kubectl_cmd"></a> [configure\_kubectl\_cmd](#output\_configure\_kubectl\_cmd) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_run_example_aws_batch_job"></a> [run\_example\_aws\_batch\_job](#output\_run\_example\_aws\_batch\_job) | Use the AWS CLI to submit the example Hello World AWS Batch job definition to the Spot job queue. |
 | <a name="output_run_example_aws_batch_job_on_spot"></a> [run\_example\_aws\_batch\_job\_on\_spot](#output\_run\_example\_aws\_batch\_job\_on\_spot) | Use the AWS CLI to submit the example Hello World AWS Batch job definition to the Spot job queue. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/schedulers/terraform/managed-airflow-mwaa/README.md
+++ b/schedulers/terraform/managed-airflow-mwaa/README.md
@@ -1,7 +1,7 @@
 # Amazon Managed Workflows for Apache Airflow (MWAA)
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/job-schedulers/aws-managed-airflow) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -67,4 +67,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_emr_on_eks"></a> [emr\_on\_eks](#output\_emr\_on\_eks) | EMR on EKS |
 | <a name="output_mwaa_webserver_url"></a> [mwaa\_webserver\_url](#output\_mwaa\_webserver\_url) | MWAA Webserver Url |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/schedulers/terraform/self-managed-airflow/README.md
+++ b/schedulers/terraform/self-managed-airflow/README.md
@@ -1,7 +1,7 @@
 # Self-managed Apache Airflow deployment for EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/job-schedulers/self-managed-airflow) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -120,4 +120,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
 | <a name="output_s3_bucket_id_airflow_logs"></a> [s3\_bucket\_id\_airflow\_logs](#output\_s3\_bucket\_id\_airflow\_logs) | Airflow logs S3 bucket ID |
 | <a name="output_s3_bucket_id_fluentbit_logs"></a> [s3\_bucket\_id\_fluentbit\_logs](#output\_s3\_bucket\_id\_fluentbit\_logs) | FluentBit logs S3 bucket ID |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/streaming/emr-eks-flink/README.md
+++ b/streaming/emr-eks-flink/README.md
@@ -2,7 +2,7 @@
 
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/streaming/emr-eks-flink) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -68,7 +68,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_flink_job_execution_role_arn"></a> [flink\_job\_execution\_role\_arn](#output\_flink\_job\_execution\_role\_arn) | IAM linked role for the flink job |
 | <a name="output_flink_operator_bucket"></a> [flink\_operator\_bucket](#output\_flink\_operator\_bucket) | S3 bucket name for Flink operator data,logs,checkpoint and savepoint |
 | <a name="output_flink_operator_role_arn"></a> [flink\_operator\_role\_arn](#output\_flink\_operator\_role\_arn) | IAM linked role for the flink operator |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/streaming/flink/README.md
+++ b/streaming/flink/README.md
@@ -1,6 +1,6 @@
 # Apache Flink on EKS
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -91,4 +91,4 @@
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
 | <a name="output_oidc_provider"></a> [oidc\_provider](#output\_oidc\_provider) | The OIDC Provider |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC Provider |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/streaming/kafka/README.md
+++ b/streaming/kafka/README.md
@@ -2,7 +2,7 @@
 
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/streaming-platforms-eks/kafka) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -74,4 +74,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 |------|-------------|
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/streaming/nifi/README.md
+++ b/streaming/nifi/README.md
@@ -1,7 +1,7 @@
 # Apache NiFi on EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/streaming-platforms-eks/nifi) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -94,4 +94,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_grafana_secret_name"></a> [grafana\_secret\_name](#output\_grafana\_secret\_name) | Grafana password secret name |
 | <a name="output_nifi_login_password_secret_name"></a> [nifi\_login\_password\_secret\_name](#output\_nifi\_login\_password\_secret\_name) | Apache NiFi Login password secret name |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/streaming/spark-streaming/terraform/README.md
+++ b/streaming/spark-streaming/terraform/README.md
@@ -1,7 +1,7 @@
 # Spark on K8s Operator with EKS
 Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/blueprints/streaming-platforms/spark-streaming) to deploy this pattern and run sample tests.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -96,4 +96,4 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="output_s3_bucket_id_spark_history_server"></a> [s3\_bucket\_id\_spark\_history\_server](#output\_s3\_bucket\_id\_spark\_history\_server) | Spark History server logs S3 bucket ID |
 | <a name="output_s3_bucket_region_spark_history_server"></a> [s3\_bucket\_region\_spark\_history\_server](#output\_s3\_bucket\_region\_spark\_history\_server) | Spark History server logs S3 bucket ID |
 | <a name="output_subnet_ids_starting_with_100"></a> [subnet\_ids\_starting\_with\_100](#output\_subnet\_ids\_starting\_with\_100) | Secondary CIDR Private Subnet IDs for EKS Data Plane |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/website/docs/bestpractices/analytics/trino-best-practices.md
+++ b/website/docs/bestpractices/analytics/trino-best-practices.md
@@ -20,7 +20,7 @@ This section covers Trino's core architecture, capabilities, use cases, and ecos
 
 ### Core Architecture
 
-Trino is a powerful distributed SQL query engine designed for high-performance analytics and big data processing. Some of the key components are 
+Trino is a powerful distributed SQL query engine designed for high-performance analytics and big data processing. Some of the key components are
 
 - Distributed coordinator-worker model
 - In-memory processing architecture
@@ -411,7 +411,7 @@ This sections focuses on AWS services for optimal storage management with Trino 
 - Configure appropriate bucket policies and access through IAM roles
 - Use S3 bucket prefixes strategically for better query performance
 - Use Trino with S3 Select to improve query performance
-- 
+-
 
 ### EBS Storage for Coordinator and Workers
 
@@ -572,7 +572,7 @@ hive.s3.ssl.enabled=true
 - Set `iceberg.catalog.type=glue` and specify the region
 - Use Iceberg REST Catalog protocol
  `iceberg.catalog.type=rest`
-  `iceberg.rest-catalog.uri=https://iceberg-with-rest:8181/'` 
+  `iceberg.rest-catalog.uri=https://iceberg-with-rest:8181/'`
 
 ####   File Format
 - Use Parquet or ORC for optimal performance


### PR DESCRIPTION
### What does this PR do?
This PR updates the pre-commit configuration and the workflow that runs the pre-commit hooks as one of the checks on new PRs to address #831. 

Removing the cache and letting each blueprint pull the plugins to it's own `*/.terraform/` directory baloons the whole project directory >25GB. A terraform cache is highly recommended.

To work around this I set `--hook-config=--parallelism-limit=1` in the arguements for the `terraform_valdate` hook. This has a couple of side effects:
- the first run for this hook can take 15min+ depending on the system as it will run `terraform init` across each blueprint 1 at a time.
- without a cache, each blueprint will also need to pull the plugins to it's own directory in the repo/workspace.


I've also updated the Github cache configuration so that a cache is saved named for the incoming branch name and a hash of all of the `versions.tf` files (for uniqueness). Each job will try to find an exact match for it's cache, but if not it will use any from the same branch (in case versions were updated) and finally any cache from the repo (in case the PR is from a new branch). 
The cache is saved when the `Max TF pre-commit` job completes successfully so that it should include all of the plugins for all of the blueprints. These should help improve the runtimes as we should be able to pull the latest cache on new PRs. 


Finally I bumped the versions of the dependencies/hooks we are using in the pre-commit file and in the Github Workflow. Details are in the `Additional Notes` section.


### Motivation
I was seeing the `Max TF pre-commit` job fail with errors about corrupted/missing modules that I think are related to the cache combined with concurrency the workflow is using (see [#831](https://github.com/awslabs/data-on-eks/issues/831#issuecomment-2852719567)). The docs for the `terraform_validate` mention [race conditions and issues](https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#terraform_validate) when running simultaneous terraform init to the same cache (see also https://github.com/hashicorp/terraform/issues/31964).


### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

*Versions updated*
In `.pre-commit-config.yaml`:
- pre-commit/pre-commit-hooks v4.6.0 -> v5.0.0
- antonbabenko/pre-commit-terraform v1.90.0 -> v1.99.0

In `pre-commit.yaml` Workflow:
- actions/checkout v3 -> v4
- clowdhaus/terraform-composite-actions/directories v1.9.0 -> v1.11.1
- dorny/paths-filter v2 -> v3
- actions/cache v3 -> actions/cache/save v4 and actions/cache/restore v4
- clowdhaus/terraform-min-max v1.3.1 -> v1.3.2

Versions of utilities used in the workflow:
- terraform-docs v0.16.0 -> v0.20.0
- tfsec v1.22.0 -> v1.28.14
- tflint v0.50.2 -> v0.56.0
