### PR TITLE
docs: Update EMR on EKS with Flink Streaming documentation

### DIFF
--- a/website/docs/blueprints/streaming-platforms/emr-eks-flink.md
+++ b/website/docs/blueprints/streaming-platforms/emr-eks-flink.md
@@ -190,7 +190,7 @@ Flink Operator provides three upgrade modes for Flink jobs. Checkout the [Flink 
 
 <CollapsibleContent header={<h2><span>Deploying the Solution</span></h2>}>
 
-In this [example](https://github.com/awslabs/data-on-eks/tree/main/streaming/flink), you will provision the following resources required to run Flink Jobs with Flink Operator and Apache YuniKorn.
+In this [example](https://github.com/awslabs/data-on-eks/tree/main/streaming/emr-eks-flink), you will provision the following resources required to run Flink Jobs with Flink Operator and Apache YuniKorn.
 
 This example deploys an EKS Cluster running the Flink Operator into a new VPC.
 
@@ -336,3 +336,4 @@ cd .. && chmod +x cleanup.sh
 :::caution
 To avoid unwanted charges to your AWS account, delete all the AWS resources created during this deployment
 :::
+


### PR DESCRIPTION
Incorrect URL used within documentation

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Updating the URL within the EMR-EKS-Flink blueprint documentation to point to the correct place.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
