### PR TITLE
feat: Deploying gp3 storage class before the addons to avoud race condition

### DIFF
--- a/analytics/terraform/spark-k8s-operator/install.sh
+++ b/analytics/terraform/spark-k8s-operator/install.sh
@@ -9,6 +9,8 @@ targets=(
   "module.vpc_endpoints_sg"
   "module.vpc_endpoints"
   "module.eks"
+  "kubernetes_annotations.gp2_default"
+  "kubernetes_storage_class.ebs_csi_encrypted_gp3_storage_class"
   "module.eks_blueprints_addons" # install kube-prometheus-stack first so addons can use CRDs
 )
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

- Ensuring that GP3 storage is deployed before the actual addons which requires this storage class to create EBS Volumes

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
