### PR TITLE
fix: Return ipv4 DNS records for ipv4 clusters

### DIFF
--- a/infra/terraform/helm-values/aws-for-fluentbit.yaml
+++ b/infra/terraform/helm-values/aws-for-fluentbit.yaml
@@ -29,6 +29,7 @@ service:
     HTTP_Listen  0.0.0.0
     HTTP_PORT    2020
     Health_Check On
+    Dns.prefer_ipv4 On
 %{ endif ~}
   extraParsers: |
     [PARSER]

--- a/infra/terraform/vpc.tf
+++ b/infra/terraform/vpc.tf
@@ -121,7 +121,7 @@ module "vpc_endpoints" {
       )
       ip_address_type = "dualstack"
       dns_options = {
-        dns_record_ip_type = "dualstack"
+        dns_record_ip_type = var.enable_ipv6 ? "dualstack" : "ipv4"
       }
       private_dns_enabled = true
     }


### PR DESCRIPTION
### What does this PR do?

This returns A records for ipv4 clusters.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
