### PR TITLE
feat: Enabling and deploying Spark History MCP server

### DIFF
--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/Chart.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: mcp-apache-spark-history-server
+description: A Helm chart for Spark History Server MCP
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - spark
+  - mcp
+  - analytics
+  - performance
+  - history-server
+home: https://github.com/kubeflow/mcp-apache-spark-history-server
+sources:
+  - https://github.com/kubeflow/mcp-apache-spark-history-server
+maintainers:
+  - name: Manabu McCloskey
+    email: Manabu.McCloskey@gmail.com
+  - name: Vara Bonthu
+    email: vara.bonthu@gmail.com
+annotations:
+  category: Analytics

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/NOTES.txt
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/NOTES.txt
@@ -1,0 +1,47 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mcp-apache-spark-history-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mcp-apache-spark-history-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mcp-apache-spark-history-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mcp-apache-spark-history-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+
+2. Test the MCP server:
+  kubectl run test-mcp --rm -i --tty --image=curlimages/curl -- sh
+  # Inside the test pod:
+  curl -X POST http://{{ include "mcp-apache-spark-history-server.fullname" . }}:{{ .Values.service.port }}/tools \
+    -H "Content-Type: application/json" \
+    -d '{"tool": "list_applications", "parameters": {}}'
+
+3. Check the status:
+  helm status {{ .Release.Name }}
+  kubectl get pods -l app.kubernetes.io/name={{ include "mcp-apache-spark-history-server.name" . }}
+
+{{- if .Values.monitoring.enabled }}
+4. Access monitoring:
+  - Prometheus metrics: http://{{ include "mcp-apache-spark-history-server.fullname" . }}:{{ .Values.service.port }}/metrics
+{{- end }}
+
+{{- if not .Values.config.servers }}
+⚠️  WARNING: No Spark History Servers configured. Please update your values.yaml to include:
+   config:
+     servers:
+       default:
+         default: true
+         url: "http://your-spark-history-server:18080"
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/_helpers.tpl
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/_helpers.tpl
@@ -1,0 +1,130 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-apache-spark-history-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mcp-apache-spark-history-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-apache-spark-history-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-apache-spark-history-server.labels" -}}
+helm.sh/chart: {{ include "mcp-apache-spark-history-server.chart" . }}
+{{ include "mcp-apache-spark-history-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-apache-spark-history-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-apache-spark-history-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mcp-apache-spark-history-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-apache-spark-history-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the config map
+*/}}
+{{- define "mcp-apache-spark-history-server.configMapName" -}}
+{{- printf "%s-config" (include "mcp-apache-spark-history-server.fullname" .) }}
+{{- end }}
+
+{{/*
+Create the name of the secret
+*/}}
+{{- define "mcp-apache-spark-history-server.secretName" -}}
+{{- $default := printf "%s-auth" (include "mcp-apache-spark-history-server.fullname" .) -}}
+{{- if .Values.auth.secret.name -}}
+{{- .Values.auth.secret.name -}}
+{{- else -}}
+{{- $default -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Create image name
+*/}}
+{{- define "mcp-apache-spark-history-server.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+Create environment variables
+*/}}
+{{- define "mcp-apache-spark-history-server.env" -}}
+- name: MCP_PORT
+  value: {{ .Values.config.port | quote }}
+- name: MCP_DEBUG
+  value: {{ .Values.config.debug | quote }}
+{{- $csi := (default (dict) .Values.auth.csisecretstore) -}}
+{{- if and .Values.auth.enabled (or .Values.auth.secret.create .Values.auth.externalsecret.create $csi.enabled) }}
+- name: SPARK_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "mcp-apache-spark-history-server.secretName" . }}
+      key: username
+      optional: true
+- name: SPARK_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "mcp-apache-spark-history-server.secretName" . }}
+      key: password
+      optional: true
+- name: SPARK_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "mcp-apache-spark-history-server.secretName" . }}
+      key: token
+      optional: true
+{{- end }}
+{{- range .Values.env }}
+- name: {{ .name }}
+  value: {{ .value | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the name of the SecretProviderClass (must be created externally)
+*/}}
+{{- define "mcp-apache-spark-history-server.secretProviderClassName" -}}
+{{- .Values.auth.csisecretstore.secretProviderClassName -}}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/configmap.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    mcp:
+      transports:
+        - streamable-http
+      port: "{{ .Values.config.port }}"
+      debug: {{ .Values.config.debug }}
+      address: 0.0.0.0
+    servers:
+      {{- range $name, $server := .Values.config.servers }}
+      {{ $name }}:
+        {{- if $server.default }}
+        default: {{ $server.default }}
+        {{- end }}
+        url: {{ $server.url | quote }}
+        {{- if $server.auth }}
+        auth:
+          {{- toYaml $server.auth | nindent 10 }}
+        {{- end }}
+      {{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/deployment.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/deployment.yaml
@@ -1,0 +1,134 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mcp-apache-spark-history-server.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if and .Values.auth.enabled .Values.auth.secret.create }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.auth.enabled .Values.auth.externalsecret.create }}
+        checksum/externalsecret: {{ include (print $.Template.BasePath "/externalsecret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.auth.enabled .Values.auth.csisecretstore.enabled }}
+        checksum/secretproviderclass: {{ include "mcp-apache-spark-history-server.secretProviderClassName" . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "mcp-apache-spark-history-server.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-apache-spark-history-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "mcp-apache-spark-history-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          env:
+            {{- include "mcp-apache-spark-history-server.env" . | nindent 12 }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+            {{- if and .Values.auth.enabled .Values.auth.csisecretstore.enabled }}
+            - name: csi-secrets
+              mountPath: {{ .Values.auth.csisecretstore.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mcp-apache-spark-history-server.configMapName" . }}
+            defaultMode: 0644
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-apache-spark-history-server.fullname" . }}
+        {{- end }}
+        {{- if and .Values.auth.enabled .Values.auth.csisecretstore.enabled }}
+        - name: csi-secrets
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "mcp-apache-spark-history-server.secretProviderClassName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/externalsecret.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/externalsecret.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.auth.enabled .Values.auth.externalsecret.create }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.auth.externalsecret.refreshInterval | default "1h" | quote }}
+  secretStoreRef:
+    name: {{ .Values.auth.externalsecret.secretStoreRef.name | quote }}
+    kind: {{ .Values.auth.externalsecret.secretStoreRef.kind | default "ClusterSecretStore" | quote }}
+  target:
+    name: {{ include "mcp-apache-spark-history-server.secretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ .Values.auth.externalsecret.secretPath | quote }}
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: {{ .Values.auth.externalsecret.secretPath | quote }}
+        property: password
+    - secretKey: token
+      remoteRef:
+        key: {{ .Values.auth.externalsecret.secretPath | quote }}
+        property: token
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/hpa.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mcp-apache-spark-history-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/ingress.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/ingress.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mcp-apache-spark-history-server.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")) }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/pdb.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mcp-apache-spark-history-server.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/pvc.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/secret.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.auth.enabled .Values.auth.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  username: {{ .Values.auth.secret.username | default "" | quote }}
+  password: {{ .Values.auth.secret.password | default "" | quote }}
+  token: {{ .Values.auth.secret.token | default "" | quote }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/service.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "mcp-apache-spark-history-server.selectorLabels" . | nindent 4 }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/serviceaccount.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/servicemonitor.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mcp-apache-spark-history-server.fullname" . }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "mcp-apache-spark-history-server.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.monitoring.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mcp-apache-spark-history-server.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+    interval: {{ .Values.monitoring.serviceMonitor.interval }}
+    path: {{ .Values.monitoring.serviceMonitor.path }}
+    scheme: http
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/spark-history-mcp/values.yaml
@@ -1,0 +1,229 @@
+# Default values for spark-history-mcp
+# This is a YAML-formatted file.
+
+# Image configuration
+image:
+  repository: ghcr.io/kubeflow/mcp-apache-spark-history-server
+  pullPolicy: IfNotPresent
+  tag: "v0.1.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Pod replica count (used when autoscaling is disabled)
+replicaCount: 2
+
+# Service account configuration
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+# Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - ALL
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 18888
+  targetPort: http
+  # nodePort: 31888  # Uncomment and set when service.type is NodePort
+  annotations: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: spark-mcp.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: spark-mcp-tls
+  #    hosts:
+  #      - spark-mcp.local
+
+# Resource configuration
+resources:
+  limits:
+    memory: 2Gi
+    cpu: 1000m
+  requests:
+    memory: 512Mi
+    cpu: 250m
+
+# Autoscaling configuration
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# MCP server configuration
+config:
+  port: 18888
+  debug: false
+
+  # Spark History Server configuration
+  servers:
+    default:
+      default: true
+      url: "http://spark-history-server:18080"
+    # Example: Additional servers
+    # staging:
+    #   url: "http://staging-spark-history:18080"
+    # production:
+    #   url: "http://prod-spark-history:18080"
+
+# Authentication configuration
+auth:
+  enabled: false
+
+  # secret: use Kubernetes Secret to store spark history server credentials as environment variables
+  secret:
+    create: false
+    name: ""
+    username: ""
+    password: ""
+    token: ""
+
+  # externalsecret: use External Secrets Operator to sync a Secret from a secret provider.
+  # Requiring External Secrets Operator to be installed in the k8s cluster.
+  externalsecret:
+    create: false
+    secretStoreRef:
+      name: ""           # e.g. my-secret-store
+      kind: ClusterSecretStore  # or SecretStore
+    secretPath: ""        # e.g. path/to/secret containing username/password/token properties
+
+  # csisecretstore: use Secret Store CSI Driver to mount secrets and (optionally) sync to a Kubernetes Secret.
+  # Requires the Secret Store CSI Driver to be installed in the cluster, and the relevant provider.
+  # Note: SecretProviderClass must be created separately by platform/security team.
+  csisecretstore:
+    enabled: false
+    # Reference to existing SecretProviderClass (must be created separately)
+    secretProviderClassName: ""
+    # mountPath: /mnt/secrets-store
+
+# Environment variables
+env: []
+  # - name: CUSTOM_VAR
+  #   value: "custom_value"
+
+# Environment variables from secrets/configmaps
+envFrom: []
+
+# Health checks
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 12
+
+# Node selector
+nodeSelector: {}
+
+# Tolerations
+tolerations: []
+
+# Affinity
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - spark-history-mcp
+        topologyKey: kubernetes.io/hostname
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod labels
+podLabels: {}
+
+# Monitoring configuration
+monitoring:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    namespace: ""
+    interval: 30s
+    path: /metrics
+    labels: {}
+    annotations: {}
+
+# Persistence (for logs, if needed)
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  mountPath: /app/logs
+
+# Pod disruption budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# Extra volumes
+extraVolumes: []
+
+# Extra volume mounts
+extraVolumeMounts: []
+
+# Init containers
+initContainers: []
+
+# Sidecar containers
+sidecars: []
+
+# Deployment strategy
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 1

--- a/analytics/terraform/spark-k8s-operator/helm-values/spark-history-mcp-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/spark-history-mcp-values.yaml
@@ -1,0 +1,59 @@
+# Spark History MCP Server - AI agent bridge to Spark History Server
+image:
+  repository: ghcr.io/kubeflow/mcp-apache-spark-history-server
+  tag: "0.1.5"
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 18888
+
+config:
+  port: 18888
+  debug: false
+  servers:
+    default:
+      default: true
+      url: "http://spark-history-server.spark-history-server:80"
+
+resources:
+  limits:
+    memory: 1Gi
+    cpu: 500m
+  requests:
+    memory: 256Mi
+    cpu: 100m
+
+monitoring:
+  enabled: ${monitoring_enabled}
+  serviceMonitor:
+    enabled: ${monitoring_enabled}
+    namespace: kube-prometheus-stack
+    interval: 30s
+
+nodeSelector:
+  eks.amazonaws.com/compute-type: auto
+
+# Disable health probes - MCP server doesn't expose /health or /ready endpoints yet
+# See: https://github.com/kubeflow/mcp-apache-spark-history-server/issues
+# Default probes from chart values.yaml:
+# livenessProbe:
+#   httpGet:
+#     path: /health
+#     port: http
+#   initialDelaySeconds: 30
+#   periodSeconds: 10
+#   timeoutSeconds: 5
+#   failureThreshold: 3
+# readinessProbe:
+#   httpGet:
+#     path: /ready
+#     port: http
+#   initialDelaySeconds: 5
+#   periodSeconds: 5
+#   timeoutSeconds: 3
+#   failureThreshold: 3
+livenessProbe: null
+readinessProbe: null
+startupProbe: null

--- a/analytics/terraform/spark-k8s-operator/spark-history-mcp.tf
+++ b/analytics/terraform/spark-k8s-operator/spark-history-mcp.tf
@@ -1,0 +1,22 @@
+#---------------------------------------------------------------
+# Spark History MCP Server
+# Provides AI agent access to Spark History Server for job analysis
+# https://github.com/kubeflow/mcp-apache-spark-history-server
+#---------------------------------------------------------------
+
+resource "helm_release" "spark_history_mcp" {
+  count = var.enable_spark_history_mcp ? 1 : 0
+
+  name             = "spark-history-mcp"
+  chart            = "${path.module}/helm-charts/spark-history-mcp"
+  namespace        = "spark-history-server"
+  create_namespace = false
+
+  values = [
+    templatefile("${path.module}/helm-values/spark-history-mcp-values.yaml", {
+      monitoring_enabled = var.enable_amazon_prometheus
+    })
+  ]
+
+  depends_on = [module.eks_data_addons]
+}

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -97,3 +97,9 @@ variable "enable_spark_history_server" {
   type        = bool
   default     = true
 }
+
+variable "enable_spark_history_mcp" {
+  description = "Enable Spark History MCP Server for AI agent integration"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
### What does this PR do?

Adds optional Spark History MCP Server integration to the spark-k8s-operator blueprint. This enables AI assistants (Kiro CLI, Amazon Q CLI, Claude Desktop, etc.) to query Spark History Server data via the Model Context Protocol (MCP), allowing natural language interactions for job analysis, performance debugging, and bottleneck identification.

Changes:
- Added helm-values/spark-history-mcp-values.yaml - Helm values for MCP server configuration
- Added spark-history-mcp.tf - Terraform resource to deploy MCP server via Helm
- Added helm-charts/spark-history-mcp/ - Local Helm chart (from kubeflow/mcp-apache-spark-history-server)
- Modified variables.tf - Added enable_spark_history_mcp variable (default: false)
- Modified analytics/scripts/data-gen.py to generate 7 million records instead of 1000 (will create order.parquet file)

MCP Server provides 18 tools including:
- list_applications, get_application
- list_jobs, list_stages, list_executors
- get_job_bottlenecks, list_slowest_stages
- compare_job_performance, get_resource_usage_timeline

### Motivation

Spark debugging requires deep expertise and manual navigation through Spark UI. The MCP server bridges AI agents with Spark History Server, transforming complex debugging sessions into conversational interactions. Engineers can ask questions like "Why did my Spark job fail?" or "Show bottlenecks for the latest application" and receive actionable insights.

Reference: [kubeflow/mcp-apache-spark-history-server](https://github.com/kubeflow/mcp-apache-spark-history-server)

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested the changes on a new workshop setup.

ec2-user:~/environment:$ curl -s -X POST http://localhost:18888/mcp/ \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "mcp-session-id: $SESSION_ID" \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_applications","arguments":{}}}'
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"{\n  \"id\": \"spark-0370e3582b8f4658922b571019e1506b\",\n  \"name\": \"OrderData_2026_02_02_19_59_57\",\n  \"coresGranted\": null,\n  \"maxCores\": null,\n  \"coresPerExecutor\": null,\n  \"memoryPerExecutorMB\": null,\n  \"attempts\": [\n    {\n      \"attemptId\": null,\n      \"startTime\": \"2026-02-02T19:59:57.711000Z\",\n      \"endTime\": \"2026-02-02T20:01:58.762000Z\",\n      \"lastUpdated\": \"2026-02-02T20:02:00Z\",\n      \"duration\": 121051,\n      \"sparkUser\": \"spark\",\n      \"appSparkVersion\": \"4.0.1\",\n      \"completed\": true\n    }\n  ]\n}"},{"type":"text","text":"{\n  \"id\": \"spark-e14cfd07f8db4942b2c18424d09bd521\",\n  \"name\": \"OrderData_2026_02_02_19_59_41\",\n  \"coresGranted\": null,\n  \"maxCores\": null,\n  \"coresPerExecutor\": null,\n  \"memoryPerExecutorMB\": null,\n  \"attempts\": [\n    {\n      \"attemptId\": null,\n      \"startTime\": \"2026-02-02T19:59:41.467000Z\",\n      \"endTime\": \"2026-02-02T20:01:21.843000Z\",\n      \"lastUpdated\": \"2026-02-02T20:01:23Z\",\n      \"duration\": 100376,\n      \"sparkUser\": \"spark\",\n      \"appSparkVersion\": \"4.0.1\",\n      \"completed\": true\n    }\n  ]\n}"}],"isError":false}}

ec2-user:~/environment:$ 
ec2-user:~/environment:$ 
ec2-user:~/environment:$ curl -s -X POST http://localhost:18888/mcp/ \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "mcp-session-id: $SESSION_ID" \
  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_job_bottlenecks","arguments":{"app_id":"spark-0370e3582b8f4658922b571019e1506b"}}}'
event: message
data: {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"{\n  \"application_id\": \"spark-0370e3582b8f4658922b571019e1506b\",\n  \"performance_bottlenecks\": {\n    \"slowest_stages\": [\n      {\n        \"stage_id\": 7,\n        \"attempt_id\": 0,\n        \"name\": \"$anonfun$withThreadLocalCaptured$2 at CompletableFuture.java:1768\",\n        \"duration_seconds\": 28.433,\n        \"task_count\": 2,\n        \"failed_tasks\": 0\n      },\n      {\n        \"stage_id\": 5,\n        \"attempt_id\": 0,\n        \"name\": \"$anonfun$withThreadLocalCaptured$2 at CompletableFuture.java:1768\",\n        \"duration_seconds\": 12.607,\n        \"task_count\": 24,\n        \"failed_tasks\": 0\n      },\n      {\n        \"stage_id\": 1,\n        \"attempt_id\": 0,\n        \"name\": \"showString at NativeMethodAccessorImpl.java:0\",\n        \"duration_seconds\": 3.26,\n        \"task_count\": 1,\n        \"failed_tasks\": 0\n      },\n      {\n        \"stage_id\": 2,\n        \"attempt_id\": 0,\n        \"name\": \"$anonfun$withThreadLocalCaptured$2 at CompletableFuture.java:1768\",\n        \"duration_seconds\": 2.989,\n        \"task_count\": 24,\n        \"failed_tasks\": 0\n      },\n      {\n        \"stage_id\": 0,\n        \"attempt_id\": 0,\n        \"name\": \"parquet at NativeMethodAccessorImpl.java:0\",\n        \"duration_seconds\": 28.548,\n        \"task_count\": 1,\n        \"failed_tasks\": 0\n      }\n    ],\n    \"slowest_jobs\": [\n      {\n        \"job_id\": 0,\n        \"name\": \"parquet at NativeMethodAccessorImpl.java:0\",\n        \"duration_seconds\": 28.572,\n        \"failed_tasks\": 0,\n        \"status\": \"SUCCEEDED\"\n      },\n      {\n        \"job_id\": 5,\n        \"name\": \"$anonfun$withThreadLocalCaptured$2 at CompletableFuture.java:1768\",\n        \"duration_seconds\": 28.435,\n        \"failed_tasks\": 0,\n        \"status\": \"SUCCEEDED\"\n      },\n      {\n        \"job_id\": 4,\n        \"name\": \"$anonfun$withThreadLocalCaptured$2 at CompletableFuture.java:1768\",\n        \"duration_seconds\": 12.613,\n        \"failed_tasks\": 0,\n        \"status\": \"SUCCEEDED\"\n      },\n      {\n        \"job_id\": 1,\n        \"name\": \"showString at NativeMethodAccessorImpl.java:0\",\n        \"duration_seconds\": 3.265,\n        \"failed_tasks\": 0,\n        \"status\": \"SUCCEEDED\"\n      },\n      {\n        \"job_id\": 2,\n        \"name\": \"$anonfun$withThreadLocalCaptured$2 at CompletableFuture.java:1768\",\n        \"duration_seconds\": 3.003,\n        \"failed_tasks\": 0,\n        \"status\": \"SUCCEEDED\"\n      }\n    ]\n  },\n  \"resource_bottlenecks\": {\n    \"memory_spill_stages\": [],\n    \"gc_pressure_ratio\": 0.003960190033637341,\n    \"executor_utilization\": {\n      \"total_executors\": 5,\n      \"active_executors\": 5,\n      \"utilization_ratio\": 1.0\n    }\n  },\n  \"recommendations\": []\n}"}],"isError":false}}