### PR TITLE
fix: Shorten shs role name

### DIFF
--- a/infra/terraform/spark-history-server.tf
+++ b/infra/terraform/spark-history-server.tf
@@ -36,7 +36,7 @@ resource "kubectl_manifest" "spark_history_server" {
 module "spark_history_server_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version = "~> 6.0"
-  name    = "${module.eks.cluster_name}-spark-history-server"
+  name    = "${module.eks.cluster_name}-shs"
 
   policies = {
     policy = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess" # Policy needs to be defined based in what you need to give access to your notebook instances.


### PR DESCRIPTION
### What does this PR do?

This shortens the IAM role name for the spark history server. When working with the clickhouse on eks module, we get:

```
╷
│ Error: expected length of name_prefix to be in the range (1 - 38), got clickhouse-on-eks-spark-history-server-
│
│   with module.spark_history_server_irsa.aws_iam_role.this[0],
│   on .terraform/modules/spark_history_server_irsa/modules/iam-role-for-service-accounts/main.tf line 84, in resource "aws_iam_role" "this":
│   84:   name_prefix = var.use_name_prefix ? "${var.name}-" : null
│
╵
```




### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
