### PR TITLE
fea: Add initial clickhouse stack

### DIFF
--- a/data-stacks/clickhouse-on-eks/cleanup.sh
+++ b/data-stacks/clickhouse-on-eks/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd terraform/_local
+source ./cleanup.sh

--- a/data-stacks/clickhouse-on-eks/deploy.sh
+++ b/data-stacks/clickhouse-on-eks/deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+# --- Configuration ---
+STACKS="data-on-eks"
+TERRAFORM_DIR="terraform"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+KUBECONFIG_FILE="kubeconfig.yaml"
+
+
+# --- Get Repo Root ---
+REPO_PATH=$(git rev-parse --show-toplevel)
+
+# --- Source and Execute the Main Deployment Engine ---
+# The centralized install.sh handles all the heavy lifting.
+source $REPO_PATH/infra/terraform/install.sh
+
+# --- Post-Deployment Steps ---
+# Steps specific to this stack can be added here.
+print_status "Running stack-specific post-deployment steps..."
+
+# Backup the state file from the _local directory
+cp "$TERRAFORM_DIR/_local/terraform.tfstate" "$TERRAFORM_DIR/terraform.tfstate.bak"
+print_status "Backed up terraform.tfstate."
+
+# Setup kubeconfig
+setup_kubeconfig
+
+# Get ArgoCD admin password
+export KUBECONFIG=$KUBECONFIG_FILE
+ARGOCD_PASSWORD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+
+print_next_steps

--- a/data-stacks/clickhouse-on-eks/examples/clickhouse-cluster.yaml
+++ b/data-stacks/clickhouse-on-eks/examples/clickhouse-cluster.yaml
@@ -1,0 +1,74 @@
+# Example: Deploy a ClickHouse cluster on Graviton r8g.4xlarge nodes
+#
+# Prerequisites:
+#   - ClickHouse operator installed (enable_clickhouse = true)
+#   - clickhouse namespace created
+#
+# Usage:
+#   kubectl create namespace clickhouse
+#   kubectl create secret generic clickhouse-password -n clickhouse --from-literal=password="$(openssl rand -base64 24)"
+#   kubectl apply -f clickhouse-cluster.yaml
+
+apiVersion: clickhouse.com/v1alpha1
+kind: KeeperCluster
+metadata:
+  name: clickhouse-keeper
+  namespace: clickhouse
+spec:
+  replicas: 3
+  settings:
+    logger:
+      level: information
+    extraConfig:
+      logger:
+        formatting:
+          type: json
+  dataVolumeClaimSpec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+---
+apiVersion: clickhouse.com/v1alpha1
+kind: ClickHouseCluster
+metadata:
+  name: clickhouse-cluster
+  namespace: clickhouse
+spec:
+  settings:
+    logger:
+      level: information
+    extraConfig:
+      logger:
+        formatting:
+          type: json
+    defaultUserPassword:
+      secret:
+        name: clickhouse-password
+        key: password
+  shards: 1
+  replicas: 1
+  keeperClusterRef:
+    name: clickhouse-keeper
+  dataVolumeClaimSpec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 500Gi
+  podTemplate:
+    nodeSelector:
+      karpenter.k8s.aws/instance-family: r8g
+      karpenter.k8s.aws/instance-size: 4xlarge
+  containerTemplate:
+    image:
+      repository: clickhouse/clickhouse-server
+      tag: "25.1"
+    resources:
+      requests:
+        cpu: "8"
+        memory: 64Gi
+      limits:
+        cpu: "16"
+        memory: 120Gi

--- a/data-stacks/clickhouse-on-eks/terraform/data-stack.tfvars
+++ b/data-stacks/clickhouse-on-eks/terraform/data-stack.tfvars
@@ -1,0 +1,4 @@
+name                 = "clickhouse-on-eks"
+region               = "us-west-2"
+enable_ingress_nginx = false
+enable_clickhouse    = true

--- a/infra/terraform/argocd-applications/clickhouse-operator.yaml
+++ b/infra/terraform/argocd-applications/clickhouse-operator.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: clickhouse-operator
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/clickhouse
+    chart: clickhouse-operator-helm
+    targetRevision: "0.0.3"
+    helm:
+      values: |
+        ${user_values_yaml}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: clickhouse-operator-system
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/terraform/clickhouse.tf
+++ b/infra/terraform/clickhouse.tf
@@ -1,0 +1,15 @@
+locals {
+  clickhouse_operator_values = templatefile("${path.module}/helm-values/clickhouse-operator.yaml", {})
+}
+
+resource "kubectl_manifest" "clickhouse_operator" {
+  count = var.enable_clickhouse ? 1 : 0
+
+  yaml_body = templatefile("${path.module}/argocd-applications/clickhouse-operator.yaml", {
+    user_values_yaml = indent(8, local.clickhouse_operator_values)
+  })
+
+  depends_on = [
+    helm_release.argocd,
+  ]
+}

--- a/infra/terraform/helm-values/clickhouse-operator.yaml
+++ b/infra/terraform/helm-values/clickhouse-operator.yaml
@@ -1,0 +1,6 @@
+watchNamespaces:
+  - clickhouse
+
+manager:
+  nodeSelector:
+    NodeGroupType: core

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -224,6 +224,12 @@ variable "enable_emr_spark_operator" {
   default     = false
 }
 
+variable "enable_clickhouse" {
+  description = "Enable ClickHouse Operator for managing ClickHouse clusters"
+  type        = bool
+  default     = false
+}
+
 #---------------------------------------------------------------
 # EKS Provisioned Control Plane (PCP) Tier
 # Controls the EKS control plane capacity for high-scale workloads


### PR DESCRIPTION
### What does this PR do?

This adds initial Clickhouse data stack using the official clickhouse operator. We will need to add more comprehensive examples and docs in followup PRs

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
