### PR TITLE
feat: VPC Module update to create subnets dynamically for AZ = 2 to 4

### DIFF
--- a/analytics/terraform/spark-k8s-operator/README.md
+++ b/analytics/terraform/spark-k8s-operator/README.md
@@ -88,6 +88,7 @@ Checkout the [documentation website](https://awslabs.github.io/data-on-eks/docs/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Number of Availability Zones (2-4) | `number` | `3` | no |
 | <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | EKS Cluster version | `string` | `"1.33"` | no |
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `true` | no |
 | <a name="input_enable_jupyterhub"></a> [enable\_jupyterhub](#input\_enable\_jupyterhub) | Enable Jupyter Hub | `bool` | `false` | no |

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -69,7 +69,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -123,7 +123,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -183,7 +183,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -236,7 +236,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -368,7 +368,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -413,7 +413,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -449,7 +449,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -488,7 +488,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -530,7 +530,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -578,7 +578,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node
@@ -631,7 +631,7 @@ module "eks_data_addons" {
         karpenterRole: ${split("/", module.eks_blueprints_addons.karpenter.node_iam_role_arn)[1]}
         subnetSelectorTerms:
           tags:
-            Name: "${module.eks.cluster_name}-private*"
+            Name: "${module.eks.cluster_name}-private-secondary*"
         securityGroupSelectorTerms:
           tags:
             Name: ${module.eks.cluster_name}-node

--- a/analytics/terraform/spark-k8s-operator/main.tf
+++ b/analytics/terraform/spark-k8s-operator/main.tf
@@ -35,7 +35,7 @@ provider "kubectl" {
 locals {
   name   = var.name
   region = var.region
-  azs = slice(data.aws_availability_zones.available.names, 0, var.az_count)
+  azs    = slice(data.aws_availability_zones.available.names, 0, var.az_count)
 
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition

--- a/analytics/terraform/spark-k8s-operator/main.tf
+++ b/analytics/terraform/spark-k8s-operator/main.tf
@@ -35,7 +35,7 @@ provider "kubectl" {
 locals {
   name   = var.name
   region = var.region
-  azs    = slice(data.aws_availability_zones.available.names, 0, 2)
+  azs = slice(data.aws_availability_zones.available.names, 0, var.az_count)
 
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -31,6 +31,18 @@ variable "secondary_cidr_blocks" {
   type        = list(string)
 }
 
+# How many AZs to span (2..4)
+variable "az_count" {
+  description = "Number of Availability Zones (2-4)"
+  type        = number
+  default     = 3
+  
+  validation {
+    condition     = var.az_count >= 2 && var.az_count <= 4
+    error_message = "AZ count must be between 2 and 4"
+  }
+}
+
 # Enable this for fully private clusters
 variable "enable_vpc_endpoints" {
   description = "Enable VPC Endpoints"

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -36,7 +36,7 @@ variable "az_count" {
   description = "Number of Availability Zones (2-4)"
   type        = number
   default     = 3
-  
+
   validation {
     condition     = var.az_count >= 2 && var.az_count <= 4
     error_message = "AZ count must be between 2 and 4"

--- a/analytics/terraform/spark-k8s-operator/vpc.tf
+++ b/analytics/terraform/spark-k8s-operator/vpc.tf
@@ -34,24 +34,24 @@ locals {
   private_primary_subnets = [
     for i, az in local.azs : cidrsubnet(var.vpc_cidr, 4, i)
   ]
-  
+
   private_secondary_subnets = [
     for i, az in local.azs : cidrsubnet(var.secondary_cidr_blocks[0], 2, i)
   ]
-  
+
   public_subnets = [
     for i, az in local.azs : cidrsubnet(var.vpc_cidr, 8, 128 + i)
   ]
-  
+
   # Combine all private subnets
   all_private_subnets = concat(local.private_primary_subnets, local.private_secondary_subnets)
-  
+
   # Generate subnet names
   private_subnet_names = concat(
     [for az in local.azs : "${var.name}-private-${az}"],
-    [for az in local.azs : "${var.name}-private-secondary-${az}"]  # Secondary CIDR for workload pods
+    [for az in local.azs : "${var.name}-private-secondary-${az}"] # Secondary CIDR for workload pods
   )
-  
+
   public_subnet_names = [for az in local.azs : "${var.name}-public-${az}"]
 
 }

--- a/analytics/terraform/spark-k8s-operator/vpc.tf
+++ b/analytics/terraform/spark-k8s-operator/vpc.tf
@@ -3,7 +3,58 @@
 #---------------------------------------------------------------
 # WARNING: This VPC module includes the creation of an Internet Gateway and NAT Gateway, which simplifies cluster deployment and testing, primarily intended for sandbox accounts.
 # IMPORTANT: For preprod and prod use cases, it is crucial to consult with your security team and AWS architects to design a private infrastructure solution that aligns with your security requirements
+#
+# ╔═══════════════════════════════════════════════════════════════════════════════════════════════╗
+# ║                              VPC SUBNET ALLOCATION TABLE                                      ║
+# ╠═══════════════════════════════════════════════════════════════════════════════════════════════╣
+# ║ AZ Count │ Private Primary (/20)    │ Private Secondary CIDR (/18)  │ Public (/24)            ║
+# ║          │ from 10.1.0.0/16         │ from 100.64.0.0/16            │ from 10.1.0.0/16        ║
+# ╠═══════════════════════════════════════════════════════════════════════════════════════════════╣
+# ║    2     │ 10.1.0.0/20   (4096 IPs) │ 100.64.0.0/18  (16384)        │ 10.1.128.0/24 (256)     ║
+# ║          │ 10.1.16.0/20  (4096 IPs) │ 100.64.64.0/18 (16384)        │ 10.1.129.0/24 (256)     ║
+# ╠═══════════════════════════════════════════════════════════════════════════════════════════════╣
+# ║    3     │ 10.1.0.0/20   (4096 IPs) │ 100.64.0.0/18   (16384)       │ 10.1.128.0/24 (256)     ║
+# ║          │ 10.1.16.0/20  (4096 IPs) │ 100.64.64.0/18  (16384)       │ 10.1.129.0/24 (256)     ║
+# ║          │ 10.1.32.0/20  (4096 IPs) │ 100.64.128.0/18 (16384)       │ 10.1.130.0/24 (256)     ║
+# ╠═══════════════════════════════════════════════════════════════════════════════════════════════╣
+# ║    4     │ 10.1.0.0/20   (4096 IPs) │ 100.64.0.0/18   (16384)       │ 10.1.128.0/24 (256)     ║
+# ║          │ 10.1.16.0/20  (4096 IPs) │ 100.64.64.0/18  (16384)       │ 10.1.129.0/24 (256)     ║
+# ║          │ 10.1.32.0/20  (4096 IPs) │ 100.64.128.0/18 (16384)       │ 10.1.130.0/24 (256)     ║
+# ║          │ 10.1.48.0/20  (4096 IPs) │ 100.64.192.0/18 (16384)       │ 10.1.131.0/24 (256)     ║
+# ╚═══════════════════════════════════════════════════════════════════════════════════════════════╝
+#
+# Usage Notes:
+# • Private Primary: Main application subnets (EC2, RDS, etc.)
+# • Private Secondary: Pod/container networking (EKS, Fargate)
+# • Public: Load balancers, NAT gateways, bastion hosts
+# • Change var.az_count (2-4) to scale AZs - CIDR ranges adapt automatically
 
+locals {
+
+  private_primary_subnets = [
+    for i, az in local.azs : cidrsubnet(var.vpc_cidr, 4, i)
+  ]
+  
+  private_secondary_subnets = [
+    for i, az in local.azs : cidrsubnet(var.secondary_cidr_blocks[0], 2, i)
+  ]
+  
+  public_subnets = [
+    for i, az in local.azs : cidrsubnet(var.vpc_cidr, 8, 128 + i)
+  ]
+  
+  # Combine all private subnets
+  all_private_subnets = concat(local.private_primary_subnets, local.private_secondary_subnets)
+  
+  # Generate subnet names
+  private_subnet_names = concat(
+    [for az in local.azs : "${var.name}-private-${az}"],
+    [for az in local.azs : "${var.name}-private-secondary-${az}"]  # Secondary CIDR for workload pods
+  )
+  
+  public_subnet_names = [for az in local.azs : "${var.name}-public-${az}"]
+
+}
 #---------------------------------------------------------------
 # VPC
 #---------------------------------------------------------------
@@ -19,20 +70,11 @@ module "vpc" {
   # Secondary CIDR block attached to VPC for EKS Control Plane ENI + Nodes + Pods
   secondary_cidr_blocks = var.secondary_cidr_blocks
 
-
-  # 1/ EKS Data Plane secondary CIDR blocks for two subnets across two AZs for EKS Control Plane ENI + Nodes + Pods
-  # 2/ Two private Subnets with RFC1918 private IPv4 address range for Private NAT + NLB + Airflow + EC2 Jumphost etc.
-  private_subnets = concat(
-    [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k)],
-    [for k, v in local.azs : cidrsubnet(var.secondary_cidr_blocks[0], 2, k)]
-  )
-  public_subnets = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 8, k + 48)]
-
-  private_subnet_names = concat(
-    [for k, v in local.azs : "${var.name}-private-${v}"],
-    [for k, v in local.azs : "${var.name}-private-secondary-${v}"]
-  )
-  public_subnet_names = [for k, v in local.azs : "${var.name}-public-${v}"]
+  # Subnet configuration
+  private_subnets      = local.all_private_subnets
+  private_subnet_names = local.private_subnet_names
+  public_subnets       = local.public_subnets
+  public_subnet_names  = local.public_subnet_names
 
   enable_nat_gateway = true
   single_nat_gateway = true


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

- Updated VPC Module to create all subnets dynamically in a region with number of AZs  from 2 to 4
- Just enter number of AZs in the variable and the module calculates the CIDR ranges
- Karpenter is now using only secondary CIDR subnets for Spark workloads

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
