### PR TITLE
fix: karpenter version in module flink on eks

### DIFF
--- a/streaming/flink/addons.tf
+++ b/streaming/flink/addons.tf
@@ -82,7 +82,7 @@ module "eks_blueprints_addons" {
     }
   }
   karpenter = {
-    chart_version       = "v0.37.1"
+    chart_version       = "1.5.2"
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
   }

--- a/streaming/flink/karpenter-provisioners/flink-compute-optimized-provisioner.yaml
+++ b/streaming/flink/karpenter-provisioners/flink-compute-optimized-provisioner.yaml
@@ -1,6 +1,6 @@
 ---
-apiVersion: karpenter.sh/v1beta1
-kind: NodePool # Previously kind: Provisioner
+apiVersion: karpenter.sh/v1
+kind: NodePool
 metadata:
   name: flink-compute-optimized
   namespace: karpenter # Same namespace as Karpenter add-on installed
@@ -13,7 +13,10 @@ spec:
         NodeGroupType: FlinkComputeOptimized
     spec:
       nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
         name: flink-compute-optimized
+      expireAfter: 720h # 30 * 24h = 720h
       requirements:
         - key: "topology.kubernetes.io/zone"
           operator: In
@@ -42,35 +45,22 @@ spec:
   limits:
     cpu: 1000
   disruption:
-    # Describes which types of Nodes Karpenter should consider for consolidation
-    # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
-    # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
-    consolidationPolicy: WhenEmpty
-    # The amount of time Karpenter should wait after discovering a consolidation decision
-    # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
-    # You can choose to disable consolidation entirely by setting the string value 'Never' here
+    consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 30s
-    # The amount of time a Node can live on the cluster before being removed
-    # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
-    # You can choose to disable expiration entirely by setting the string value 'Never' here
-    expireAfter: 720h
-
-  # Priority given to the NodePool when the scheduler considers which NodePool
-  # to select. Higher weights indicate higher priority when comparing NodePools.
-  # Specifying no weight is equivalent to specifying a weight of 0.
   weight: 10
-
 
 
 # NOTE: Multiple NodePools may point to the same EC2NodeClass.
 ---
-apiVersion: karpenter.k8s.aws/v1beta1
-kind: EC2NodeClass # Previously kind: AWSNodeTemplate
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
 metadata:
   name: flink-compute-optimized
   namespace: karpenter
 spec:
   amiFamily: AL2
+  amiSelectorTerms:
+    - alias: "al2@latest"  
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:
@@ -80,10 +70,11 @@ spec:
         deleteOnTermination: true
   role: "${eks_cluster_id}-karpenter-node"
   subnetSelectorTerms:
-    - tags: # Update the correct region and zones
-        Name: "${eks_cluster_id}-private*"
+    - tags:
+        karpenter.sh/discovery: "${eks_cluster_id}" # replace with your cluster name
   securityGroupSelectorTerms:
-    - name: "${eks_cluster_id}-node*"
+    - tags:
+        karpenter.sh/discovery: "${eks_cluster_id}" # replace with your cluster name  
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/streaming/flink/karpenter-provisioners/flink-graviton-memory-optimized-provisioner.yaml
+++ b/streaming/flink/karpenter-provisioners/flink-graviton-memory-optimized-provisioner.yaml
@@ -1,6 +1,6 @@
 ---
-apiVersion: karpenter.sh/v1beta1
-kind: NodePool # Previously kind: Provisioner
+apiVersion: karpenter.sh/v1
+kind: NodePool
 metadata:
   name: flink-graviton-memory-optimized
   namespace: karpenter # Same namespace as Karpenter add-on installed
@@ -13,7 +13,10 @@ spec:
         NodeGroupType: FlinkGravitonMemoryOptimized
     spec:
       nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
         name: flink-graviton-memory-optimized
+      expireAfter: 720h # 30 * 24h = 720h
       requirements:
         - key: "topology.kubernetes.io/zone"
           operator: In
@@ -42,35 +45,22 @@ spec:
   limits:
     cpu: 1000
   disruption:
-    # Describes which types of Nodes Karpenter should consider for consolidation
-    # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
-    # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
-    consolidationPolicy: WhenEmpty
-    # The amount of time Karpenter should wait after discovering a consolidation decision
-    # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
-    # You can choose to disable consolidation entirely by setting the string value 'Never' here
+    consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 30s
-    # The amount of time a Node can live on the cluster before being removed
-    # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
-    # You can choose to disable expiration entirely by setting the string value 'Never' here
-    expireAfter: 720h
-
-  # Priority given to the NodePool when the scheduler considers which NodePool
-  # to select. Higher weights indicate higher priority when comparing NodePools.
-  # Specifying no weight is equivalent to specifying a weight of 0.
   weight: 10
-
 
 
 # NOTE: Multiple NodePools may point to the same EC2NodeClass.
 ---
-apiVersion: karpenter.k8s.aws/v1beta1
-kind: EC2NodeClass # Previously kind: AWSNodeTemplate
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
 metadata:
   name: flink-graviton-memory-optimized
   namespace: karpenter
 spec:
   amiFamily: AL2
+  amiSelectorTerms:
+    - alias: "al2@latest"  
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:
@@ -80,10 +70,11 @@ spec:
         deleteOnTermination: true
   role: "${eks_cluster_id}-karpenter-node"
   subnetSelectorTerms:
-    - tags: # Update the correct region and zones
-        Name: "${eks_cluster_id}-private*"
+    - tags:
+        karpenter.sh/discovery: "${eks_cluster_id}" # replace with your cluster name
   securityGroupSelectorTerms:
-    - name: "${eks_cluster_id}-node*"
+    - tags:
+        karpenter.sh/discovery: "${eks_cluster_id}" # replace with your cluster name  
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/streaming/flink/karpenter-provisioners/flink-memory-optimized-provisioner.yaml
+++ b/streaming/flink/karpenter-provisioners/flink-memory-optimized-provisioner.yaml
@@ -1,6 +1,6 @@
 ---
-apiVersion: karpenter.sh/v1beta1
-kind: NodePool # Previously kind: Provisioner
+apiVersion: karpenter.sh/v1
+kind: NodePool
 metadata:
   name: flink-memory-optimized
   namespace: karpenter # Same namespace as Karpenter add-on installed
@@ -13,7 +13,10 @@ spec:
         NodeGroupType: FlinkMemoryOptimized
     spec:
       nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
         name: flink-memory-optimized
+      expireAfter: 720h # 30 * 24h = 720h
       requirements:
         - key: "topology.kubernetes.io/zone"
           operator: In
@@ -42,35 +45,23 @@ spec:
   limits:
     cpu: 1000
   disruption:
-    # Describes which types of Nodes Karpenter should consider for consolidation
-    # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
-    # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods
-    consolidationPolicy: WhenEmpty
-    # The amount of time Karpenter should wait after discovering a consolidation decision
-    # This value can currently only be set when the consolidationPolicy is 'WhenEmpty'
-    # You can choose to disable consolidation entirely by setting the string value 'Never' here
+    consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 30s
-    # The amount of time a Node can live on the cluster before being removed
-    # Avoiding long-running Nodes helps to reduce security vulnerabilities as well as to reduce the chance of issues that can plague Nodes with long uptimes such as file fragmentation or memory leaks from system processes
-    # You can choose to disable expiration entirely by setting the string value 'Never' here
-    expireAfter: 720h
-
-  # Priority given to the NodePool when the scheduler considers which NodePool
-  # to select. Higher weights indicate higher priority when comparing NodePools.
-  # Specifying no weight is equivalent to specifying a weight of 0.
   weight: 10
 
 
 
 # NOTE: Multiple NodePools may point to the same EC2NodeClass.
 ---
-apiVersion: karpenter.k8s.aws/v1beta1
-kind: EC2NodeClass # Previously kind: AWSNodeTemplate
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
 metadata:
   name: flink-memory-optimized
   namespace: karpenter
 spec:
   amiFamily: AL2
+  amiSelectorTerms:
+    - alias: "al2@latest"  
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:
@@ -80,10 +71,11 @@ spec:
         deleteOnTermination: true
   role: "${eks_cluster_id}-karpenter-node"
   subnetSelectorTerms:
-    - tags: # Update the correct region and zones
-        Name: "${eks_cluster_id}-private*"
+    - tags:
+        karpenter.sh/discovery: "${eks_cluster_id}" # replace with your cluster name
   securityGroupSelectorTerms:
-    - name: "${eks_cluster_id}-node*"
+    - tags:
+        karpenter.sh/discovery: "${eks_cluster_id}" # replace with your cluster name  
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/streaming/flink/main.tf
+++ b/streaming/flink/main.tf
@@ -96,6 +96,13 @@ module "eks" {
     }
   }
 
+  node_security_group_tags = merge(local.tags, {
+    # NOTE - if creating multiple security groups with this module, only tag the
+    # security group that Karpenter should utilize with the following tag
+    # (i.e. - at most, only one security group should have this tag in your account)
+    "karpenter.sh/discovery" = local.name
+  })
+
   eks_managed_node_groups = {
     #  We recommend to have a MNG to place your critical workloads and add-ons
     #  Then rely on Karpenter to scale your workloads


### PR DESCRIPTION
### What does this PR do?

🛑 Resolve issue - Flink module uses invalid Karpenter version #849


<!-- A brief description of the change being made with this pull request. -->

### Motivation

Doing a PoC Flink on EKS
<!-- What inspired you to submit this pull request? -->

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
```
 % kg ec2nodeclasses.karpenter.k8s.aws                               
NAME                              READY   AGE
flink-compute-optimized           True    120m
flink-graviton-memory-optimized   True    120m
flink-memory-optimized            True    120m
 % kg nodepools.karpenter.sh                               
NAME                              NODECLASS                         NODES   READY   AGE
flink-compute-optimized           flink-compute-optimized           2       True    120m
flink-graviton-memory-optimized   flink-graviton-memory-optimized   0       True    120m
flink-memory-optimized            flink-memory-optimized            0       True    120m


 % kubectl get deployments -n flink-team-a-ns
NAME            READY   UP-TO-DATE   AVAILABLE   AGE
basic-example   1/1     1            1           87s
 % kubectl get services -n flink-team-a-ns
NAME                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
basic-example-rest   ClusterIP   172.20.40.152   <none>        8081/TCP   105s
 % kubectl get pods -n flink-team-a-ns       
NAME                            READY   STATUS    RESTARTS   AGE
basic-example-6cbb8dc46-d87lq   1/1     Running   0          102m
basic-example-taskmanager-1-1   1/1     Running   0          101m
basic-example-taskmanager-1-2   1/1     Running   0          101m
 % kubectl port-forward svc/basic-example-rest 8081 -n flink-team-a-ns
Forwarding from 127.0.0.1:8081 -> 8081
Forwarding from [::1]:8081 -> 8081
Handling connection for 8081
```
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
