### PR TITLE
Update logging infra and configurations for k8s events and spark

### DIFF
--- a/infra/terraform/argocd-applications/clickhouse-operator.yaml
+++ b/infra/terraform/argocd-applications/clickhouse-operator.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/clickhouse
     chart: clickhouse-operator-helm
-    targetRevision: "0.0.3"
+    targetRevision: "0.0.4"
     helm:
       values: |
         ${user_values_yaml}

--- a/infra/terraform/grafana-dashboards/k8s-events-dashboard.json
+++ b/infra/terraform/grafana-dashboards/k8s-events-dashboard.json
@@ -30,7 +30,8 @@
         {
           "rawSql": "SELECT toStartOfMinute(timestamp) AS time, type, count() AS events FROM k8s_events.events WHERE timestamp >= $__fromTime AND timestamp <= $__toTime GROUP BY time, type ORDER BY time",
           "format": 1,
-          "refId": "A"
+          "refId": "A",
+          "meta": { "database": "k8s_events", "table": "events" }
         }
       ],
       "fieldConfig": {
@@ -49,7 +50,8 @@
         {
           "rawSql": "SELECT namespace, count() AS events FROM k8s_events.events WHERE timestamp >= $__fromTime AND timestamp <= $__toTime GROUP BY namespace ORDER BY events DESC LIMIT 20",
           "format": 1,
-          "refId": "A"
+          "refId": "A",
+          "meta": { "database": "k8s_events", "table": "events" }
         }
       ],
       "transformations": [],
@@ -75,9 +77,10 @@
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse-observability" },
       "targets": [
         {
-          "rawSql": "SELECT timestamp, type, namespace, object_kind, object_name, reason, source_component, message FROM k8s_events.events WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND ('${search:raw}' = '' OR message ILIKE '%${search:raw}%') ORDER BY timestamp DESC LIMIT 500",
+          "rawSql": "SELECT timestamp, type, namespace, object_kind, object_name, reason, source_component, message FROM k8s_events.events WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND ('${search:raw}' = '' OR hasTokenCaseInsensitive(message, '${search:raw}')) ORDER BY timestamp DESC LIMIT 500",
           "format": 1,
-          "refId": "A"
+          "refId": "A",
+          "meta": { "database": "k8s_events", "table": "events" }
         }
       ],
       "options": { "showHeader": true, "sortBy": [{ "displayName": "timestamp", "desc": true }] },

--- a/infra/terraform/grafana-dashboards/spark-logs-dashboard.json
+++ b/infra/terraform/grafana-dashboards/spark-logs-dashboard.json
@@ -14,15 +14,22 @@
       },
       {
         "name": "level",
-        "type": "query",
+        "type": "custom",
         "label": "Level",
-        "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse-observability" },
-        "query": "SELECT DISTINCT level FROM app_logs.spark ORDER BY level",
+        "query": "FATAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN",
         "includeAll": true,
-        "allValue": "'ERROR','WARN','INFO','DEBUG','TRACE','FATAL'",
+        "allValue": "'ERROR','WARN','INFO','DEBUG','TRACE','FATAL','UNKNOWN'",
         "multi": true,
-        "current": { "text": ["ERROR", "WARN"], "value": ["ERROR", "WARN"] },
-        "refresh": 2
+        "current": { "text": ["ERROR", "WARN", "UNKNOWN"], "value": ["ERROR", "WARN", "UNKNOWN"] }
+      },
+      {
+        "name": "role",
+        "type": "custom",
+        "label": "Role",
+        "query": "driver,executor",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": ["driver"], "value": ["driver"] }
       },
       {
         "name": "spark_filter",
@@ -31,7 +38,6 @@
         "defaultKeys": [
           { "text": "namespace", "value": "namespace" },
           { "text": "app", "value": "app" },
-          { "text": "role", "value": "role" },
           { "text": "node_name", "value": "node_name" },
           { "text": "pod_name", "value": "pod_name" },
           { "text": "container_name", "value": "container_name" }
@@ -48,7 +54,7 @@
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse-observability" },
       "targets": [
         {
-          "rawSql": "SELECT toStartOfMinute(timestamp) AS time, level, count() AS logs FROM app_logs.spark WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND level IN (${level:sqlstring}) GROUP BY time, level ORDER BY time",
+          "rawSql": "SELECT toStartOfMinute(timestamp) AS time, level, count() AS logs FROM app_logs.spark WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND level IN (${level:sqlstring}) AND role IN (${role:sqlstring}) GROUP BY time, level ORDER BY time",
           "format": 0,
           "refId": "A",
           "meta": { "database": "app_logs", "table": "spark" }
@@ -73,7 +79,7 @@
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse-observability" },
       "targets": [
         {
-          "rawSql": "SELECT app, count() AS logs FROM app_logs.spark WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND level IN (${level:sqlstring}) GROUP BY app ORDER BY logs DESC LIMIT 20",
+          "rawSql": "SELECT app, count() AS logs FROM app_logs.spark WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND level IN (${level:sqlstring}) AND role IN (${role:sqlstring}) GROUP BY app ORDER BY logs DESC LIMIT 20",
           "format": 1,
           "refId": "A",
           "meta": { "database": "app_logs", "table": "spark" }
@@ -101,7 +107,7 @@
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse-observability" },
       "targets": [
         {
-          "rawSql": "SELECT timestamp, message AS body, level, namespace, app, role, pod_name, container_name, node_name, toString(log) AS log FROM app_logs.spark WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND level IN (${level:sqlstring}) AND ('${search:raw}' = '' OR message ILIKE '%${search:raw}%') ORDER BY timestamp DESC LIMIT 500",
+          "rawSql": "SELECT timestamp, message AS body, level, namespace, app, role, pod_name, container_name, node_name FROM app_logs.spark WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND level IN (${level:sqlstring}) AND role IN (${role:sqlstring}) AND ('${search:raw}' = '' OR hasTokenCaseInsensitive(message, '${search:raw}')) ORDER BY timestamp DESC LIMIT 500",
           "format": 2,
           "refId": "A",
           "meta": { "database": "app_logs", "table": "spark" }

--- a/infra/terraform/helm-values/aws-for-fluentbit.yaml
+++ b/infra/terraform/helm-values/aws-for-fluentbit.yaml
@@ -105,14 +105,21 @@ additionalFilters: |
       Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
       Annotations         Off
 
-  # Enriches spark records with Kubernetes metadata and parses the JSON log line.
-  # Extracts level/message as top-level columns; remaining fields go into log JSON.
-  # Drops non-JSON lines (plain stdout/stderr) by returning -1 when level is absent.
+  # Reassemble multi-line stack traces before parsing
+  [FILTER]
+      Name                  multiline
+      Match                 spark.*
+      multiline.key_content log
+      multiline.parser      java
+
+  # Enriches spark records with Kubernetes metadata and parses the log line.
+  # Extracts level/message from plain-text Spark log format.
+  # Drops lines that don't match the expected pattern.
   [FILTER]
       Name                lua
       Match               spark.*
       call                enrich
-      code                function enrich(tag, timestamp, record) local k8s = record.kubernetes or {} local labels = k8s.labels or {} local parsed = record.log_processed or {} if type(parsed) == "string" then local ok, obj = pcall(cjson.decode, parsed) if ok then parsed = obj else parsed = {} end end if not parsed.level then return -1, timestamp, record end local explicit = {namespace=true, pod_name=true, container_name=true, node_name=true, app=true, role=true, timestamp=true, level=true, message=true} local log = {} for k,v in pairs(parsed) do if not explicit[k] then log[k] = v end end return 1, timestamp, {namespace=k8s.namespace_name or "", pod_name=k8s.pod_name or "", container_name=k8s.container_name or "", node_name=k8s.host or "", app=labels["spark-app-selector"] or "", role=labels["spark-role"] or "", level=parsed.level, message=parsed.message or "", log=log} end
+      code                function enrich(tag, timestamp, record) local k8s = record.kubernetes or {} local labels = k8s.labels or {} local line = record.log or "" local ts, lvl, cls, msg = line:match("^(%d+/%d+/%d+%s+%S+)%s+(%w+)%s+(%S+):%s+(.*)") if not lvl then lvl, msg = line:match("^(%u+)%s+(.*)") end if not lvl then lvl = "UNKNOWN" msg = line end return 1, timestamp, {namespace=k8s.namespace_name or "", pod_name=k8s.pod_name or "", container_name=k8s.container_name or "", node_name=k8s.host or "", app=labels["spark-app-selector"] or "", role=labels["spark-role"] or "", level=lvl, message=msg or ""} end
 
 cloudWatchLogs:
  enabled: false

--- a/infra/terraform/helm-values/event-collector.yaml
+++ b/infra/terraform/helm-values/event-collector.yaml
@@ -82,7 +82,7 @@ config:
         Match        kube_events.*
         Host         ${clickhouse_host}
         Port         ${clickhouse_port}
-        URI          /?query=INSERT+INTO+${clickhouse_database}.events+FORMAT+JSONEachRow&input_format_skip_unknown_fields=1
+        URI          /?query=INSERT+INTO+${clickhouse_database}.events+FORMAT+JSONEachRow&input_format_skip_unknown_fields=1&date_time_input_format=best_effort&async_insert=1&wait_for_async_insert=0
         Format       json_stream
         json_date_format iso8601
         Header       X-ClickHouse-User $${CLICKHOUSE_USER}

--- a/infra/terraform/manifests/event-store/templates/clickhouse-cluster.yaml
+++ b/infra/terraform/manifests/event-store/templates/clickhouse-cluster.yaml
@@ -67,8 +67,8 @@ spec:
       karpenter.k8s.aws/instance-size: 4xlarge
   containerTemplate:
     image:
-      repository: clickhouse/clickhouse-server
-      tag: "25.1"
+      repository: docker.io/clickhouse/clickhouse-server
+      tag: "26.3.9.8"
     resources:
       requests:
         cpu: "8"
@@ -95,7 +95,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: init-schema
-          image: clickhouse/clickhouse-server:25.1
+          image: docker.io/clickhouse/clickhouse-server:26.3.9.8
           command:
             - bash
             - -c
@@ -126,15 +126,16 @@ spec:
                   message String,
                   source_component LowCardinality(String),
                   source_host String,
-                  reporting_component String,
+                  reporting_component LowCardinality(String),
                   reporting_instance String,
                   count UInt32,
-                  action String,
-                  firstTimestamp String,
-                  lastTimestamp String
+                  action LowCardinality(String),
+                  firstTimestamp DateTime64(3) DEFAULT now64(),
+                  lastTimestamp DateTime64(3) DEFAULT now64(),
+                  INDEX message_idx(message) TYPE text(tokenizer = splitByNonAlpha, preprocessor = lower(message))
                 ) ENGINE = MergeTree()
                 PARTITION BY toYYYYMM(timestamp)
-                ORDER BY (namespace, object_kind, type, timestamp)
+                ORDER BY (timestamp, namespace, object_kind, type)
                 TTL toDateTime(timestamp) + INTERVAL 14 DAY TO VOLUME 'cold',
                     toDateTime(timestamp) + INTERVAL 60 DAY DELETE
                 SETTINGS storage_policy = 'tiered';
@@ -151,10 +152,10 @@ spec:
                   role LowCardinality(String),
                   level LowCardinality(String),
                   message String,
-                  log JSON
+                  INDEX message_idx(message) TYPE text(tokenizer = splitByNonAlpha, preprocessor = lower(message))
                 ) ENGINE = MergeTree()
                 PARTITION BY toYYYYMM(timestamp)
-                ORDER BY (namespace, app, level, timestamp)
+                ORDER BY (timestamp, namespace, app, level)
                 TTL toDateTime(timestamp) + INTERVAL 7 DAY TO VOLUME 'cold',
                     toDateTime(timestamp) + INTERVAL 60 DAY DELETE
                 SETTINGS storage_policy = 'tiered';
@@ -162,14 +163,15 @@ spec:
                 CREATE TABLE IF NOT EXISTS app_logs.spark_operator (
                   timestamp DateTime64(3) DEFAULT now64(),
                   namespace LowCardinality(String),
-                  pod_name String,
+                  pod_name LowCardinality(String),
                   container_name LowCardinality(String),
                   level LowCardinality(String),
                   message String,
-                  log JSON
+                  log JSON,
+                  INDEX message_idx(message) TYPE text(tokenizer = splitByNonAlpha, preprocessor = lower(message))
                 ) ENGINE = MergeTree()
                 PARTITION BY toYYYYMM(timestamp)
-                ORDER BY (namespace, timestamp)
+                ORDER BY (timestamp, namespace)
                 TTL toDateTime(timestamp) + INTERVAL 7 DAY TO VOLUME 'cold',
                     toDateTime(timestamp) + INTERVAL 60 DAY DELETE
                 SETTINGS storage_policy = 'tiered';


### PR DESCRIPTION
### What does this PR do?

This updates the Clickhouse Operator and Clickhouse server versions to take advantage of inverted index for more efficient text searching. This is supported from version 26.2+ so we need to upgrade. 


### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
