### PR TITLE
feat: Add Amazon S3 Files support for POSIX file access to S3 data

### DIFF
--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -79,6 +79,13 @@ resource "aws_eks_addon" "aws_mountpoint_s3_csi_driver" {
   service_account_role_arn = module.s3_csi_driver_irsa.iam_role_arn
 }
 
+resource "aws_eks_addon" "aws_efs_csi_driver" {
+  cluster_name = module.eks.cluster_name
+  addon_name   = "aws-efs-csi-driver"
+
+  service_account_role_arn = module.efs_csi_driver_irsa.iam_role_arn
+}
+
 
 #---------------------------------------------------------------
 # Data on EKS Kubernetes Addons
@@ -173,7 +180,7 @@ module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
   version = "1.22.0"
   # # ensure ebs and other eks addons are ready before installing helm charts
-  depends_on = [aws_eks_addon.aws_ebs_csi_driver, aws_eks_addon.metrics_server, aws_eks_addon.amazon_cloudwatch_observability, aws_eks_addon.aws_mountpoint_s3_csi_driver, aws_eks_addon.coredns]
+  depends_on = [aws_eks_addon.aws_ebs_csi_driver, aws_eks_addon.metrics_server, aws_eks_addon.amazon_cloudwatch_observability, aws_eks_addon.aws_mountpoint_s3_csi_driver, aws_eks_addon.coredns, aws_eks_addon.aws_efs_csi_driver]
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pv.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pv.yaml
@@ -1,0 +1,33 @@
+# PersistentVolume for S3 Files
+# S3 Files syncs data bidirectionally with S3 bucket
+#
+# IMPORTANT: Replace the following values from terraform outputs:
+#   - fs-XXXXXXXXX with: terraform output -raw s3_files_filesystem_id
+#   - fsap-XXXXXXXXX with: terraform output -raw s3_files_access_point_id
+#   - MOUNT_TARGET_IP: Get from mount target (see below)
+#
+# To get mount target IP:
+#   terraform output s3_files_mount_targets
+#   Then: aws s3files describe-mount-targets --file-system-id <fs-id> --region <region>
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3files-pv
+  labels:
+    type: s3-files
+    usage: spark-data
+spec:
+  capacity:
+    storage: 1200Gi  # Arbitrary value for S3 Files (actual storage is in S3)
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany  # Multiple pods can read/write simultaneously
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: s3files-sc
+  csi:
+    driver: efs.csi.aws.com  # S3 Files uses EFS CSI driver
+    # Format: s3files:<filesystem-id>::<access-point-id>
+    volumeHandle: s3files:<S3_FILES_FS_ID>::<S3_FILES_AP_ID>
+    volumeAttributes:
+      mounttargetip: "<S3_FILES_MOUNT_TARGET_IP>"

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pv.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pv.yaml
@@ -1,15 +1,3 @@
-# PersistentVolume for S3 Files
-# S3 Files syncs data bidirectionally with S3 bucket
-#
-# IMPORTANT: Replace the following values from terraform outputs:
-#   - fs-XXXXXXXXX with: terraform output -raw s3_files_filesystem_id
-#   - fsap-XXXXXXXXX with: terraform output -raw s3_files_access_point_id
-#   - MOUNT_TARGET_IP: Get from mount target (see below)
-#
-# To get mount target IP:
-#   terraform output s3_files_mount_targets
-#   Then: aws s3files describe-mount-targets --file-system-id <fs-id> --region <region>
----
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -19,15 +7,14 @@ metadata:
     usage: spark-data
 spec:
   capacity:
-    storage: 1200Gi  # Arbitrary value for S3 Files (actual storage is in S3)
+    storage: 100Gi
   volumeMode: Filesystem
   accessModes:
-    - ReadWriteMany  # Multiple pods can read/write simultaneously
+    - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: s3files-sc
+  storageClassName: s3-files-sc
   csi:
-    driver: efs.csi.aws.com  # S3 Files uses EFS CSI driver
-    # Format: s3files:<filesystem-id>::<access-point-id>
+    driver: efs.csi.aws.com
     volumeHandle: s3files:<S3_FILES_FS_ID>::<S3_FILES_AP_ID>
     volumeAttributes:
       mounttargetip: "<S3_FILES_MOUNT_TARGET_IP>"

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pvc.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pvc.yaml
@@ -1,0 +1,22 @@
+# PersistentVolumeClaim for S3 Files in spark-team-a namespace
+# This claims the S3 Files PV for use by Spark applications
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-files-pvc
+  namespace: spark-team-a
+  labels:
+    app: spark
+    storage-type: s3-files
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: s3-files-sc
+  resources:
+    requests:
+      storage: 100Gi  # Must match PV capacity
+  selector:
+    matchLabels:
+      type: s3-files
+      usage: spark-data

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pvc.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-pvc.yaml
@@ -1,6 +1,3 @@
-# PersistentVolumeClaim for S3 Files in spark-team-a namespace
-# This claims the S3 Files PV for use by Spark applications
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -15,7 +12,7 @@ spec:
   storageClassName: s3-files-sc
   resources:
     requests:
-      storage: 100Gi  # Must match PV capacity
+      storage: 100Gi
   selector:
     matchLabels:
       type: s3-files

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-sc.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-sc.yaml
@@ -1,18 +1,14 @@
-# StorageClass for Amazon S3 Files
-# S3 Files provides POSIX-compliant file system access to S3 data
-# Built on EFS with intelligent caching for performance
----
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: s3-files-sc
 provisioner: efs.csi.aws.com
 parameters:
-  provisioningMode: efs-ap  # Use EFS Access Points for isolation
-  fileSystemId: fs-XXXXXXXXX  # REPLACE with your S3 Files filesystem ID from Terraform output
+  provisioningMode: efs-ap
+  fileSystemId: <S3_FILES_FS_ID>
   directoryPerms: "755"
   gidRangeStart: "1000"
   gidRangeEnd: "2000"
-  basePath: "/dynamic"  # Base path for dynamically provisioned volumes
+  basePath: "/dynamic"
 mountOptions:
-  - tls  # Enable encryption in transit
+  - tls

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-sc.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/s3-files-sc.yaml
@@ -1,0 +1,18 @@
+# StorageClass for Amazon S3 Files
+# S3 Files provides POSIX-compliant file system access to S3 data
+# Built on EFS with intelligent caching for performance
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: s3-files-sc
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap  # Use EFS Access Points for isolation
+  fileSystemId: fs-XXXXXXXXX  # REPLACE with your S3 Files filesystem ID from Terraform output
+  directoryPerms: "755"
+  gidRangeStart: "1000"
+  gidRangeEnd: "2000"
+  basePath: "/dynamic"  # Base path for dynamically provisioned volumes
+mountOptions:
+  - tls  # Enable encryption in transit

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-s3files.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-s3files.yaml
@@ -1,14 +1,3 @@
-# SparkApplication using Amazon S3 Files
-# S3 Files provides POSIX file system semantics on top of S3 data
-# Built on EFS with intelligent caching for performance
-# Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files.html
-#
-# This job reads/writes data via mounted S3 Files filesystem instead of s3a:// protocol
-# Benefits:
-# - File system semantics (POSIX compliance, file locking)
-# - Intelligent caching (active data in high-performance storage)
-# - Bidirectional sync with S3 bucket
-# - Better for small file operations and metadata-heavy workloads
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
@@ -26,12 +15,10 @@ spec:
   imagePullPolicy: IfNotPresent
   mainApplicationFile: "s3a://<S3_BUCKET>/scripts/pyspark-order.py"
   arguments:
-    # Use file:// protocol to read/write from mounted S3 Files filesystem
-    # S3 Files automatically syncs changes bidirectionally with S3 bucket
     - "file:///mnt/s3-files/order/input/"
     - "file:///mnt/s3-files/order/output/s3-files/"
   sparkConf:
-    # AWS SDK V2 for s3a:// access (still needed for mainApplicationFile and event logs)
+    # AWS SDK V2
     "spark.hadoop.fs.s3a.aws.credentials.provider": "software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider,software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider"
     "spark.hadoop.fs.s3.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
     "spark.hadoop.fs.s3a.connection.timeout": "1200000"
@@ -44,7 +31,15 @@ spec:
     "spark.app.name": "order-s3files"
     "spark.kubernetes.driver.pod.name": "order-s3files-driver"
     "spark.kubernetes.executor.podNamePrefix": "order-s3files"
-    # Spark Event logs - keep on s3a:// for Spark History Server compatibility
+    # Mount S3 Files PVC on driver
+    "spark.kubernetes.driver.volumes.persistentVolumeClaim.s3-files-volume.options.claimName": "s3-files-pvc"
+    "spark.kubernetes.driver.volumes.persistentVolumeClaim.s3-files-volume.mount.path": "/mnt/s3-files"
+    "spark.kubernetes.driver.volumes.persistentVolumeClaim.s3-files-volume.mount.readOnly": "false"
+    # Mount S3 Files PVC on executors
+    "spark.kubernetes.executor.volumes.persistentVolumeClaim.s3-files-volume.options.claimName": "s3-files-pvc"
+    "spark.kubernetes.executor.volumes.persistentVolumeClaim.s3-files-volume.mount.path": "/mnt/s3-files"
+    "spark.kubernetes.executor.volumes.persistentVolumeClaim.s3-files-volume.mount.readOnly": "false"
+    # Spark Event logs
     "spark.eventLog.enabled": "true"
     "spark.eventLog.dir": "s3a://<S3_BUCKET>/spark-event-logs"
     "spark.eventLog.rolling.enabled": "true"
@@ -70,16 +65,7 @@ spec:
     serviceAccount: spark-team-a
     nodeSelector:
       karpenter.sh/capacity-type: "on-demand"
-      NodeGroupType: "SparkGravitonMemoryOptimized"
-    # Mount S3 Files filesystem via EFS CSI driver
-    volumes:
-      - name: s3-files-volume
-        persistentVolumeClaim:
-          claimName: s3-files-pvc
-    volumeMounts:
-      - name: s3-files-volume
-        mountPath: "/mnt/s3-files"
-        readOnly: false
+      NodeGroupType: "SparkComputeGeneral"
   executor:
     annotations:
       karpenter.sh/do-not-disrupt: "true"
@@ -88,22 +74,10 @@ spec:
     memory: "4g"
     memoryOverhead: "2g"
     serviceAccount: spark-team-a
-    podSecurityContext:
-      fsGroup: 185
     nodeSelector:
       karpenter.sh/capacity-type: "spot"
-      NodeGroupType: "SparkGravitonMemoryOptimized"
-    # Mount S3 Files filesystem via EFS CSI driver
-    volumes:
-      - name: s3-files-volume
-        persistentVolumeClaim:
-          claimName: s3-files-pvc
-    volumeMounts:
-      - name: s3-files-volume
-        mountPath: "/mnt/s3-files"
-        readOnly: false
+      NodeGroupType: "SparkComputeGeneral"
     affinity:
-      # Keep executors in same AZ for better performance
       podAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-s3files.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-s3files.yaml
@@ -1,0 +1,115 @@
+# SparkApplication using Amazon S3 Files
+# S3 Files provides POSIX file system semantics on top of S3 data
+# Built on EFS with intelligent caching for performance
+# Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files.html
+#
+# This job reads/writes data via mounted S3 Files filesystem instead of s3a:// protocol
+# Benefits:
+# - File system semantics (POSIX compliance, file locking)
+# - Intelligent caching (active data in high-performance storage)
+# - Bidirectional sync with S3 bucket
+# - Better for small file operations and metadata-heavy workloads
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "order-s3files"
+  namespace: spark-team-a
+  labels:
+    app: "order-s3files"
+    queue: root.test
+spec:
+  type: Python
+  sparkVersion: "4.0.1"
+  pythonVersion: "3"
+  mode: cluster
+  image: "public.ecr.aws/data-on-eks/spark:4.0.1-scala2.13-java21-python3-r-ubuntu"
+  imagePullPolicy: IfNotPresent
+  mainApplicationFile: "s3a://<S3_BUCKET>/scripts/pyspark-order.py"
+  arguments:
+    # Use file:// protocol to read/write from mounted S3 Files filesystem
+    # S3 Files automatically syncs changes bidirectionally with S3 bucket
+    - "file:///mnt/s3-files/order/input/"
+    - "file:///mnt/s3-files/order/output/s3-files/"
+  sparkConf:
+    # AWS SDK V2 for s3a:// access (still needed for mainApplicationFile and event logs)
+    "spark.hadoop.fs.s3a.aws.credentials.provider": "software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider,software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider"
+    "spark.hadoop.fs.s3.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    "spark.hadoop.fs.s3a.connection.timeout": "1200000"
+    "spark.hadoop.fs.s3a.path.style.access": "true"
+    "spark.hadoop.fs.s3a.connection.maximum": "200"
+    "spark.hadoop.fs.s3a.fast.upload": "true"
+    "spark.hadoop.fs.s3a.readahead.range": "256K"
+    "spark.hadoop.fs.s3a.input.fadvise": "random"
+    # K8s Pod naming
+    "spark.app.name": "order-s3files"
+    "spark.kubernetes.driver.pod.name": "order-s3files-driver"
+    "spark.kubernetes.executor.podNamePrefix": "order-s3files"
+    # Spark Event logs - keep on s3a:// for Spark History Server compatibility
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "s3a://<S3_BUCKET>/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.driver.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.executor.sink.prometheusServlet.path": "/metrics/executors/prometheus/"
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 3
+    onSubmissionFailureRetryInterval: 20
+  driver:
+    annotations:
+      karpenter.sh/do-not-disrupt: "true"
+    cores: 2
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-team-a
+    nodeSelector:
+      karpenter.sh/capacity-type: "on-demand"
+      NodeGroupType: "SparkGravitonMemoryOptimized"
+    # Mount S3 Files filesystem via EFS CSI driver
+    volumes:
+      - name: s3-files-volume
+        persistentVolumeClaim:
+          claimName: s3-files-pvc
+    volumeMounts:
+      - name: s3-files-volume
+        mountPath: "/mnt/s3-files"
+        readOnly: false
+  executor:
+    annotations:
+      karpenter.sh/do-not-disrupt: "true"
+    cores: 2
+    instances: 4
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-team-a
+    podSecurityContext:
+      fsGroup: 185
+    nodeSelector:
+      karpenter.sh/capacity-type: "spot"
+      NodeGroupType: "SparkGravitonMemoryOptimized"
+    # Mount S3 Files filesystem via EFS CSI driver
+    volumes:
+      - name: s3-files-volume
+        persistentVolumeClaim:
+          claimName: s3-files-pvc
+    volumeMounts:
+      - name: s3-files-volume
+        mountPath: "/mnt/s3-files"
+        readOnly: false
+    affinity:
+      # Keep executors in same AZ for better performance
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - order-s3files
+          topologyKey: topology.kubernetes.io/zone

--- a/analytics/terraform/spark-k8s-operator/iam.tf
+++ b/analytics/terraform/spark-k8s-operator/iam.tf
@@ -91,7 +91,7 @@ module "efs_csi_driver_irsa" {
   version          = "5.60.0"
   role_name_prefix = format("%s-%s-", local.name, "efs-csi-driver")
 
-  attach_efs_csi_policy = true
+  attach_efs_csi_policy = false
 
   oidc_providers = {
     main = {
@@ -100,6 +100,30 @@ module "efs_csi_driver_irsa" {
     }
   }
   tags = local.tags
+}
+
+# Inline policy for EFS CSI driver (avoids iam:CreatePolicy permission requirement)
+resource "aws_iam_role_policy" "efs_csi_driver" {
+  name_prefix = "${local.name}-efs-csi-"
+  role        = module.efs_csi_driver_irsa.iam_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticfilesystem:DescribeAccessPoints",
+          "elasticfilesystem:DescribeFileSystems",
+          "elasticfilesystem:DescribeMountTargets",
+          "elasticfilesystem:CreateAccessPoint",
+          "elasticfilesystem:DeleteAccessPoint",
+          "ec2:DescribeAvailabilityZones"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
 }
 
 # Additional S3 Files permissions for EFS CSI driver
@@ -117,9 +141,12 @@ resource "aws_iam_role_policy" "efs_csi_s3files" {
           "s3files:ClientMount",
           "s3files:ClientWrite",
           "s3files:ClientRootAccess",
-          "s3files:DescribeFileSystems",
-          "s3files:DescribeMountTargets",
-          "s3files:DescribeAccessPoints"
+          "s3files:GetFileSystem",
+          "s3files:ListFileSystems",
+          "s3files:GetMountTarget",
+          "s3files:ListMountTargets",
+          "s3files:GetAccessPoint",
+          "s3files:ListAccessPoints"
         ]
         Resource = "*"
       }

--- a/analytics/terraform/spark-k8s-operator/iam.tf
+++ b/analytics/terraform/spark-k8s-operator/iam.tf
@@ -83,6 +83,49 @@ resource "aws_iam_policy" "s3_irsa_access_policy" {
   })
 }
 
+#---------------------------------------------------------------
+# IRSA for EFS CSI Driver
+#---------------------------------------------------------------
+module "efs_csi_driver_irsa" {
+  source           = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version          = "5.60.0"
+  role_name_prefix = format("%s-%s-", local.name, "efs-csi-driver")
+
+  attach_efs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:efs-csi-controller-sa", "kube-system:efs-csi-node-sa"]
+    }
+  }
+  tags = local.tags
+}
+
+# Additional S3 Files permissions for EFS CSI driver
+# TODO: Replace with AmazonS3FilesCSIDriverPolicy managed policy when available
+resource "aws_iam_role_policy" "efs_csi_s3files" {
+  name_prefix = "${local.name}-efs-csi-s3files-"
+  role        = module.efs_csi_driver_irsa.iam_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3files:ClientMount",
+          "s3files:ClientWrite",
+          "s3files:ClientRootAccess",
+          "s3files:DescribeFileSystems",
+          "s3files:DescribeMountTargets",
+          "s3files:DescribeAccessPoints"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
 
 #---------------------------------------------------------------
 # IRSA for Kubecost EC2 access
@@ -193,6 +236,18 @@ data "aws_iam_policy_document" "spark_operator" {
       "logs:DescribeLogGroups",
       "logs:DescribeLogStreams",
       "logs:PutLogEvents",
+    ]
+  }
+
+  statement {
+    sid       = "S3FilesAccess"
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "s3files:ClientMount",
+      "s3files:ClientWrite",
+      "s3files:ClientRootAccess",
     ]
   }
 }

--- a/analytics/terraform/spark-k8s-operator/outputs.tf
+++ b/analytics/terraform/spark-k8s-operator/outputs.tf
@@ -67,6 +67,60 @@ output "s3directory_bucket_zone" {
 }
 
 ################################################################################
+# S3 Files Configuration (CLI-based, provider v5.x workaround)
+################################################################################
+
+output "s3_files_filesystem_id" {
+  description = "S3 Files filesystem ID - use this in PersistentVolume manifests"
+  value       = trimspace(data.local_file.s3_files_fs_id.content)
+}
+
+output "s3_files_access_point_id" {
+  description = "S3 Files Access Point ID for spark-team-a"
+  value       = trimspace(data.local_file.s3_files_ap_id.content)
+}
+
+output "s3_files_mount_target_ip" {
+  description = "S3 Files mount target IP for PV configuration"
+  value       = trimspace(data.local_file.s3_files_mt_ip.content)
+}
+
+################################################################################
+# S3 Files Configuration (native Terraform, requires AWS provider v6.40+)
+# Uncomment when upstream modules support AWS provider v6
+################################################################################
+
+# output "s3_files_filesystem_id" {
+#   description = "S3 Files filesystem ID - use this in PersistentVolume manifests"
+#   value       = aws_s3files_file_system.spark_data.id
+# }
+#
+# output "s3_files_filesystem_arn" {
+#   description = "S3 Files filesystem ARN"
+#   value       = aws_s3files_file_system.spark_data.arn
+# }
+#
+# output "s3_files_access_point_id" {
+#   description = "S3 Files Access Point ID for spark-team-a"
+#   value       = aws_s3files_access_point.spark_team_a.id
+# }
+#
+# output "s3_files_access_point_arn" {
+#   description = "S3 Files Access Point ARN for spark-team-a"
+#   value       = aws_s3files_access_point.spark_team_a.arn
+# }
+#
+# output "s3_files_mount_targets" {
+#   description = "S3 Files mount target IDs by AZ"
+#   value       = { for idx, mt in aws_s3files_mount_target.spark_data : local.azs[idx] => mt.id }
+# }
+#
+# output "s3_files_mount_target_ip" {
+#   description = "S3 Files mount target IP for PV configuration (first AZ)"
+#   value       = aws_s3files_mount_target.spark_data[0].ipv4_address
+# }
+
+################################################################################
 # Ray Data Configuration
 ################################################################################
 

--- a/analytics/terraform/spark-k8s-operator/outputs.tf
+++ b/analytics/terraform/spark-k8s-operator/outputs.tf
@@ -67,58 +67,23 @@ output "s3directory_bucket_zone" {
 }
 
 ################################################################################
-# S3 Files Configuration (CLI-based, provider v5.x workaround)
+# S3 Files Configuration
 ################################################################################
 
 output "s3_files_filesystem_id" {
   description = "S3 Files filesystem ID - use this in PersistentVolume manifests"
-  value       = trimspace(data.local_file.s3_files_fs_id.content)
+  value       = aws_cloudformation_stack.s3_files_fs.outputs["FileSystemId"]
 }
 
 output "s3_files_access_point_id" {
   description = "S3 Files Access Point ID for spark-team-a"
-  value       = trimspace(data.local_file.s3_files_ap_id.content)
+  value       = aws_cloudformation_stack.s3_files_resources.outputs["AccessPointId"]
 }
 
 output "s3_files_mount_target_ip" {
   description = "S3 Files mount target IP for PV configuration"
-  value       = trimspace(data.local_file.s3_files_mt_ip.content)
+  value       = data.external.s3_files_mount_target_ip.result["ip"]
 }
-
-################################################################################
-# S3 Files Configuration (native Terraform, requires AWS provider v6.40+)
-# Uncomment when upstream modules support AWS provider v6
-################################################################################
-
-# output "s3_files_filesystem_id" {
-#   description = "S3 Files filesystem ID - use this in PersistentVolume manifests"
-#   value       = aws_s3files_file_system.spark_data.id
-# }
-#
-# output "s3_files_filesystem_arn" {
-#   description = "S3 Files filesystem ARN"
-#   value       = aws_s3files_file_system.spark_data.arn
-# }
-#
-# output "s3_files_access_point_id" {
-#   description = "S3 Files Access Point ID for spark-team-a"
-#   value       = aws_s3files_access_point.spark_team_a.id
-# }
-#
-# output "s3_files_access_point_arn" {
-#   description = "S3 Files Access Point ARN for spark-team-a"
-#   value       = aws_s3files_access_point.spark_team_a.arn
-# }
-#
-# output "s3_files_mount_targets" {
-#   description = "S3 Files mount target IDs by AZ"
-#   value       = { for idx, mt in aws_s3files_mount_target.spark_data : local.azs[idx] => mt.id }
-# }
-#
-# output "s3_files_mount_target_ip" {
-#   description = "S3 Files mount target IP for PV configuration (first AZ)"
-#   value       = aws_s3files_mount_target.spark_data[0].ipv4_address
-# }
 
 ################################################################################
 # Ray Data Configuration

--- a/analytics/terraform/spark-k8s-operator/s3-bucket.tf
+++ b/analytics/terraform/spark-k8s-operator/s3-bucket.tf
@@ -23,6 +23,10 @@ module "s3_bucket" {
   # For example only - please evaluate for your environment
   force_destroy = true
 
+  versioning = {
+    enabled = true
+  }
+
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {

--- a/analytics/terraform/spark-k8s-operator/s3-files.tf
+++ b/analytics/terraform/spark-k8s-operator/s3-files.tf
@@ -1,0 +1,265 @@
+#---------------------------------------------------------------
+# Amazon S3 Files - File System Interface to S3
+#---------------------------------------------------------------
+# S3 Files provides file system semantics (POSIX, NFS) on top of S3 data
+# Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files.html
+
+#---------------------------------------------------------------
+# IAM Role for S3 Files Filesystem
+#---------------------------------------------------------------
+resource "aws_iam_role" "s3_files" {
+  name_prefix = "${local.name}-s3-files-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticfilesystem.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "s3_files_bucket_access" {
+  name_prefix = "${local.name}-s3-files-bucket-"
+  role        = aws_iam_role.s3_files.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          module.s3_bucket.s3_bucket_arn,
+          "${module.s3_bucket.s3_bucket_arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+#---------------------------------------------------------------
+# Security Group for S3 Files Access
+#---------------------------------------------------------------
+resource "aws_security_group" "s3_files" {
+  name_prefix = "${local.name}-s3-files-"
+  description = "Security group for S3 Files access from EKS nodes"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "NFS from VPC CIDR blocks"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = concat(
+      [module.vpc.vpc_cidr_block],
+      module.vpc.vpc_secondary_cidr_blocks
+    )
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.name}-s3-files-sg"
+    }
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+#---------------------------------------------------------------
+# S3 Files Resources via AWS CLI
+# Workaround: aws_s3files_* resources require AWS provider v6+
+# but upstream modules (EKS, eks-data-addons) are pinned to v5.x
+# TODO: Replace with native Terraform resources when modules support v6
+#---------------------------------------------------------------
+locals {
+  s3_files_output_dir = "${path.module}/.s3files"
+}
+
+resource "null_resource" "s3_files_create" {
+  depends_on = [
+    aws_iam_role.s3_files,
+    aws_iam_role_policy.s3_files_bucket_access,
+    aws_security_group.s3_files,
+    module.vpc
+  ]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      mkdir -p ${local.s3_files_output_dir}
+
+      echo "=== Creating S3 Files filesystem ==="
+      FS_ID=$(aws s3files create-file-system \
+        --bucket "${module.s3_bucket.s3_bucket_arn}" \
+        --role-arn "${aws_iam_role.s3_files.arn}" \
+        --region "${local.region}" \
+        --query 'Id' --output text)
+      echo -n $FS_ID > ${local.s3_files_output_dir}/fs_id.txt
+      echo "Created filesystem: $FS_ID"
+
+      echo "=== Waiting for filesystem to become available ==="
+      for i in $(seq 1 30); do
+        STATUS=$(aws s3files describe-file-system --file-system-id $FS_ID --region "${local.region}" --query 'Status' --output text 2>/dev/null || echo "CREATING")
+        echo "  Status: $STATUS"
+        if [ "$STATUS" = "AVAILABLE" ]; then break; fi
+        sleep 10
+      done
+
+      echo "=== Creating mount target ==="
+      MT_RESULT=$(aws s3files create-mount-target \
+        --file-system-id "$FS_ID" \
+        --subnet-id "${module.vpc.private_subnets[0]}" \
+        --security-groups "${aws_security_group.s3_files.id}" \
+        --region "${local.region}" \
+        --output json)
+      MT_ID=$(echo $MT_RESULT | python3 -c "import sys,json; print(json.load(sys.stdin)['Id'])")
+      MT_IP=$(echo $MT_RESULT | python3 -c "import sys,json; print(json.load(sys.stdin).get('Ipv4Address',''))")
+      echo -n $MT_ID > ${local.s3_files_output_dir}/mt_id.txt
+      echo -n $MT_IP > ${local.s3_files_output_dir}/mt_ip.txt
+      echo "Created mount target: $MT_ID ($MT_IP)"
+
+      echo "=== Waiting for mount target to become available ==="
+      for i in $(seq 1 30); do
+        STATUS=$(aws s3files describe-mount-targets --file-system-id $FS_ID --region "${local.region}" --query 'MountTargets[0].Status' --output text 2>/dev/null || echo "CREATING")
+        echo "  Status: $STATUS"
+        if [ "$STATUS" = "AVAILABLE" ]; then break; fi
+        sleep 10
+      done
+
+      echo "=== Creating access point ==="
+      AP_ID=$(aws s3files create-access-point \
+        --file-system-id "$FS_ID" \
+        --posix-user "Uid=185,Gid=185" \
+        --region "${local.region}" \
+        --query 'Id' --output text)
+      echo -n $AP_ID > ${local.s3_files_output_dir}/ap_id.txt
+      echo "Created access point: $AP_ID"
+
+      echo "=== S3 Files setup complete ==="
+      echo "Filesystem ID: $FS_ID"
+      echo "Mount Target ID: $MT_ID"
+      echo "Mount Target IP: $MT_IP"
+      echo "Access Point ID: $AP_ID"
+    EOT
+  }
+}
+
+data "local_file" "s3_files_fs_id" {
+  filename   = "${local.s3_files_output_dir}/fs_id.txt"
+  depends_on = [null_resource.s3_files_create]
+}
+
+data "local_file" "s3_files_mt_ip" {
+  filename   = "${local.s3_files_output_dir}/mt_ip.txt"
+  depends_on = [null_resource.s3_files_create]
+}
+
+data "local_file" "s3_files_ap_id" {
+  filename   = "${local.s3_files_output_dir}/ap_id.txt"
+  depends_on = [null_resource.s3_files_create]
+}
+
+data "local_file" "s3_files_mt_id" {
+  filename   = "${local.s3_files_output_dir}/mt_id.txt"
+  depends_on = [null_resource.s3_files_create]
+}
+
+#---------------------------------------------------------------
+# Native Terraform resources (requires AWS provider v6.40+)
+# Uncomment when upstream modules support AWS provider v6
+#---------------------------------------------------------------
+# resource "aws_s3files_file_system" "spark_data" {
+#   bucket   = module.s3_bucket.s3_bucket_arn
+#   role_arn = aws_iam_role.s3_files.arn
+#
+#   tags = merge(
+#     local.tags,
+#     {
+#       Name        = "${local.name}-s3-files"
+#       Description = "S3 Files filesystem for Spark data access"
+#       Purpose     = "SparkOnEKS"
+#     }
+#   )
+# }
+#
+# resource "aws_s3files_mount_target" "spark_data" {
+#   count = length(local.azs)
+#
+#   file_system_id  = aws_s3files_file_system.spark_data.id
+#   subnet_id       = module.vpc.private_subnets[count.index]
+#   security_groups = [aws_security_group.s3_files.id]
+# }
+#
+# resource "aws_s3files_file_system_policy" "spark_data" {
+#   file_system_id = aws_s3files_file_system.spark_data.id
+#
+#   policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [
+#       {
+#         Effect = "Allow"
+#         Principal = {
+#           AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+#         }
+#         Action   = "s3files:ClientMount"
+#         Resource = "*"
+#       }
+#     ]
+#   })
+# }
+#
+# resource "aws_s3files_synchronization_configuration" "spark_data" {
+#   file_system_id = aws_s3files_file_system.spark_data.id
+#
+#   import_data_rule {
+#     prefix         = "order/"
+#     size_less_than = 52673613135872
+#     trigger        = "ON_FILE_ACCESS"
+#   }
+#
+#   expiration_data_rule {
+#     days_after_last_access = 30
+#   }
+# }
+#
+# resource "aws_s3files_access_point" "spark_team_a" {
+#   file_system_id = aws_s3files_file_system.spark_data.id
+#
+#   posix_user {
+#     gid = 185
+#     uid = 185
+#   }
+#
+#   tags = merge(
+#     local.tags,
+#     {
+#       Name = "${local.name}-spark-team-a-ap"
+#       Team = "spark-team-a"
+#     }
+#   )
+# }

--- a/analytics/terraform/spark-k8s-operator/s3-files.tf
+++ b/analytics/terraform/spark-k8s-operator/s3-files.tf
@@ -1,8 +1,7 @@
 #---------------------------------------------------------------
 # Amazon S3 Files - File System Interface to S3
+# Uses CloudFormation to avoid null_resource/CLI workarounds
 #---------------------------------------------------------------
-# S3 Files provides file system semantics (POSIX, NFS) on top of S3 data
-# Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files.html
 
 #---------------------------------------------------------------
 # IAM Role for S3 Files Filesystem
@@ -39,8 +38,12 @@ resource "aws_iam_role_policy" "s3_files_bucket_access" {
           "s3:GetObject",
           "s3:PutObject",
           "s3:DeleteObject",
+          "s3:HeadObject",
           "s3:ListBucket",
-          "s3:GetBucketLocation"
+          "s3:GetBucketLocation",
+          "s3:GetBucketVersioning",
+          "s3:GetObjectVersion",
+          "s3:ListBucketVersions"
         ]
         Resource = [
           module.s3_bucket.s3_bucket_arn,
@@ -78,12 +81,7 @@ resource "aws_security_group" "s3_files" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(
-    local.tags,
-    {
-      Name = "${local.name}-s3-files-sg"
-    }
-  )
+  tags = merge(local.tags, { Name = "${local.name}-s3-files-sg" })
 
   lifecycle {
     create_before_destroy = true
@@ -91,175 +89,131 @@ resource "aws_security_group" "s3_files" {
 }
 
 #---------------------------------------------------------------
-# S3 Files Resources via AWS CLI
-# Workaround: aws_s3files_* resources require AWS provider v6+
-# but upstream modules (EKS, eks-data-addons) are pinned to v5.x
-# TODO: Replace with native Terraform resources when modules support v6
+# Step 1: CloudFormation stack for S3 Files FileSystem only
+# CFN waits for the filesystem to reach AVAILABLE before completing
 #---------------------------------------------------------------
-locals {
-  s3_files_output_dir = "${path.module}/.s3files"
-}
+resource "aws_cloudformation_stack" "s3_files_fs" {
+  name = "${local.name}-s3-files-fs"
 
-resource "null_resource" "s3_files_create" {
+  template_body = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+    Description              = "S3 Files filesystem for Spark on EKS"
+
+    Resources = {
+      FileSystem = {
+        Type = "AWS::S3Files::FileSystem"
+        Properties = {
+          Bucket  = module.s3_bucket.s3_bucket_arn
+          RoleArn = aws_iam_role.s3_files.arn
+          Tags = [
+            { Key = "Name", Value = "${local.name}-s3-files" },
+            { Key = "Blueprint", Value = local.name }
+          ]
+        }
+      }
+    }
+
+    Outputs = {
+      FileSystemId = {
+        Value = { "Fn::GetAtt" = ["FileSystem", "FileSystemId"] }
+      }
+    }
+  })
+
   depends_on = [
-    aws_iam_role.s3_files,
     aws_iam_role_policy.s3_files_bucket_access,
-    aws_security_group.s3_files,
-    module.vpc
+    module.s3_bucket
   ]
 
-  provisioner "local-exec" {
-    command = <<-EOT
-      set -e
-      mkdir -p ${local.s3_files_output_dir}
-
-      echo "=== Creating S3 Files filesystem ==="
-      FS_ID=$(aws s3files create-file-system \
-        --bucket "${module.s3_bucket.s3_bucket_arn}" \
-        --role-arn "${aws_iam_role.s3_files.arn}" \
-        --region "${local.region}" \
-        --query 'Id' --output text)
-      echo -n $FS_ID > ${local.s3_files_output_dir}/fs_id.txt
-      echo "Created filesystem: $FS_ID"
-
-      echo "=== Waiting for filesystem to become available ==="
-      for i in $(seq 1 30); do
-        STATUS=$(aws s3files describe-file-system --file-system-id $FS_ID --region "${local.region}" --query 'Status' --output text 2>/dev/null || echo "CREATING")
-        echo "  Status: $STATUS"
-        if [ "$STATUS" = "AVAILABLE" ]; then break; fi
-        sleep 10
-      done
-
-      echo "=== Creating mount target ==="
-      MT_RESULT=$(aws s3files create-mount-target \
-        --file-system-id "$FS_ID" \
-        --subnet-id "${module.vpc.private_subnets[0]}" \
-        --security-groups "${aws_security_group.s3_files.id}" \
-        --region "${local.region}" \
-        --output json)
-      MT_ID=$(echo $MT_RESULT | python3 -c "import sys,json; print(json.load(sys.stdin)['Id'])")
-      MT_IP=$(echo $MT_RESULT | python3 -c "import sys,json; print(json.load(sys.stdin).get('Ipv4Address',''))")
-      echo -n $MT_ID > ${local.s3_files_output_dir}/mt_id.txt
-      echo -n $MT_IP > ${local.s3_files_output_dir}/mt_ip.txt
-      echo "Created mount target: $MT_ID ($MT_IP)"
-
-      echo "=== Waiting for mount target to become available ==="
-      for i in $(seq 1 30); do
-        STATUS=$(aws s3files describe-mount-targets --file-system-id $FS_ID --region "${local.region}" --query 'MountTargets[0].Status' --output text 2>/dev/null || echo "CREATING")
-        echo "  Status: $STATUS"
-        if [ "$STATUS" = "AVAILABLE" ]; then break; fi
-        sleep 10
-      done
-
-      echo "=== Creating access point ==="
-      AP_ID=$(aws s3files create-access-point \
-        --file-system-id "$FS_ID" \
-        --posix-user "Uid=185,Gid=185" \
-        --region "${local.region}" \
-        --query 'Id' --output text)
-      echo -n $AP_ID > ${local.s3_files_output_dir}/ap_id.txt
-      echo "Created access point: $AP_ID"
-
-      echo "=== S3 Files setup complete ==="
-      echo "Filesystem ID: $FS_ID"
-      echo "Mount Target ID: $MT_ID"
-      echo "Mount Target IP: $MT_IP"
-      echo "Access Point ID: $AP_ID"
-    EOT
-  }
-}
-
-data "local_file" "s3_files_fs_id" {
-  filename   = "${local.s3_files_output_dir}/fs_id.txt"
-  depends_on = [null_resource.s3_files_create]
-}
-
-data "local_file" "s3_files_mt_ip" {
-  filename   = "${local.s3_files_output_dir}/mt_ip.txt"
-  depends_on = [null_resource.s3_files_create]
-}
-
-data "local_file" "s3_files_ap_id" {
-  filename   = "${local.s3_files_output_dir}/ap_id.txt"
-  depends_on = [null_resource.s3_files_create]
-}
-
-data "local_file" "s3_files_mt_id" {
-  filename   = "${local.s3_files_output_dir}/mt_id.txt"
-  depends_on = [null_resource.s3_files_create]
+  tags = local.tags
 }
 
 #---------------------------------------------------------------
-# Native Terraform resources (requires AWS provider v6.40+)
-# Uncomment when upstream modules support AWS provider v6
+# Step 2: CloudFormation stack for MountTarget + AccessPoint
+# Only created after filesystem stack completes (filesystem is AVAILABLE)
 #---------------------------------------------------------------
-# resource "aws_s3files_file_system" "spark_data" {
-#   bucket   = module.s3_bucket.s3_bucket_arn
-#   role_arn = aws_iam_role.s3_files.arn
-#
-#   tags = merge(
-#     local.tags,
-#     {
-#       Name        = "${local.name}-s3-files"
-#       Description = "S3 Files filesystem for Spark data access"
-#       Purpose     = "SparkOnEKS"
-#     }
-#   )
-# }
-#
-# resource "aws_s3files_mount_target" "spark_data" {
-#   count = length(local.azs)
-#
-#   file_system_id  = aws_s3files_file_system.spark_data.id
-#   subnet_id       = module.vpc.private_subnets[count.index]
-#   security_groups = [aws_security_group.s3_files.id]
-# }
-#
-# resource "aws_s3files_file_system_policy" "spark_data" {
-#   file_system_id = aws_s3files_file_system.spark_data.id
-#
-#   policy = jsonencode({
-#     Version = "2012-10-17"
-#     Statement = [
-#       {
-#         Effect = "Allow"
-#         Principal = {
-#           AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
-#         }
-#         Action   = "s3files:ClientMount"
-#         Resource = "*"
-#       }
-#     ]
-#   })
-# }
-#
-# resource "aws_s3files_synchronization_configuration" "spark_data" {
-#   file_system_id = aws_s3files_file_system.spark_data.id
-#
-#   import_data_rule {
-#     prefix         = "order/"
-#     size_less_than = 52673613135872
-#     trigger        = "ON_FILE_ACCESS"
-#   }
-#
-#   expiration_data_rule {
-#     days_after_last_access = 30
-#   }
-# }
-#
-# resource "aws_s3files_access_point" "spark_team_a" {
-#   file_system_id = aws_s3files_file_system.spark_data.id
-#
-#   posix_user {
-#     gid = 185
-#     uid = 185
-#   }
-#
-#   tags = merge(
-#     local.tags,
-#     {
-#       Name = "${local.name}-spark-team-a-ap"
-#       Team = "spark-team-a"
-#     }
-#   )
-# }
+resource "aws_cloudformation_stack" "s3_files_resources" {
+  name = "${local.name}-s3-files-resources"
+
+  template_body = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+    Description              = "S3 Files mount target, access point, and filesystem policy for Spark on EKS"
+
+    Resources = {
+      FileSystemPolicy = {
+        Type = "AWS::S3Files::FileSystemPolicy"
+        Properties = {
+          FileSystemId = aws_cloudformation_stack.s3_files_fs.outputs["FileSystemId"]
+          Policy = {
+            Version = "2012-10-17"
+            Statement = [
+              {
+                Effect    = "Allow"
+                Principal = { AWS = "*" }
+                Action = [
+                  "s3files:ClientMount",
+                  "s3files:ClientWrite",
+                  "s3files:ClientRootAccess"
+                ]
+                Resource = "*"
+              }
+            ]
+          }
+        }
+      }
+
+      MountTarget = {
+        Type = "AWS::S3Files::MountTarget"
+        Properties = {
+          FileSystemId   = aws_cloudformation_stack.s3_files_fs.outputs["FileSystemId"]
+          SubnetId       = module.vpc.private_subnets[0]
+          SecurityGroups = [aws_security_group.s3_files.id]
+        }
+      }
+
+      AccessPoint = {
+        Type      = "AWS::S3Files::AccessPoint"
+        DependsOn = "FileSystemPolicy"
+        Properties = {
+          FileSystemId = aws_cloudformation_stack.s3_files_fs.outputs["FileSystemId"]
+          PosixUser = {
+            Uid = "0"
+            Gid = "0"
+          }
+          Tags = [
+            { Key = "Name", Value = "${local.name}-spark-team-a-ap" },
+            { Key = "Team", Value = "spark-team-a" }
+          ]
+        }
+      }
+    }
+
+    Outputs = {
+      MountTargetId = {
+        Value = { "Fn::GetAtt" = ["MountTarget", "MountTargetId"] }
+      }
+      AccessPointId = {
+        Value = { "Fn::GetAtt" = ["AccessPoint", "AccessPointId"] }
+      }
+    }
+  })
+
+  depends_on = [aws_cloudformation_stack.s3_files_fs]
+
+  tags = local.tags
+}
+
+#---------------------------------------------------------------
+# Look up mount target IP after creation
+# (Ipv4Address is not a CFN GetAtt attribute for MountTarget)
+#---------------------------------------------------------------
+data "external" "s3_files_mount_target_ip" {
+  program = ["bash", "-c", <<-EOT
+    MT_ID="${aws_cloudformation_stack.s3_files_resources.outputs["MountTargetId"]}"
+    IP=$(aws s3files get-mount-target --mount-target-id "$MT_ID" --region "${local.region}" --query 'ipv4Address' --output text)
+    echo "{\"ip\": \"$IP\"}"
+  EOT
+  ]
+
+  depends_on = [aws_cloudformation_stack.s3_files_resources]
+}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Adds Amazon S3 Files integration for the Spark on EKS workshop, enabling Spark to read and write S3 data via a POSIX-compliant NFS mount instead of the s3a:// protocol. S3 Files provides sub-millisecond latency for cached data and automatic bidirectional synchronization with S3.

Changes:
- `s3-files.tf` — CloudFormation-based provisioning of S3 Files filesystem, mount target, access point, and file system policy (Terraform required major version upgrades that can cause breaking changes across this repo)
- `s3-bucket.tf` — Enabled S3 bucket versioning (required by S3 Files)
- `addons.tf` — Added EFS CSI driver addon
- `iam.tf` — EFS CSI driver IRSA with inline policy, S3 Files IAM actions for Spark operator and EFS CSI driver
- `outputs.tf` — Added filesystem ID, access point ID, mount target IP outputs
- `examples/karpenter/s3-files-sc.yaml` — StorageClass for S3 Files
- `examples/karpenter/s3-files-pv.yaml` — PersistentVolume with S3 Files volumeHandle
- `examples/karpenter/s3-files-pvc.yaml` — PersistentVolumeClaim (ReadWriteMany)
- `examples/karpenter/spark-app-s3files.yaml` — SparkApplication using file:// paths via NFS mount

Key design decisions:
- Uses CloudFormation instead of null_resource/CLI for S3 Files provisioning (proper lifecycle management, no shell script fragility)
- Two CFN stacks: filesystem first (waits for AVAILABLE), then mount target + access point
- Access point uses PosixUser uid=0/gid=0 (S3 Files exposes existing S3 objects as root-owned, this maps NFS clients to root for write access)
- File system policy grants ClientMount, ClientWrite, ClientRootAccess
- EFS CSI IRSA uses inline policy to avoid iam:CreatePolicy permission requirement in workshop environments

### Motivation

S3 Files is a new AWS capability that provides file system semantics on top of S3. This lab demonstrates an alternative data access pattern for Spark — reading/writing via NFS mount instead of s3a:// — which benefits workloads with repeated reads, metadata-heavy operations, and POSIX requirements.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested on a Workshop Studio event. Spark job reads 28M records from S3 Files mount and writes ~3GB parquet output. S3 Files auto-exports written data to S3 within ~60 seconds. 

Workshop IDE role requires additional permissions which will be taken care of outside this repo.
