### PR TITLE
fix: Increase memory for Spark History Server

### DIFF
--- a/infra/terraform/helm-values/spark-history-server.yaml
+++ b/infra/terraform/helm-values/spark-history-server.yaml
@@ -3,8 +3,9 @@ historyServer:
     maxDiskUsage: 25g
     hybridStore:
       enabled: true
+      maxMemoryUsage: 6g
 sparkDaemon:
-  memory: 10g
+  memory: 12g
 logStore:
   s3:
     bucket: ${s3_bucket_name}
@@ -12,7 +13,7 @@ logStore:
     irsaRoleArn: ${spark_history_server_role}
 resources:
   limits:
-    memory: 12Gi
+    memory: 24Gi
 sparkConf: |-
   # Storage backend optimizations for S3/ABFS (non-conflicting settings)
   spark.hadoop.fs.s3a.connection.maximum=200


### PR DESCRIPTION
### What does this PR do?

This increases the memory assigned to Spark history server. 


<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
