### PR TITLE
fix: Pin celeborn to version 6.2.0

### DIFF
--- a/infra/terraform/helm-values/celeborn.yaml
+++ b/infra/terraform/helm-values/celeborn.yaml
@@ -1,5 +1,6 @@
 image:
   pullPolicy: IfNotPresent
+  tag: 0.6.2
 
 serviceAccount:
   create: true


### PR DESCRIPTION
### What does this PR do?

The helm chart default value references v0.7.0 which is not yet released, but we need s3 integration introduced in the latest helm chart. So we need pin the image to 6.2.0.



### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
