### PR TITLE
fix: Pin Karpenter dashboard to a commit

### DIFF
--- a/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/kube-prometheus-amp-enable.yaml
@@ -169,9 +169,9 @@ grafana:
   dashboards:
     default:
       karpenter-capacity-dashboard:
-        url: https://karpenter.sh/v1.2/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
+        url: https://raw.githubusercontent.com/aws/karpenter-provider-aws/d389d3c82f93b9abd713746ed3fefd3ef8f34d72/website/content/en/v1.2/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
       karpenter-performance-dashboard:
-        url: https://karpenter.sh/v1.2/getting-started/getting-started-with-karpenter/karpenter-performance-dashboard.json
+        url: https://raw.githubusercontent.com/aws/karpenter-provider-aws/d389d3c82f93b9abd713746ed3fefd3ef8f34d72/website/content/en/v1.2/getting-started/getting-started-with-karpenter/karpenter-performance-dashboard.json
       spark-job-dashboard:
         url: https://raw.githubusercontent.com/awslabs/data-on-eks/refs/heads/main/analytics/terraform/spark-k8s-operator/examples/benchmark/spark-operator-benchmark-kit/emr-eks-grafana-dashboard.json
       spark-operator-dashboard:


### PR DESCRIPTION
### What does this PR do?

This PR pins Karpenter capacity and performance dashboards to commit [`d389d3c82f93b9abd713746ed3fefd3ef8f34d72`](https://github.com/aws/karpenter-provider-aws/tree/d389d3c82f93b9abd713746ed3fefd3ef8f34d72) (version 1.2.4).

fixes: #854 

### Motivation

Because the links no longer works, the Grafana pod fails to start. We need to fix it.

```
$ curl -sIX GET https://karpenter.sh/v1.2/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json
HTTP/2 404
age: 98873
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; hit
content-type: text/html; charset=utf-8
date: Wed, 11 Jun 2025 22:05:29 GMT
etag: 1627067155-ssl
server: Netlify
strict-transport-security: max-age=31536000
x-nf-request-id: 01JXGGDQ5C8P1X06FJM7A7SG1K
content-length: 7294
```

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?




