### PR TITLE
feat: Update Graviton Generation values for Spark workshop

### DIFF
--- a/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-compute-general-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-compute-general-graviton.yaml
@@ -8,7 +8,7 @@ spec:
       labels:
         node.kubernetes.io/workload-type: compute-general-graviton
         node.kubernetes.io/instance-category: general
-        node.kubernetes.io/arch: amd64
+        node.kubernetes.io/arch: arm64
         NodeGroupType: "SparkGravitonComputeGeneral"
 
     spec:
@@ -43,7 +43,7 @@ spec:
           operator: In
           values: ["nitro"]
 
-        # Generation 6+
+        # Generation 7+
         - key: eks.amazonaws.com/instance-generation
           operator: Gt
           values: ["6"]

--- a/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-compute-optimized-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-compute-optimized-graviton.yaml
@@ -33,7 +33,7 @@ spec:
           operator: In
           values: ["c"]
 
-        # Instance families - Graviton compute families (gen 6+)
+        # Instance families - Graviton compute families (gen 7+)
         - key: eks.amazonaws.com/instance-family
           operator: In
           values: ["c7g", "c7gd", "c7gn", "c8g", "c8gd", "c8gn"]
@@ -48,7 +48,7 @@ spec:
           operator: In
           values: ["nitro"]
 
-        # Generation 6+ (Graviton starts at gen 5)
+        # Generation 7+ (Graviton starts at gen 5)
         - key: eks.amazonaws.com/instance-generation
           operator: Gt
           values: ["6"]

--- a/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-memory-optimized-graviton.yaml
+++ b/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-memory-optimized-graviton.yaml
@@ -33,7 +33,7 @@ spec:
           operator: In
           values: ["r"]
 
-        # Instance families - Graviton memory families (gen 6+)
+        # Instance families - Graviton memory families (gen 7+)
         - key: eks.amazonaws.com/instance-family
           operator: In
           values: ["r7g", "r7gd", "r8g", "r8gd"]
@@ -48,7 +48,7 @@ spec:
           operator: In
           values: ["nitro"]
 
-        # Generation 6+ (Graviton starts at gen 5)
+        # Generation 7+ (Graviton starts at gen 5)
         - key: eks.amazonaws.com/instance-generation
           operator: Gt
           values: ["6"]


### PR DESCRIPTION
### What does this PR do?

Updates Graviton NodePool configurations for Spark K8s Operator (EKSAuto Mode) to use generation 7+ instance families, ensuring workloads leverage the latest Graviton processors.

### Motivation

Latest processors offer improved price-performance for Spark workloads compared to earlier generations. This update ensures users get the latest Graviton instances for better compute efficiency and cost optimization.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Instance families included:
- Compute optimized: c7g, c7gd, c7gn, c8g, c8gd, c8gn
- Memory optimized: r7g, r7gd, r8g, r8gd
