### PR TITLE
feat: Spark on EKS Blueprint Update

### DIFF
--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -30,7 +30,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 | <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.55 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 20.33 |
 | <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | ~> 1.20 |
-| <a name="module_eks_data_addons"></a> [eks\_data\_addons](#module\_eks\_data\_addons) | aws-ia/eks-data-addons/aws | 1.37.1 |
+| <a name="module_eks_data_addons"></a> [eks\_data\_addons](#module\_eks\_data\_addons) | aws-ia/eks-data-addons/aws | 1.38.0 |
 | <a name="module_jupyterhub_single_user_irsa"></a> [jupyterhub\_single\_user\_irsa](#module\_jupyterhub\_single\_user\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.52.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.6 |
 | <a name="module_s3_csi_driver_irsa"></a> [s3\_csi\_driver\_irsa](#module\_s3\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.55 |
@@ -86,17 +86,15 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | EKS Cluster version | `string` | `"1.31"` | no |
-| <a name="input_eks_data_plane_subnet_secondary_cidr"></a> [eks\_data\_plane\_subnet\_secondary\_cidr](#input\_eks\_data\_plane\_subnet\_secondary\_cidr) | Secondary CIDR blocks. 32766 IPs per Subnet per Subnet/AZ for EKS Node and Pods | `list(string)` | <pre>[<br/>  "100.64.0.0/17",<br/>  "100.64.128.0/17"<br/>]</pre> | no |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | EKS Cluster version | `string` | `"1.33"` | no |
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `true` | no |
-| <a name="input_enable_jupyterhub"></a> [enable\_jupyterhub](#input\_enable\_jupyterhub) | Enable Jupyter Hub | `bool` | `false` | no |
+| <a name="input_enable_jupyterhub"></a> [enable\_jupyterhub](#input\_enable\_jupyterhub) | Enable Jupyter Hub | `bool` | `true` | no |
 | <a name="input_enable_raydata"></a> [enable\_raydata](#input\_enable\_raydata) | Enable Ray Data Spark logs processing with Iceberg | `bool` | `false` | no |
+| <a name="input_enable_spark_workshop_config"></a> [enable\_spark\_workshop\_config](#input\_enable\_spark\_workshop\_config) | Enabling config for Spark Workshop | `bool` | `false` | no |
 | <a name="input_enable_vpc_endpoints"></a> [enable\_vpc\_endpoints](#input\_enable\_vpc\_endpoints) | Enable VPC Endpoints | `bool` | `false` | no |
 | <a name="input_enable_yunikorn"></a> [enable\_yunikorn](#input\_enable\_yunikorn) | Enable Apache YuniKorn Scheduler | `bool` | `false` | no |
 | <a name="input_kms_key_admin_roles"></a> [kms\_key\_admin\_roles](#input\_kms\_key\_admin\_roles) | list of role ARNs to add to the KMS policy | `list(string)` | `[]` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the VPC and EKS Cluster | `string` | `"spark-operator-doeks"` | no |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Private Subnets CIDRs. 254 IPs per Subnet/AZ for Private NAT + NLB + Airflow + EC2 Jumphost etc. | `list(string)` | <pre>[<br/>  "10.1.1.0/24",<br/>  "10.1.2.0/24"<br/>]</pre> | no |
-| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Public Subnets CIDRs. 62 IPs per Subnet/AZ | `list(string)` | <pre>[<br/>  "10.1.0.0/26",<br/>  "10.1.0.64/26"<br/>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the VPC and EKS Cluster | `string` | `"spark-on-eks"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region | `string` | `"us-west-2"` | no |
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | Secondary CIDR blocks to be attached to VPC | `list(string)` | <pre>[<br/>  "100.64.0.0/16"<br/>]</pre> | no |
 | <a name="input_spark_benchmark_ssd_desired_size"></a> [spark\_benchmark\_ssd\_desired\_size](#input\_spark\_benchmark\_ssd\_desired\_size) | Desired size for nodegroup of c5d 12xlarge instances to run data generation for Spark benchmark | `number` | `0` | no |

--- a/analytics/terraform/spark-k8s-operator/helm-values/jupyterhub-singleuser-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/jupyterhub-singleuser-values.yaml
@@ -1,10 +1,12 @@
 hub:
+%{ if enable_spark_workshop_config ~}
+  baseUrl: "/jupyter/"
+%{ endif ~}
   db:
     pvc:
       storage: 50Gi
       storageClassName: gp3
   authenticatePrometheus: false
-
 proxy:
   https:
     enabled: false

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -1,6 +1,6 @@
 variable "name" {
   description = "Name of the VPC and EKS Cluster"
-  default     = "spark-operator-doeks"
+  default     = "spark-on-eks"
   type        = string
 }
 
@@ -12,7 +12,7 @@ variable "region" {
 
 variable "eks_cluster_version" {
   description = "EKS Cluster version"
-  default     = "1.31"
+  default     = "1.33"
   type        = string
 }
 
@@ -23,33 +23,11 @@ variable "vpc_cidr" {
   type        = string
 }
 
-# Routable Public subnets with NAT Gateway and Internet Gateway. Not required for fully private clusters
-variable "public_subnets" {
-  description = "Public Subnets CIDRs. 62 IPs per Subnet/AZ"
-  default     = ["10.1.0.0/26", "10.1.0.64/26"]
-  type        = list(string)
-}
-
-# Routable Private subnets only for Private NAT Gateway -> Transit Gateway -> Second VPC for overlapping overlapping CIDRs
-variable "private_subnets" {
-  description = "Private Subnets CIDRs. 254 IPs per Subnet/AZ for Private NAT + NLB + Airflow + EC2 Jumphost etc."
-  default     = ["10.1.1.0/24", "10.1.2.0/24"]
-  type        = list(string)
-}
-
 # RFC6598 range 100.64.0.0/10
 # Note you can only /16 range to VPC. You can add multiples of /16 if required
 variable "secondary_cidr_blocks" {
   description = "Secondary CIDR blocks to be attached to VPC"
   default     = ["100.64.0.0/16"]
-  type        = list(string)
-}
-
-# EKS Worker nodes and pods will be placed on these subnets. Each Private subnet can get 32766 IPs.
-# RFC6598 range 100.64.0.0/10
-variable "eks_data_plane_subnet_secondary_cidr" {
-  description = "Secondary CIDR blocks. 32766 IPs per Subnet per Subnet/AZ for EKS Node and Pods"
-  default     = ["100.64.0.0/17", "100.64.128.0/17"]
   type        = list(string)
 }
 
@@ -73,7 +51,7 @@ variable "enable_yunikorn" {
 }
 
 variable "enable_jupyterhub" {
-  default     = false
+  default     = true
   description = "Enable Jupyter Hub"
   type        = bool
 }
@@ -98,6 +76,12 @@ variable "spark_benchmark_ssd_desired_size" {
 
 variable "enable_raydata" {
   description = "Enable Ray Data Spark logs processing with Iceberg"
+  type        = bool
+  default     = false
+}
+
+variable "enable_spark_workshop_config" {
+  description = "Enabling config for Spark Workshop"
   type        = bool
   default     = false
 }

--- a/analytics/terraform/spark-k8s-operator/vpc.tf
+++ b/analytics/terraform/spark-k8s-operator/vpc.tf
@@ -4,28 +4,38 @@
 # WARNING: This VPC module includes the creation of an Internet Gateway and NAT Gateway, which simplifies cluster deployment and testing, primarily intended for sandbox accounts.
 # IMPORTANT: For preprod and prod use cases, it is crucial to consult with your security team and AWS architects to design a private infrastructure solution that aligns with your security requirements
 
+#---------------------------------------------------------------
+# VPC
+#---------------------------------------------------------------
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 5.19"
 
   name = local.name
   cidr = var.vpc_cidr
-  azs  = local.azs
+
+  azs = local.azs
 
   # Secondary CIDR block attached to VPC for EKS Control Plane ENI + Nodes + Pods
   secondary_cidr_blocks = var.secondary_cidr_blocks
 
+
   # 1/ EKS Data Plane secondary CIDR blocks for two subnets across two AZs for EKS Control Plane ENI + Nodes + Pods
   # 2/ Two private Subnets with RFC1918 private IPv4 address range for Private NAT + NLB + Airflow + EC2 Jumphost etc.
-  private_subnets = concat(var.private_subnets, var.eks_data_plane_subnet_secondary_cidr)
+  private_subnets = concat(
+    [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k)],
+    [for k, v in local.azs : cidrsubnet(var.secondary_cidr_blocks[0], 2, k)]
+  )
+  public_subnets = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 8, k + 48)]
 
-  # ------------------------------
-  # Optional Public Subnets for NAT and IGW for PoC/Dev/Test environments
-  # Public Subnets can be disabled while deploying to Production and use Private NAT + TGW
-  public_subnets     = var.public_subnets
+  private_subnet_names = concat(
+    [for k, v in local.azs : "${var.name}-private-${v}"],
+    [for k, v in local.azs : "${var.name}-private-secondary-${v}"]
+  )
+  public_subnet_names = [for k, v in local.azs : "${var.name}-public-${v}"]
+
   enable_nat_gateway = true
   single_nat_gateway = true
-  #-------------------------------
 
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1

--- a/website/docs/benchmarks/spark-operator-benchmark/data-generation.md
+++ b/website/docs/benchmarks/spark-operator-benchmark/data-generation.md
@@ -126,7 +126,7 @@ The log snippet of the `tpcds-data-generation-1tb-driver` pod should look like b
 24/11/01 15:29:42 INFO FileFormatWriter: Start to commit write Job xxxx.
 24/11/01 15:29:42 INFO FileFormatWriter: Write Job xxxx committed. Elapsed time: 158 ms.
 24/11/01 15:29:42 INFO FileFormatWriter: Finished processing stats for write job xxxx.
-Data generated at s3a://spark-operator-doeks-spark-logs-xxx/TPCDS-TEST-1TB
+Data generated at s3a://spark-on-eks-spark-logs-xxx/TPCDS-TEST-1TB
 24/11/01 15:29:42 INFO SparkContext: SparkContext is stopping with exitCode 0.
 24/11/01 15:29:42 INFO SparkUI: Stopped Spark web UI at http://tpcds-data-generation-1tb-yyyyy-driver-svc.spark-team-a.svc:4040
 24/11/01 15:29:42 INFO KubernetesClusterSchedulerBackend: Shutting down all executors

--- a/website/docs/blueprints/amazon-emr-on-eks/emr-eks-spark-operator.md
+++ b/website/docs/blueprints/amazon-emr-on-eks/emr-eks-spark-operator.md
@@ -100,7 +100,7 @@ aws amp list-workspaces --alias amp-ws-emr-eks-karpenter
 Verify Namespace `emr-data-team-a` and Pod status for `Prometheus`, `Vertical Pod Autoscaler`, `Metrics Server` and `Cluster Autoscaler`.
 
 ```bash
-aws eks --region us-west-2 update-kubeconfig --name spark-operator-doeks # Creates k8s config file to authenticate with EKS Cluster
+aws eks --region us-west-2 update-kubeconfig --name spark-on-eks # Creates k8s config file to authenticate with EKS Cluster
 
 kubectl get nodes # Output shows the EKS Managed Node group nodes
 

--- a/website/docs/resources/mountpoint-s3-for-spark.md
+++ b/website/docs/resources/mountpoint-s3-for-spark.md
@@ -180,7 +180,7 @@ Here are the steps to test the scenario using Approach 2 with DaemonSet:
     2. ``` chmod +x copy-jars-to-s3.sh ```
     3. ``` ./copy-jars-to-s3.sh ```
 3. Set-up Kubeconfig
-    1. ```aws eks update-kubeconfig --name spark-operator-doeks```
+    1. ```aws eks update-kubeconfig --name spark-on-eks```
 4. Apply DaemonSet
     1. ```kubectl apply -f mountpoint-s3-daemonset.yaml ```
 4. Apply Spark Job sample


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

- VPC module updated to name the secondary CIDR subnets
- Spark History Server addon updated to use the latest version and Data addons version uplifted
- SHS values added with condition to handle the proxy path to enable the proxy when running from workshop VS Code
- JupyterHub values updated with proxy path used in Spark workshop with VS Code
- Cluster name changed to use spark-on-eks to align with the Spark workshop
- EKS Cluster upgraded to 1.33
- Documentation updated

NOTE: Let's merge this Data Addons PR first before merging this PR: https://github.com/aws-ia/terraform-aws-eks-data-addons/pull/55




<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
