### PR TITLE
feat: Add Apache Celeborn remote shuffle service for Spark on EKS workshop

### DIFF
--- a/analytics/terraform/spark-k8s-operator/celeborn.tf
+++ b/analytics/terraform/spark-k8s-operator/celeborn.tf
@@ -1,0 +1,20 @@
+#---------------------------------------------------------------
+# Apache Celeborn - Remote Shuffle Service for Spark
+#---------------------------------------------------------------
+# Celeborn offloads shuffle data from Spark executors to a dedicated
+# shuffle service, improving stability and performance for shuffle-heavy workloads.
+# Reference: https://celeborn.apache.org/
+
+resource "helm_release" "celeborn" {
+  count = var.enable_celeborn ? 1 : 0
+
+  name             = "celeborn"
+  namespace        = "celeborn"
+  create_namespace = true
+  chart            = "${path.module}/helm-charts/celeborn"
+  timeout          = 600
+
+  values = [templatefile("${path.module}/helm-values/celeborn-values.yaml", {})]
+
+  depends_on = [module.eks, kubectl_manifest.auto_mode_nodepools]
+}

--- a/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-celeborn.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/karpenter/spark-app-celeborn.yaml
@@ -1,0 +1,104 @@
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "order-celeborn"
+  namespace: spark-team-a
+  labels:
+    app: "order-celeborn"
+    queue: root.test
+spec:
+  type: Python
+  sparkVersion: "4.0.1"
+  pythonVersion: "3"
+  mode: cluster
+  image: "public.ecr.aws/data-on-eks/spark:4.0.1-scala2.13-java21-python3-r-ubuntu"
+  imagePullPolicy: IfNotPresent
+  mainApplicationFile: "s3a://<S3_BUCKET>/scripts/pyspark-order.py"
+  arguments:
+    - "s3a://<S3_BUCKET>/order/input/"
+    - "s3a://<S3_BUCKET>/order/output/celeborn/"
+  deps:
+    jars:
+      - "https://repo1.maven.org/maven2/org/apache/celeborn/celeborn-client-spark-4-shaded_2.13/0.6.0/celeborn-client-spark-4-shaded_2.13-0.6.0.jar"
+  sparkConf:
+    # AWS SDK V2
+    "spark.hadoop.fs.s3a.aws.credentials.provider": "software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider,software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider"
+    "spark.hadoop.fs.s3.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    "spark.hadoop.fs.s3a.connection.timeout": "1200000"
+    "spark.hadoop.fs.s3a.path.style.access": "true"
+    "spark.hadoop.fs.s3a.connection.maximum": "200"
+    "spark.hadoop.fs.s3a.fast.upload": "true"
+    "spark.hadoop.fs.s3a.readahead.range": "256K"
+    "spark.hadoop.fs.s3a.input.fadvise": "random"
+    # K8s Pod naming
+    "spark.app.name": "order-celeborn"
+    "spark.kubernetes.driver.pod.name": "order-celeborn-driver"
+    "spark.kubernetes.executor.podNamePrefix": "order-celeborn"
+    # Celeborn Remote Shuffle Service
+    "spark.shuffle.manager": "org.apache.spark.shuffle.celeborn.SparkShuffleManager"
+    "spark.serializer": "org.apache.spark.serializer.KryoSerializer"
+    "spark.shuffle.service.enabled": "false"
+    "spark.celeborn.master.endpoints": "celeborn-master-0.celeborn-master-svc.celeborn.svc.cluster.local:9097"
+    "spark.celeborn.client.push.replicate.enabled": "true"
+    "spark.celeborn.client.spark.shuffle.writer": "sort"
+    "spark.celeborn.client.shuffle.batchHandleCommitPartition.enabled": "true"
+    "spark.celeborn.client.fetch.maxRetriesForEachReplica": "5"
+    "spark.celeborn.data.io.retryWait": "15s"
+    "spark.celeborn.client.rpc.maxRetries": "5"
+    # Adaptive Query Execution
+    "spark.sql.adaptive.enabled": "true"
+    "spark.sql.adaptive.coalescePartitions.enabled": "true"
+    "spark.sql.adaptive.localShuffleReader.enabled": "false"
+    "spark.sql.shuffle.partitions": "200"
+    # Timeouts
+    "spark.network.timeout": "2000s"
+    "spark.executor.heartbeatInterval": "300s"
+    "spark.rpc.askTimeout": "600s"
+    # Spark Event logs
+    "spark.eventLog.enabled": "true"
+    "spark.eventLog.dir": "s3a://<S3_BUCKET>/spark-event-logs"
+    "spark.eventLog.rolling.enabled": "true"
+    "spark.eventLog.rolling.maxFileSize": "64m"
+    # Expose Spark metrics for Prometheus
+    "spark.ui.prometheus.enabled": "true"
+    "spark.executor.processTreeMetrics.enabled": "true"
+    "spark.metrics.conf.*.sink.prometheusServlet.class": "org.apache.spark.metrics.sink.PrometheusServlet"
+    "spark.metrics.conf.driver.sink.prometheusServlet.path": "/metrics/driver/prometheus/"
+    "spark.metrics.conf.executor.sink.prometheusServlet.path": "/metrics/executors/prometheus/"
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 3
+    onSubmissionFailureRetryInterval: 20
+  driver:
+    annotations:
+      karpenter.sh/do-not-disrupt: "true"
+    cores: 2
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-team-a
+    nodeSelector:
+      karpenter.sh/capacity-type: "on-demand"
+      NodeGroupType: "SparkComputeGeneral"
+  executor:
+    annotations:
+      karpenter.sh/do-not-disrupt: "true"
+    cores: 2
+    instances: 4
+    memory: "4g"
+    memoryOverhead: "2g"
+    serviceAccount: spark-team-a
+    nodeSelector:
+      karpenter.sh/capacity-type: "spot"
+      NodeGroupType: "SparkComputeGeneral"
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - order-celeborn
+          topologyKey: topology.kubernetes.io/zone

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/.helmignore
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/.helmignore
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+
+ci/
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# MacOS
+.DS_Store
+
+# helm-unittest
+./tests
+.debug
+__snapshot__
+
+# helm-docs
+README.md.gotmpl

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/Chart.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/Chart.yaml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v2
+name: celeborn
+description: >
+  [Apache Celeborn](https://celeborn.apache.org) is an intermediate data service for Big Data compute engines (i.e. ETL, OLAP and Streaming engines) to boost performance, stability, and flexibility.
+  Intermediate data typically include shuffle and spilled data.
+type: application
+version: 0.1.0
+appVersion: 0.7.0
+keywords:
+  - Apache Celeborn
+  - Big Data
+  - Shuffle
+home: https://github.com/apache/celeborn

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/README.md
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/README.md
@@ -1,0 +1,59 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Helm Chart for Apache Celeborn
+
+[Apache Celeborn](https://celeborn.apache.org) is an intermediate data service for Big Data compute engines (i.e. ETL, OLAP and Streaming engines) to boost performance, stability, and flexibility. Intermediate data typically include shuffle and spilled data.
+
+## Introduction
+
+This chart will bootstrap an [Celeborn](https://celeborn.apache.org) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Requirements
+
+Configure kubectl to connect to the Kubernetes cluster.
+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
+- [Helm 3.0+](https://helm.sh/docs/using_helm/#installing-helm)
+
+## Template rendering
+
+When you want to test the template rendering, but not actually install anything. [Debugging templates](https://helm.sh/docs/chart_template_guide/debugging/) provide a quick way of viewing the generated content without YAML parse errors blocking.
+
+There are two ways to render templates. It will return the rendered template to you so you can see the output.
+
+- Local rendering chart templates
+
+```shell
+helm template --debug ../celeborn
+```
+
+- Server side rendering chart templates
+
+```shell
+helm install --dry-run --debug --generate-name ../celeborn
+```
+
+More details in [Helm Install](https://helm.sh/docs/helm/helm_install/).
+The chart can be customized using the following [celeborn configurations](https://celeborn.apache.org/docs/latest/configuration/#important-configurations).
+Specify parameters using `--set key=value[,key=value]` argument to `helm install`.
+
+## Documentation
+
+For additional details on deploying the Celeborn Kubernetes Helm chart, please refer to the [Celeborn on Kubernetes](https://celeborn.apache.org/docs/latest/deploy_on_k8s/) documentation.

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/ci/values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/ci/values.yaml
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default values for celeborn.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Specifies the Celeborn image to use
+image:
+  # -- Image repository
+  repository: apache/celeborn
+  # -- Image tag
+  tag: latest
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+celeborn:
+  celeborn.metrics.enabled: false
+  celeborn.worker.storage.dirs: /mnt/disk1:disktype=SSD:capacity=1Gi,/mnt/disk2:disktype=SSD:capacity=1Gi
+
+master:
+  # -- Number of Celeborn master replicas to deploy, should not less than 3.
+  replicas: 1
+
+  # -- Environment variables for Celeborn master containers.
+  env:
+  - name: CELEBORN_MASTER_MEMORY
+    value: 100m
+  - name: CELEBORN_MASTER_JAVA_OPTS
+    value: -XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-master.out -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "true"
+  - name: TZ
+    value: Asia/Shanghai
+
+  # -- Volume mounts for Celeborn master containers.
+  volumeMounts:
+  - name: celeborn-ratis
+    mountPath: /mnt/celeborn_ratis
+
+  # -- Resources for Celeborn master containers.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 800Mi
+    limits:
+      cpu: 100m
+      memory: 800Mi
+
+  # -- Volumes for Celeborn master pods.
+  volumes:
+  - name: celeborn-ratis
+    emptyDir:
+      sizeLimit: 1Gi
+
+  # -- DNS policy for Celeborn master pods.
+  dnsPolicy: ClusterFirstWithHostNet
+
+  # -- Whether to use the host's network namespace in Celeborn master pods.
+  hostNetwork: true
+
+worker:
+  # -- Number of Celeborn worker replicas to deploy, should less than node number.
+  replicas: 1
+
+  # -- Environment variables for Celeborn worker containers.
+  env:
+  - name: CELEBORN_WORKER_MEMORY
+    value: 100m
+  - name: CELEBORN_WORKER_OFFHEAP_MEMORY
+    value: 100m
+  - name: CELEBORN_WORKER_JAVA_OPTS
+    value: -XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "true"
+  - name: TZ
+    value: Asia/Shanghai
+
+  # -- Volume mounts for Celeborn worker containers.
+  volumeMounts:
+  - name: disk1
+    mountPath: /mnt/disk1
+  - name: disk2
+    mountPath: /mnt/disk2
+
+  # -- Resources for Celeborn worker containers.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1Gi
+    limits:
+      cpu: 100m
+      memory: 1Gi
+
+  # --Volumes for Celeborn worker pods.
+  volumes:
+  - name: disk1
+    emptyDir:
+      sizeLimit: 1Gi
+  - name: disk2
+    emptyDir:
+      sizeLimit: 1Gi
+
+  # -- DNS policy for Celeborn worker pods.
+  dnsPolicy: ClusterFirstWithHostNet
+
+  # -- Whether to use the host's network namespace in Celeborn worker pods.
+  hostNetwork: true
+
+podMonitor:
+  # -- Specifies whether to enable creating pod monitors for Celeborn pods
+  enable: false
+
+serviceAccount:
+  # -- Specifies whether to create a service account for Celeborn
+  create: false
+
+rbac:
+  create: false

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/files/conf/log4j2.xml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/files/conf/log4j2.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  ~ Extra logging related to initialization of Log4j.
+  ~ Set to debug or trace if log4j initialization is failing.
+  -->
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="stdout" target="SYSTEM_OUT">
+            <!--
+              ~ In the pattern layout configuration below, we specify an explicit `%ex` conversion
+              ~ pattern for logging Throwables. If this was omitted, then (by default) Log4J would
+              ~ implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
+              ~ class packaging information. That extra information can sometimes add a substantial
+              ~ performance overhead, so we disable it in our default logging config.
+              -->
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+        </Console>
+        <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log"
+                                 filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d-%i">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="7">
+                <Delete basePath="${env:CELEBORN_LOG_DIR}" maxDepth="1">
+                    <IfFileName glob="celeborn.log*">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="1 GB"/>
+                            <IfAccumulatedFileCount exceeds="10"/>
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
+        <RollingRandomAccessFile name="restAuditFile" fileName="${env:CELEBORN_LOG_DIR}/audit/rest-audit.log"
+                                 filePattern="${env:CELEBORN_LOG_DIR}/audit/rest-audit.log.%d-%i">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="7">
+                <Delete basePath="${env:CELEBORN_LOG_DIR}/audit" maxDepth="1">
+                    <IfFileName glob="rest-audit.log*">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="1 GB"/>
+                            <IfAccumulatedFileCount exceeds="10"/>
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
+        <RollingRandomAccessFile name="shuffleAuditFile" fileName="${env:CELEBORN_LOG_DIR}/audit/shuffle-audit.log"
+                                 filePattern="${env:CELEBORN_LOG_DIR}/audit/shuffle-audit.log.%d-%i">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="7">
+                <Delete basePath="${env:CELEBORN_LOG_DIR}/audit" maxDepth="1">
+                    <IfFileName glob="shuffle-audit.log*">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="1 GB"/>
+                            <IfAccumulatedFileCount exceeds="10"/>
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
+        <RollingRandomAccessFile name="metricsAuditFile" fileName="${env:CELEBORN_LOG_DIR}/audit/metrics-audit.log"
+                                 filePattern="${env:CELEBORN_LOG_DIR}/audit/metrics-audit.log.%d-%i">
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="7">
+                <Delete basePath="${env:CELEBORN_LOG_DIR}/audit" maxDepth="1">
+                    <IfFileName glob="metrics-audit.log*">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="1 GB"/>
+                            <IfAccumulatedFileCount exceeds="10"/>
+                        </IfAny>
+                    </IfFileName>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingRandomAccessFile>
+    </Appenders>
+
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="file"/>
+        </Root>
+        <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
+            <Appender-ref ref="stdout" level="WARN"/>
+            <Appender-ref ref="file" level="WARN"/>
+        </Logger>
+        <Logger name="org.apache.ratis.server.RaftServerConfigKeys" level="WARN" additivity="false">
+            <Appender-ref ref="stdout" level="WARN"/>
+            <Appender-ref ref="file" level="WARN"/>
+        </Logger>
+        <Logger name="org.apache.celeborn.server.common.http.RestAuditLogger" level="INFO" additivity="false">
+            <Appender-ref ref="restAuditFile" level="INFO"/>
+        </Logger>
+        <Logger name="org.apache.celeborn.service.deploy.master.audit.ShuffleAuditLogger" level="INFO"
+                additivity="false">
+            <Appender-ref ref="shuffleAuditFile" level="INFO"/>
+        </Logger>
+        <Logger name="org.apache.celeborn.common.metrics.sink.LoggerSink" level="INFO" additivity="false">
+            <Appender-ref ref="metricsAuditFile" level="INFO"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/files/conf/metrics.properties
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/files/conf/metrics.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+*.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
+*.sink.jsonServlet.class=org.apache.celeborn.common.metrics.sink.JsonServlet
+*.sink.loggerSink.class=org.apache.celeborn.common.metrics.sink.LoggerSink

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/files/conf/ratis-log4j.properties
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/files/conf/ratis-log4j.properties
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These properties may be overridden by system properties. log4j gives system properties
+# a higher precedence than locally defined variables.
+log4j.rootLogger=INFO, SHELL_LOGGER
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M) - %m%n
+
+# SHELL Logger
+log4j.appender.SHELL_LOGGER=org.apache.log4j.RollingFileAppender
+log4j.appender.SHELL_LOGGER.File=${ratis.shell.logs.dir}/celeborn-ratis-shell.log
+log4j.appender.SHELL_LOGGER.MaxFileSize=100MB
+log4j.appender.SHELL_LOGGER.MaxBackupIndex=10
+log4j.appender.SHELL_LOGGER.layout=org.apache.log4j.PatternLayout
+log4j.appender.SHELL_LOGGER.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M) - %m%n

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/NOTES.txt
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/NOTES.txt
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Celeborn

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/_helpers.tpl
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/_helpers.tpl
@@ -1,0 +1,117 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "celeborn.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "celeborn.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "celeborn.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "celeborn.labels" -}}
+helm.sh/chart: {{ include "celeborn.chart" . }}
+{{ include "celeborn.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "celeborn.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "celeborn.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Create the name of the service account to use. */}}
+{{- define "celeborn.serviceAccount.name" -}}
+{{- if .Values.serviceAccount.create }}
+{{- .Values.serviceAccount.name | default (include "celeborn.fullname" .) }}
+{{- else }}
+{{- .Values.serviceAccount.name | default "default" }}
+{{- end }}
+{{- end }}
+
+{{/* Create the name of the role to use. */}}
+{{- define "celeborn.role.name" -}}
+{{- if .Values.rbac.create }}
+{{- .Values.rbac.roleName | default (include "celeborn.fullname" .) }}
+{{- else }}
+{{- .Values.rbac.roleName | default "default" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the roleBinding to use
+*/}}
+{{- define "celeborn.roleBinding.name" -}}
+{{- if .Values.rbac.create }}
+{{- .Values.rbac.roleBindingName | default (include "celeborn.fullname" .) }}
+{{- else }}
+{{- .Values.rbac.roleBindingName | default "default" }}
+{{- end }}
+{{- end }}
+
+{{/* Create the name of configmap to use. */}}
+{{- define "celeborn.configMap.name" -}}
+{{ include "celeborn.fullname" . }}-conf
+{{- end -}}
+
+{{/* Checksum of the Celeborn ConfigMap for rollout triggers. */}}
+{{- define "celeborn.configChecksum" -}}
+{{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end -}}
+
+{{/*
+Create the name of the celeborn image to use
+*/}}
+{{- define "celeborn.image" -}}
+{{- $imageRegistry := .Values.image.registry | default "docker.io" }}
+{{- $imageRepository := .Values.image.repository | default "apache/celeborn" }}
+{{- $imageTag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s/%s:%s" $imageRegistry $imageRepository $imageTag }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/configmap.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/configmap.yaml
@@ -1,0 +1,53 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "celeborn.configMap.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.labels" . | nindent 4 }}
+data:
+  celeborn-defaults.conf: |-
+
+    {{- $endpoints := list }}
+    {{- range until (.Values.master.replicas | int) }}
+    {{- $endpoint := (printf "%s-%d.%s.%s.svc.%s.local" (include "celeborn.master.statefulSet.name" $) . (include "celeborn.master.service.name" $) $.Release.Namespace $.Values.cluster.name) }}
+    {{- $endpoints = append $endpoints $endpoint }}
+    {{- end }}
+    celeborn.master.endpoints={{ $endpoints | join "," }}
+
+    celeborn.master.internal.endpoints = {{ $endpoints | join "," }}
+
+    {{- range until (.Values.master.replicas | int) }}
+    {{- $host := (printf "%s-%d.%s.%s.svc.%s.local" (include "celeborn.master.statefulSet.name" $) . (include "celeborn.master.service.name" $) $.Release.Namespace $.Values.cluster.name) }}
+    celeborn.master.ha.node.{{ . }}.host={{ $host }}
+    {{- end }}
+
+    {{- range $key, $val := .Values.celeborn }}
+    {{ $key }}={{ $val }}
+    {{- end }}
+
+  log4j2.xml: |-
+    {{- .Files.Get "files/conf/log4j2.xml" | nindent 4 }}
+
+  metrics.properties: |-
+    {{- .Files.Get "files/conf/metrics.properties" | nindent 4 }}
+
+  ratis-log4j.properties: |-
+    {{- .Files.Get "files/conf/ratis-log4j.properties" | nindent 4 }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/_helpers.tpl
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Common labels for Celeborn master resources
+*/}}
+{{- define "celeborn.master.labels" -}}
+{{ include "celeborn.labels" . }}
+app.kubernetes.io/role: master
+{{- end }}
+
+{{/*
+Selector labels for Celeborn master pods
+*/}}
+{{- define "celeborn.master.selectorLabels" -}}
+{{ include "celeborn.selectorLabels" . }}
+app.kubernetes.io/role: master
+{{- end }}
+
+{{/*
+Create the name of the master service to use
+*/}}
+{{- define "celeborn.master.service.name" -}}
+{{ include "celeborn.fullname" . }}-master-svc
+{{- end }}
+
+
+{{/*
+Create the name of the master priority class to use
+*/}}
+{{- define "celeborn.master.priorityClass.name" -}}
+{{- with .Values.master.priorityClass.name -}}
+{{ . }}
+{{- else -}}
+{{ include "celeborn.fullname" . }}-master-priority-class
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the master statefulset to use
+*/}}
+{{- define "celeborn.master.statefulSet.name" -}}
+{{ include "celeborn.fullname" . }}-master
+{{- end }}
+
+{{/*
+Create the name of the master podmonitor to use
+*/}}
+{{- define "celeborn.master.podMonitor.name" -}}
+{{ include "celeborn.fullname" . }}-master-podmonitor
+{{- end }}
+
+{{/*
+Create master annotations if metrics enables
+*/}}
+{{- define "celeborn.master.metrics.annotations" -}}
+{{- $metricsEnabled := true -}}
+{{- $metricsPath := "/metrics/prometheus" -}}
+{{- $masterPort := 9098 -}}
+{{- range $key, $val := .Values.celeborn }}
+{{- if eq $key "celeborn.metrics.enabled" }}
+{{- $metricsEnabled = $val -}}
+{{- end }}
+{{- if eq $key "celeborn.metrics.prometheus.path" }}
+{{- $metricsPath = $val -}}
+{{- end }}
+{{- if eq $key "celeborn.master.http.port" }}
+{{- $masterPort = $val -}}
+{{- end }}
+{{- end }}
+{{- if eq (toString $metricsEnabled) "true" -}}
+prometheus.io/path: {{ $metricsPath }}
+prometheus.io/port: '{{ $masterPort }}'
+prometheus.io/scheme: 'http'
+prometheus.io/scrape: 'true'
+{{- end }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/podmonitor.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/podmonitor.yaml
@@ -1,0 +1,41 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.podMonitor.enable }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "celeborn.master.podMonitor.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.master.labels" . | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+  - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
+    port: {{ .Values.podMonitor.podMetricsEndpoint.portName | quote }}
+    scheme: {{ .Values.podMonitor.podMetricsEndpoint.scheme }}
+    path: {{ get .Values.celeborn "celeborn.metrics.prometheus.path" | default "/metrics/prometheus" }}
+  jobLabel: celeborn-master-podmonitor
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "celeborn.master.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/priorityclass.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/priorityclass.yaml
@@ -1,0 +1,27 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.master.priorityClass.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "celeborn.master.priorityClass.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.master.labels" . | nindent 4 }}
+value: {{ .Values.master.priorityClass.value }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/service.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/service.yaml
@@ -1,0 +1,68 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{ if .Values.additionalNodePortServicePerReplica.enabled }}
+{{ range  $i, $e := until (int .Values.master.replicas) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "celeborn.master.service.name" $ }}-{{ $i }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "celeborn.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "celeborn.master.metrics.annotations" $ | nindent 4 }}
+    {{- with index $.Values.additionalNodePortServicePerReplica.annotations (printf "master-replica-%d" $i) }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  selector:
+    {{- include "celeborn.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/role: master
+    apps.kubernetes.io/pod-index: "{{ $i }}"
+  ports:
+  - port: {{ $.Values.additionalNodePortServicePerReplica.port }}
+    targetPort: {{ $.Values.additionalNodePortServicePerReplica.port }}
+    nodePort: {{ add $.Values.additionalNodePortServicePerReplica.nodePortStartRange $i }}
+    protocol: TCP
+    name: celeborn-master
+  type: NodePort
+{{ end -}}
+{{ end -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "celeborn.master.service.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.master.labels" . | nindent 4 }}
+  annotations:
+    {{- include "celeborn.master.metrics.annotations" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "celeborn.master.selectorLabels" . | nindent 4 }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.port }}
+    protocol: TCP
+    name: celeborn-master
+  type: {{ .Values.service.type }}
+  clusterIP: None

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/statefulset.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/master/statefulset.yaml
@@ -1,0 +1,186 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "celeborn.master.statefulSet.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.master.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.master.replicas }}
+  selector:
+    matchLabels:
+      {{- include "celeborn.master.selectorLabels" . | nindent 6 }}
+  {{- with .Values.master.volumeClaimTemplates }}
+  volumeClaimTemplates:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  serviceName: {{ include "celeborn.master.service.name" . }}
+  template:
+    metadata:
+      labels:
+        {{- include "celeborn.master.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
+      annotations:
+        celeborn.apache.org/conf-hash: {{ include "celeborn.configChecksum" . }}
+        {{- with .Values.master.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- /* Add an init container to chown mount paths of Celeborn master volumes if necessary. */}}
+      {{- $paths := list }}
+      {{- range $volumeMount := .Values.master.volumeMounts }}
+      {{- range $volume := $.Values.master.volumes }}
+      {{- if eq $volume.name $volumeMount.name }}
+      {{- if or $volume.hostPath $volume.emptyDir }}
+      {{- $paths = append $paths $volumeMount.mountPath }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if $paths }}
+      initContainers:
+      - name: chown-celeborn-master-volume
+        image: {{ include "celeborn.image" . }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        command:
+        - chown
+        - -R
+        - {{ .Values.master.podSecurityContext.runAsUser | default 10006 }}:{{ .Values.master.podSecurityContext.runAsGroup | default 10006 }}
+        {{- range $path := $paths }}
+        - {{ $path }}
+        {{- end }}
+        {{- with .Values.master.volumeMounts }}
+        volumeMounts:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.master.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        securityContext:
+          runAsUser: 0
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ include "celeborn.image" . }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        command:
+        - /usr/bin/tini
+        - --
+        - /bin/sh
+        - -c
+        {{- $namespace := .Release.Namespace }}
+        - >
+          until {{ range until (.Values.master.replicas | int) }}
+          nslookup {{ include "celeborn.master.statefulSet.name" $ }}-{{ . }}.{{ include "celeborn.master.service.name" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
+          {{- end }}
+          true; do
+            echo "waiting for master"; 
+            sleep 2;
+          done && exec /opt/celeborn/sbin/start-master.sh
+        ports:
+        - containerPort: {{ .Values.service.port }}
+        - containerPort: {{ get .Values.celeborn "celeborn.master.http.port" | default 9098 }}
+          name: metrics
+          protocol: TCP
+        {{- with .Values.master.env }}
+        env:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.master.envFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: celeborn-conf
+          subPath: celeborn-defaults.conf
+          mountPath: /opt/celeborn/conf/celeborn-defaults.conf
+        - name: celeborn-conf
+          subPath: log4j2.xml
+          mountPath: /opt/celeborn/conf/log4j2.xml
+        - name: celeborn-conf
+          subPath: metrics.properties
+          mountPath: /opt/celeborn/conf/metrics.properties
+        - name: celeborn-conf
+          subPath: ratis-log4j.properties
+          mountPath: /opt/celeborn/conf/ratis-log4j.properties
+        {{- with .Values.master.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.master.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.master.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: celeborn-conf
+        configMap:
+          name: {{ include "celeborn.configMap.name" . }}
+          defaultMode: 0444
+          items:
+          - key: celeborn-defaults.conf
+            path: celeborn-defaults.conf
+          - key: log4j2.xml
+            path: log4j2.xml
+          - key: metrics.properties
+            path: metrics.properties
+          - key: ratis-log4j.properties
+            path: ratis-log4j.properties
+      {{- with .Values.master.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.master.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.master.priorityClass.name .Values.master.priorityClass.create }}
+      priorityClassName: {{ include "celeborn.master.priorityClass.name" . }}
+      {{- end }}
+      {{- with .Values.master.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.master.hostNetwork }}
+      hostNetwork: {{ . }}
+      {{- end }}
+      serviceAccountName: {{ include "celeborn.serviceAccount.name" . }}
+      {{- with .Values.master.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/role.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/role.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "celeborn.role.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "list", "delete"]
+{{- end }}
+

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/rolebinding.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/rolebinding.yaml
@@ -1,0 +1,34 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "celeborn.roleBinding.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "celeborn.serviceAccount.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "celeborn.role.name" . }}
+{{- end }}
+

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/serviceaccount.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/serviceaccount.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "celeborn.serviceAccount.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/_helpers.tpl
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/_helpers.tpl
@@ -1,0 +1,113 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Common labels for Celeborn worker resources
+*/}}
+{{- define "celeborn.worker.labels" -}}
+{{ include "celeborn.labels" . }}
+app.kubernetes.io/role: worker
+{{- end }}
+
+{{/*
+Selector labels for Celeborn worker pods
+*/}}
+{{- define "celeborn.worker.selectorLabels" -}}
+{{ include "celeborn.selectorLabels" . }}
+app.kubernetes.io/role: worker
+{{- end }}
+
+{{/*
+Create the name of the worker service to use
+*/}}
+{{- define "celeborn.worker.service.name" -}}
+{{ include "celeborn.fullname" . }}-worker-svc
+{{- end }}
+
+{{/*
+Create worker Service http port params if metrics is enabled
+*/}}
+{{- define "celeborn.worker.service.port" -}}
+{{- $metricsEnabled := true -}}
+{{- $workerPort := 9096 -}}
+{{- range $key, $val := .Values.celeborn }}
+{{- if eq $key "celeborn.metrics.enabled" }}
+{{- $metricsEnabled = $val -}}
+{{- end }}
+{{- if eq $key "celeborn.worker.http.port" }}
+{{- $workerPort = $val -}}
+{{- end }}
+{{- end }}
+{{- if eq (toString $metricsEnabled) "true" -}}
+ports:
+  - port: {{ $workerPort }}
+    targetPort: {{ $workerPort }}
+    protocol: TCP
+    name: celeborn-worker-http
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the worker priority class to use
+*/}}
+{{- define "celeborn.worker.priorityClass.name" -}}
+{{- with .Values.worker.priorityClass.name -}}
+{{ . }}
+{{- else -}}
+{{ include "celeborn.fullname" . }}-worker-priority-class
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the worker statefulset to use
+*/}}
+{{- define "celeborn.worker.statefulSet.name" -}}
+{{ include "celeborn.fullname" . }}-worker
+{{- end }}
+
+{{/*
+Create the name of the worker podmonitor to use
+*/}}
+{{- define "celeborn.worker.podMonitor.name" -}}
+{{ include "celeborn.fullname" . }}-worker-podmonitor
+{{- end }}
+
+{{/*
+Create worker annotations if metrics is enabled
+*/}}
+{{- define "celeborn.worker.metrics.annotations" -}}
+{{- $metricsEnabled := true -}}
+{{- $metricsPath := "/metrics/prometheus" -}}
+{{- $workerPort := 9096 -}}
+{{- range $key, $val := .Values.celeborn }}
+{{- if eq $key "celeborn.metrics.enabled" }}
+{{- $metricsEnabled = $val -}}
+{{- end }}
+{{- if eq $key "celeborn.metrics.prometheus.path" }}
+{{- $metricsPath = $val -}}
+{{- end }}
+{{- if eq $key "celeborn.worker.http.port" }}
+{{- $workerPort = $val -}}
+{{- end }}
+{{- end }}
+{{- if eq (toString $metricsEnabled) "true" -}}
+prometheus.io/path: {{ $metricsPath }}
+prometheus.io/port: '{{ $workerPort }}'
+prometheus.io/scheme: 'http'
+prometheus.io/scrape: 'true'
+{{- end }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/podmonitor.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/podmonitor.yaml
@@ -1,0 +1,41 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.podMonitor.enable }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "celeborn.worker.podMonitor.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+  - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
+    port: {{ .Values.podMonitor.podMetricsEndpoint.portName | quote }}
+    scheme: {{ .Values.podMonitor.podMetricsEndpoint.scheme }}
+    path: {{ get .Values.celeborn "celeborn.metrics.prometheus.path" | default "/metrics/prometheus" }}
+  jobLabel: celeborn-worker-podmonitor
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "celeborn.worker.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/priorityclass.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/priorityclass.yaml
@@ -1,0 +1,27 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.worker.priorityClass.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "celeborn.worker.priorityClass.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
+value: {{ .Values.worker.priorityClass.value }}
+{{- end }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/service.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/service.yaml
@@ -1,0 +1,32 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "celeborn.worker.service.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
+  annotations:
+    {{- include "celeborn.worker.metrics.annotations" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "celeborn.worker.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+  clusterIP: None
+  {{- include "celeborn.worker.service.port" . | nindent 2 }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/statefulset.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/templates/worker/statefulset.yaml
@@ -1,0 +1,185 @@
+{{- /*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "celeborn.worker.statefulSet.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "celeborn.worker.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      {{- include "celeborn.worker.selectorLabels" . | nindent 6 }}
+  {{- with .Values.worker.volumeClaimTemplates }}
+  volumeClaimTemplates:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  serviceName: {{ include "celeborn.worker.service.name" . }}
+  template:
+    metadata:
+      labels:
+        {{- include "celeborn.worker.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
+      annotations:
+        celeborn.apache.org/conf-hash: {{ include "celeborn.configChecksum" . }}
+        {{- with .Values.worker.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- /* Add an init container to chown mount paths of Celeborn workers volume if necessary. */}}
+      {{- $paths := list }}
+      {{- range $volumeMount := .Values.worker.volumeMounts }}
+      {{- range $volume := $.Values.worker.volumes }}
+      {{- if eq $volume.name $volumeMount.name }}
+      {{- if or $volume.hostPath $volume.emptyDir }}
+      {{- $paths = append $paths $volumeMount.mountPath }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if or .Values.worker.extraInitContainers $paths }}
+      initContainers:
+      {{- end }}
+      {{- with .Values.worker.extraInitContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if $paths }}
+      - name: chown-celeborn-worker-volume
+        image: {{ include "celeborn.image" . }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        command:
+        - chown
+        - -R
+        - {{ .Values.worker.podSecurityContext.runAsUser | default 10006 }}:{{ .Values.worker.podSecurityContext.runAsGroup | default 10006 }}
+        {{- range $path := $paths }}
+        - {{ $path }}
+        {{- end }}
+        {{- with .Values.worker.volumeMounts }}
+        volumeMounts:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        securityContext:
+          runAsUser: 0
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ include "celeborn.image" . }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        command:
+        - /usr/bin/tini
+        - --
+        - /bin/sh
+        - -c
+        {{- $namespace := .Release.Namespace }}
+        - >
+          until {{ range until (.Values.master.replicas | int) }}
+          nslookup {{ include "celeborn.master.statefulSet.name" $ }}-{{ . }}.{{ include "celeborn.master.service.name" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
+          {{- end }}
+          true; do
+            echo "waiting for master";
+            sleep 2;
+          done && exec /opt/celeborn/sbin/start-worker.sh
+        ports:
+        - containerPort: {{ get .Values.celeborn "celeborn.worker.http.port" | default 9096 }}
+          name: metrics
+          protocol: TCP
+        {{- with .Values.worker.env }}
+        env:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.envFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: celeborn-conf
+          subPath: celeborn-defaults.conf
+          mountPath: /opt/celeborn/conf/celeborn-defaults.conf
+        - name: celeborn-conf
+          subPath: log4j2.xml
+          mountPath: /opt/celeborn/conf/log4j2.xml
+        - name: celeborn-conf
+          subPath: metrics.properties
+          mountPath: /opt/celeborn/conf/metrics.properties
+        {{- with .Values.worker.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: celeborn-conf
+        configMap:
+          name: {{ include "celeborn.configMap.name" . }}
+          defaultMode: 0444
+          items:
+          - key: celeborn-defaults.conf
+            path: celeborn-defaults.conf
+          - key: log4j2.xml
+            path: log4j2.xml
+          - key: metrics.properties
+            path: metrics.properties
+      {{- with .Values.worker.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.worker.priorityClass.name .Values.worker.priorityClass.create }}
+      priorityClassName: {{ include "celeborn.worker.priorityClass.name" . }}
+      {{- end }}
+      {{- with .Values.worker.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.worker.hostNetwork }}
+      hostNetwork: {{ . }}
+      {{- end }}
+      serviceAccountName:  {{ include "celeborn.serviceAccount.name" . }}
+      {{- with .Values.worker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/configmap_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/configmap_test.yaml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn configmap
+
+templates:
+  - configmap.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should create configmap
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: ConfigMap
+          name: celeborn-conf
+
+  - it: Should have correct data fields
+    asserts:
+      - exists:
+          path: data["celeborn-defaults.conf"]
+      - exists:
+          path: data["log4j2.xml"]
+      - exists:
+          path: data["metrics.properties"]
+      - exists:
+          path: data["ratis-log4j.properties"]
+
+  - it: Should include celeborn.master.internal.endpoints key in celeborn-defaults.conf
+    asserts:
+      - matchRegex:
+          path: data["celeborn-defaults.conf"]
+          pattern: "(?m)^\\s*celeborn\\.master\\.internal\\.endpoints\\s*=.*"

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/podmonitor_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/podmonitor_test.yaml
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master pod monitor
+
+templates:
+  - master/podmonitor.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should not create master pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create master pod monitor if `podMonitor.enable` is true and api version `monitoring.coreos.com/v1/PodMonitor` exists
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - containsDocument:
+          apiVersion: monitoring.coreos.com/v1
+          kind: PodMonitor
+          name: celeborn-master-podmonitor
+          namespace: celeborn
+
+  - it: Should use the specified pod metrics endpoints
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+        podMetricsEndpoint:
+          scheme: http
+          interval: 3s
+          portName: test-port
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 3s
+            port: test-port
+            scheme: http
+            path: /metrics/prometheus
+          count: 1
+
+  - it: Should respect `celeborn.metrics.prometheus.path`
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      celeborn:
+        celeborn.metrics.prometheus.path: custom-metrics-path
+      podMonitor:
+        enable: true
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 5s
+            port: metrics
+            scheme: http
+            path: custom-metrics-path
+          count: 1

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/priorityclass_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/priorityclass_test.yaml
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master priority class
+
+templates:
+  - master/priorityclass.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should not create master priority as default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create master priority class if `master.priorityClass.create` is true
+    set:
+      master:
+        priorityClass:
+          create: true
+    asserts:
+      - containsDocument:
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          name: celeborn-master-priority-class
+          namespace: celeborn
+
+  - it: Should use the specified priority class value
+    set:
+      master:
+        priorityClass:
+          create: true
+          value: 1000
+    asserts:
+      - equal:
+          path: value
+          value: 1000

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/service_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/service_test.yaml
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master service
+
+templates:
+  - master/service.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should create master service
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: celeborn-master-svc
+          namespace: celeborn
+
+  - it: Should have label selectors for master
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/role"]
+          value: master
+
+  - it: Should create master service with the specified service type and port
+    set:
+      service:
+        type: NodePort
+        port: 9097
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 9097
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 9097
+
+  - it: Should create NodePort service for each master replica
+    set:
+      master:
+        replicas: 3
+      additionalNodePortServicePerReplica:
+        enabled: true
+        port: 9097
+        nodePortStartRange: 30100
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: celeborn-master-svc-0
+        equal:
+          path: spec.ports[0].nodePort
+          value: 30100
+      - documentSelector:
+          path: metadata.name
+          value: celeborn-master-svc-1
+        equal:
+          path: spec.ports[0].nodePort
+          value: 30101
+      - documentSelector:
+          path: metadata.name
+          value: celeborn-master-svc-2
+        equal:
+          path: spec.ports[0].nodePort
+          value: 30102

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/statefulset_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/master/statefulset_test.yaml
@@ -1,0 +1,480 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn master statefulset
+
+templates:
+  - configmap.yaml
+  - master/statefulset.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should create master statefulset
+    template: master/statefulset.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: apps/v1
+          kind: StatefulSet
+          name: celeborn-master
+          namespace: celeborn
+
+  - it: Should add checksum annotation referencing configmap
+    template: master/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
+          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+
+  - it: Should change checksum annotation when celeborn config changes
+    template: master/statefulset.yaml
+    set:
+      celeborn:
+        "celeborn.rpc.io.serverThreads": 128
+    asserts:
+      - notEqual:
+          path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
+          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+      - equal:
+          path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
+          value: fae6199c4ac5ac5a9fd9049705ac239ad6e3474a65db55bdd98f29720122b756
+
+  - it: Should add extra pod annotations if `master.annotations` is specified
+    template: master/statefulset.yaml
+    set:
+      master:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` is set
+    template: master/statefulset.yaml
+    set:
+      image:
+        registry: test-registry
+        repository: test-repository
+        tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="celeborn")].image
+          value: test-registry/test-repository:test-tag
+
+  - it: Should use the specified image pull policy if `image.pullPolicy` is set
+    template: master/statefulset.yaml
+    set:
+      image:
+        pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: Should use the specified replicas if `master.replicas` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        replicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10
+
+  - it: Should add environment variables if `master.env` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        env:
+          - name: test-env-name-1
+            value: test-env-value-1
+          - name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+          - name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-1
+            value: test-env-value-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+
+  - it: Should add environment variable sources if `master.envFrom` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+              optional: false
+          - secretRef:
+              name: test-secret
+              optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+              optional: false
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret
+              optional: false
+
+  - it: Should add volume mounts if `master.volumeMounts` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        volumeMounts:
+          - name: disk1
+            mountPath: /mnt/disk1
+          - name: disk2
+            mountPath: /mnt/disk2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: disk1
+            mountPath: /mnt/disk1
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: disk1
+            mountPath: /mnt/disk1
+
+  - it: Should use the specified resources if `master.resources` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      - equal:
+          path: spec.template.spec.containers[?(@.name=='celeborn')].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+
+  - it: Should add container securityContext if `master.securityContext` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          privileged: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 2000
+            fsGroup: 3000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            privileged: false
+
+  - it: Should add secrets if `imagePullSecrets` is set
+    template: master/statefulset.yaml
+    set:
+      imagePullSecrets:
+        - name: test-secret1
+        - name: test-secret2
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: test-secret1
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: test-secret2
+
+  - it: Should add volumes if `master.volumes` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        volumes:
+          - name: disk1
+            emptyDir:
+              sizeLimit: 10Gi
+          - name: disk2
+            hostPath:
+              type: DirectoryOrCreate
+              path: /mnt/disk2
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: disk1
+            emptyDir:
+              sizeLimit: 10Gi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: disk2
+            hostPath:
+              type: DirectoryOrCreate
+              path: /mnt/disk2
+
+  - it: Should add node selector if `master.nodeSelector` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        nodeSelector:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add tolerations if `master.tolerations` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified affinity if `master.affinity` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity
+          value:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+
+  - it: Should use the specified priority class name if `master.priorityClass.name` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        priorityClass:
+          name: test-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: test-priority-class
+
+  - it: Should use the specified dns policy if `master.dnsPolicy` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: Should enable host network if `master.hostNetwork` is set to true
+    template: master/statefulset.yaml
+    set:
+      master:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: Should use the specified security context if `master.podSecurityContext` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        podSecurityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  - it: Should add volume claim templates if `master.volumeClaimTemplates` is set
+    template: master/statefulset.yaml
+    set:
+      master:
+        volumeClaimTemplates:
+          - metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+          - metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/role_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/role_test.yaml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn role
+
+templates:
+  - role.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should not create role if `rbac.create` is false
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create a Role resource with specific rules when rbac.create is true
+    set:
+      rbac:
+        create: true
+        rbac:
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "watch", "list"]
+    asserts:
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          name: default
+          namespace: celeborn

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/rolebinding_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/rolebinding_test.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn rolebinding
+
+templates:
+  - rolebinding.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should not create a RoleBinding resource when `rbac.create` is false
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create a RoleBinding resource when `rbac.create` is true
+    set:
+      rbac:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          name: default
+          namespace: celeborn

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/serviceaccount_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/serviceaccount_test.yaml
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn service account
+
+templates:
+  - serviceaccount.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should not create service account if `serviceAccount.create` is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create service account if `serviceAccount.create` is true
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: ServiceAccount
+          name: celeborn
+          namespace: celeborn
+
+  - it: Should create service account with the specified name if `serviceAccount.name` is specified
+    set:
+      serviceAccount:
+        create: true
+        name: test-service-account
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: ServiceAccount
+          name: test-service-account
+          namespace: celeborn
+
+  - it: Should create service account with the specified annotations
+    set:
+      serviceAccount:
+        create: true
+        name: test-service-account
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::000000:role/Foo
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            eks.amazonaws.com/role-arn: arn:aws:iam::000000:role/Foo
+        template: serviceaccount.yaml

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/podmonitor_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/podmonitor_test.yaml
@@ -1,0 +1,87 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker pod monitor
+
+templates:
+  - worker/podmonitor.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should not create worker pod monitor without api version `monitoring.coreos.com/v1/PodMonitor` even if `podMonitor.enable` is true
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create worker pod monitor if `podMonitor.enable` is true and api version `monitoring.coreos.com/v1/PodMonitor` exists
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+    asserts:
+      - containsDocument:
+          apiVersion: monitoring.coreos.com/v1
+          kind: PodMonitor
+          name: celeborn-worker-podmonitor
+
+  - it: Should use the specified pod metrics endpoints
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      podMonitor:
+        enable: true
+        podMetricsEndpoint:
+          scheme: http
+          interval: 3s
+          portName: test-port
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 3s
+            port: test-port
+            scheme: http
+            path: /metrics/prometheus
+          count: 1
+
+  - it: Should respect `celeborn.metrics.prometheus.path`
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/PodMonitor
+    set:
+      celeborn:
+        celeborn.metrics.prometheus.path: custom-metrics-path
+      podMonitor:
+        enable: true
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints
+          content:
+            interval: 5s
+            port: metrics
+            scheme: http
+            path: custom-metrics-path
+          count: 1

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/priorityclass_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/priorityclass_test.yaml
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker priority class
+
+templates:
+  - worker/priorityclass.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should not create worker priority as default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create worker priority class if `worker.priorityClass.create` is true
+    set:
+      worker:
+        priorityClass:
+          create: true
+    asserts:
+      - containsDocument:
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          name: celeborn-worker-priority-class
+          namespace: celeborn
+
+  - it: Should use the specified priority class value
+    set:
+      worker:
+        priorityClass:
+          create: true
+          value: 1000
+    asserts:
+      - equal:
+          path: value
+          value: 1000

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/service_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/service_test.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker service
+
+templates:
+  - worker/service.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should create worker service
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: celeborn-worker-svc
+          namespace: celeborn
+
+  - it: Should have label selectors for worker
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/role"]
+          value: worker
+
+  - it: Should create worker service with the specified service type
+    set:
+      service:
+        type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/tests/worker/statefulset_test.yaml
@@ -1,0 +1,518 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Celeborn worker statefulset
+
+templates:
+  - configmap.yaml
+  - worker/statefulset.yaml
+
+release:
+  name: celeborn
+  namespace: celeborn
+
+tests:
+  - it: Should create worker statefulset
+    template: worker/statefulset.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: apps/v1
+          kind: StatefulSet
+          name: celeborn-worker
+          namespace: celeborn
+
+  - it: Should add checksum annotation referencing configmap
+    template: worker/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
+          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+
+  - it: Should change checksum annotation when celeborn config changes
+    template: worker/statefulset.yaml
+    set:
+      celeborn:
+        "celeborn.rpc.io.serverThreads": 128
+    asserts:
+      - notEqual:
+          path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
+          value: 316cfc634ed083bd70e36ad0b429578ace6893d4de3ef4897a078db5f01a7522
+      - equal:
+          path: spec.template.metadata.annotations["celeborn.apache.org/conf-hash"]
+          value: fae6199c4ac5ac5a9fd9049705ac239ad6e3474a65db55bdd98f29720122b756
+
+  - it: Should add extra pod annotations if `worker.annotations` is specified
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should use the specified image if `image.registry`, `image.repository` and `image.tag` is set
+    template: worker/statefulset.yaml
+    set:
+      image:
+        registry: test-registry
+        repository: test-repository
+        tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="celeborn")].image
+          value: test-registry/test-repository:test-tag
+
+  - it: Should use the specified image pull policy if `image.pullPolicy` is set
+    template: worker/statefulset.yaml
+    set:
+      image:
+        pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: Should use the specified replicas if `worker.replicas` is set
+    template: worker/statefulset.yaml
+    set:
+      worker.replicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10
+
+  - it: Should use the specified terminationGracePeriodSeconds if `worker.terminationGracePeriodSeconds` is set
+    template: worker/statefulset.yaml
+    set:
+      worker.terminationGracePeriodSeconds: 70
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 70
+
+  - it: Should add environment variables if `worker.env` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        env:
+          - name: test-env-name-1
+            value: test-env-value-1
+          - name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+          - name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-1
+            value: test-env-value-1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: test-key
+                optional: false
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: test-env-name-3
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: test-key
+                optional: false
+
+  - it: Should add environment variable sources if `worker.envFrom` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+              optional: false
+          - secretRef:
+              name: test-secret
+              optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+              optional: false
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret
+              optional: false
+
+  - it: Should add volume mounts if `worker.volumeMounts` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        volumeMounts:
+          - name: disk1
+            mountPath: /mnt/disk1
+          - name: disk2
+            mountPath: /mnt/disk2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: disk1
+            mountPath: /mnt/disk1
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: disk1
+            mountPath: /mnt/disk1
+
+  - it: Should use the specified resources if `worker.resources` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      - equal:
+          path: spec.template.spec.containers[?(@.name=='celeborn')].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+
+  - it: Should add container securityContext if `worker.securityContext` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          privileged: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 2000
+            fsGroup: 3000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            privileged: false
+
+  - it: Should add secrets if `imagePullSecrets` is set
+    template: worker/statefulset.yaml
+    set:
+      imagePullSecrets:
+        - name: test-secret1
+        - name: test-secret2
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: test-secret1
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: test-secret2
+
+  - it: Should add volumes if `worker.volumes` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        volumes:
+          - name: disk1
+            emptyDir:
+              sizeLimit: 10Gi
+          - name: disk2
+            hostPath:
+              type: DirectoryOrCreate
+              path: /mnt/disk2
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: disk1
+            emptyDir:
+              sizeLimit: 10Gi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: disk2
+            hostPath:
+              type: DirectoryOrCreate
+              path: /mnt/disk2
+
+  - it: Should add node selector if `worker.nodeSelector` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        nodeSelector:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add tolerations if `worker.tolerations` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should use the specified affinity if `worker.affinity` is specified
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity
+          value:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+
+  - it: Should use the specified priority class name if `worker.priorityClass.name` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        priorityClass:
+          name: test-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: test-priority-class
+
+  - it: Should use the specified dns policy if `worker.dnsPolicy` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: Should enable host network if `worker.hostNetwork` is set to true
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: Should use the specified security context if `worker.podSecurityContext` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        podSecurityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  - it: Should add volume claim templates if `worker.volumeClaimTemplates` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        volumeClaimTemplates:
+          - metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+          - metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-1
+            spec:
+              accessModes:
+                - ReadWriteMany
+              resources:
+                request:
+                  storage: 100Gi
+                limits:
+                  storage: 100Gi
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: test-volume-claim-template-2
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                request:
+                  storage: 200Gi
+                limits:
+                  storage: 200Gi
+
+  - it: Should add extra init containers when `worker.extraInitContainers` is set
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        volumeMounts: []
+        extraInitContainers:
+          - name: custom-init
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - echo "hello celeborn"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: custom-init
+      - equal:
+          path: spec.template.spec.initContainers[0].command[2]
+          value: echo "hello celeborn"
+
+  - it: Should not have initContainers when no volumes and extraInitContainers
+    template: worker/statefulset.yaml
+    set:
+      worker:
+        volumeMounts: []
+        extraInitContainers: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers

--- a/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-charts/celeborn/values.yaml
@@ -1,0 +1,452 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default values for celeborn.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- String to override the default generated name
+nameOverride: ""
+
+# -- String to override the default generated fullname
+fullnameOverride: ""
+
+# Specifies the Celeborn image to use
+image:
+  # -- Image registry
+  registry: docker.io
+  # -- Image repository
+  repository: apache/celeborn
+  # -- Image tag, default is chart `appVersion`
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: Always
+  # -- Image name for init container. (your-private-repo/alpine:3.18)
+  initContainerImage: alpine:3.18
+
+# -- Image pull secrets for private image registry
+imagePullSecrets: []
+
+# -- Celeborn configurations.
+# Ref: [Configuration - Apache Celeborn](https://celeborn.apache.org/docs/latest/configuration).
+celeborn:
+  # ============================================================================
+  # Mater
+  # ============================================================================
+  celeborn.master.http.port: 9098
+  celeborn.master.heartbeat.worker.timeout: 120s
+  celeborn.master.heartbeat.application.timeout: 300s
+
+  # ============================================================================
+  # Mater HA
+  # ============================================================================
+  celeborn.master.ha.enabled: true
+  # Do not edit `celeborn.master.ha.node.<id>.host` manually, it should be configured automatically by Helm.
+  # celeborn.master.ha.node.<id>.host: ""
+  celeborn.master.ha.ratis.raft.server.storage.dir: /mnt/celeborn_ratis
+
+  # ============================================================================
+  # Worker
+  # ============================================================================
+  # Do not edit `celeborn.master.endpoints` manually, it should be configured automatically by Helm.
+  # celeborn.master.endpoints: <localhost>:9097
+  celeborn.shuffle.chunk.size: 8m
+  celeborn.worker.fetch.io.threads: 32
+  celeborn.worker.flusher.buffer.size: 256K
+  celeborn.worker.heartbeat.timeout: 120s
+  celeborn.worker.http.port: 9096
+  celeborn.worker.monitor.disk.enabled: false
+  celeborn.worker.push.io.threads: 32
+  celeborn.worker.storage.dirs: /mnt/disk1:disktype=SSD:capacity=100Gi,/mnt/disk2:disktype=SSD:capacity=100Gi,/mnt/disk3:disktype=SSD:capacity=100Gi,/mnt/disk4:disktype=SSD:capacity=100Gi
+
+  # ============================================================================
+  # Client
+  # ============================================================================
+  celeborn.client.push.stageEnd.timeout: 120s
+
+  # ============================================================================
+  # Network
+  # ============================================================================
+  celeborn.rpc.io.serverThreads: 64
+  celeborn.rpc.io.numConnectionsPerPeer: 2
+  celeborn.rpc.io.clientThreads: 64
+  celeborn.rpc.dispatcher.numThreads: 4
+
+  # ============================================================================
+  # Metrics
+  # ============================================================================
+  celeborn.metrics.enabled: true
+  celeborn.metrics.prometheus.path: /metrics/prometheus
+
+master:
+  # -- Number of Celeborn master replicas to deploy, should not less than 3.
+  replicas: 3
+
+  # -- Annotations for Celeborn master pods.
+  annotations:
+    # key1: value1
+    # key2: value2
+
+  # -- Environment variables for Celeborn master containers.
+  env:
+  - name: CELEBORN_MASTER_MEMORY
+    value: 2g
+  - name: CELEBORN_MASTER_JAVA_OPTS
+    value: -XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-master.out -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "true"
+  - name: TZ
+    value: Asia/Shanghai
+
+  # -- Environment variable sources for Celeborn master containers.
+  envFrom:
+  # - configMapRef:
+  #     name: celeborn-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: celeborn-secret
+  #     optional: false
+
+  # -- Volume mounts for Celeborn master containers.
+  volumeMounts:
+  - name: celeborn-ratis
+    mountPath: /mnt/celeborn_ratis
+
+  # -- Resources for Celeborn master containers.
+  resources:
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  # -- Security configurations for Celeborn master containers.
+  securityContext:
+    # privileged: false
+    # allowPrivilegeEscalation: false
+    # runAsUser: 10006
+    # runAsGroup: 10006
+    # fsGroup: 10006
+
+  # -- Volumes for Celeborn master pods.
+  volumes:
+  - name: celeborn-ratis
+    hostPath:
+      type: DirectoryOrCreate
+      path: /mnt/celeborn_ratis
+
+  # -- Node selector for Celeborn master pods.
+  nodeSelector:
+    # key1: value1
+    # key2: value2
+
+  # -- Affinity for Celeborn master pods.
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - celeborn
+          - key: app.kubernetes.io/role
+            operator: In
+            values:
+            - master
+        topologyKey: kubernetes.io/hostname
+
+  # -- Tolerations for Celeborn master pods.
+  tolerations:
+  # - key: key1
+  #   operator: Equal
+  #   value: value1
+  #   effect: NoSchedule
+  # - key: key2
+  #   operator: Exists
+  #   effect: NoSchedule
+
+  # Priority class for Celeborn master pods.
+  priorityClass:
+    # -- Specifies whether a new priority class for Celeborn master pods should be created.
+    create: false
+    # -- Specifies the name of priority class for Celeborn master pods to be used (created if `create: true`), empty means `${Release.Name}-master-priority-class`.
+    name: ""
+    # -- Specifies the integer value of this priority class, default is half of system-cluster-critical.
+    value: 1000000000
+
+  # -- DNS policy for Celeborn master pods.
+  dnsPolicy: ClusterFirst
+
+  # -- Whether to use the host's network namespace in Celeborn master pods.
+  hostNetwork: false
+
+  # -- Pod-level security configurations for Celeborn master pods.
+  podSecurityContext:
+    # The user ID to use when running the entrypoint of the container process.
+    runAsUser: 10006
+    # The group ID to use when running the entrypoint of the container process.
+    runAsGroup: 10006
+    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
+    fsGroup: 10006
+
+  # -- Volume claim templates for Celeborn master statefulset.
+  volumeClaimTemplates:
+  # - metadata:
+  #     name: celeborn-ratis
+  #   spec:
+  #     accessModes:
+  #     - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: 100Gi
+  #       limits:
+  #         storage: 100Gi
+
+worker:
+  # -- Number of Celeborn worker replicas to deploy, should less than node number.
+  replicas: 5
+
+  # -- Value for terminationGracePeriodSeconds for worker pods
+  terminationGracePeriodSeconds: 30
+
+  # -- Annotations for Celeborn worker pods.
+  annotations:
+    # key1: value1
+    # key2: value2
+
+  # -- Environment variables for Celeborn worker containers.
+  env:
+  - name: CELEBORN_WORKER_MEMORY
+    value: 2g
+  - name: CELEBORN_WORKER_OFFHEAP_MEMORY
+    value: 12g
+  - name: CELEBORN_WORKER_JAVA_OPTS
+    value: -XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced
+  - name: CELEBORN_NO_DAEMONIZE
+    value: "true"
+  - name: TZ
+    value: Asia/Shanghai
+
+  # -- Environment variable sources for Celeborn worker containers.
+  envFrom:
+  # - configMapRef:
+  #     name: celeborn-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: celeborn-secret
+  #     optional: false
+
+  # -- Volume mounts for Celeborn worker containers.
+  volumeMounts:
+  - name: disk1
+    mountPath: /mnt/disk1
+  - name: disk2
+    mountPath: /mnt/disk2
+  - name: disk3
+    mountPath: /mnt/disk3
+  - name: disk4
+    mountPath: /mnt/disk4
+
+  # -- Resources for Celeborn worker containers.
+  resources:
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  # -- Security configurations for Celeborn worker containers.
+  securityContext:
+    # privileged: false
+    # allowPrivilegeEscalation: false
+    # runAsUser: 10006
+    # runAsGroup: 10006
+    # fsGroup: 10006
+
+  # Add additional init containers into workers (templated).
+  extraInitContainers: []
+
+  # --Volumes for Celeborn worker pods.
+  volumes:
+  - name: disk1
+    hostPath:
+      type: DirectoryOrCreate
+      path: /mnt/disk1
+  - name: disk2
+    hostPath:
+      type: DirectoryOrCreate
+      path: /mnt/disk2
+  - name: disk3
+    hostPath:
+      type: DirectoryOrCreate
+      path: /mnt/disk3
+  - name: disk4
+    hostPath:
+      type: DirectoryOrCreate
+      path: /mnt/disk4
+
+  # -- Node selector for Celeborn worker pods.
+  nodeSelector:
+    # key1: value1
+    # key2: value2
+
+  # -- Affinity for Celeborn worker pods.
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - celeborn
+          - key: app.kubernetes.io/role
+            operator: In
+            values:
+            - worker
+        topologyKey: kubernetes.io/hostname
+
+  # -- Tolerations for Celeborn worker pods.
+  tolerations:
+  # - key: key1
+  #   operator: Equal
+  #   value: value1
+  #   effect: NoSchedule
+  # - key: key2
+  #   operator: Exists
+  #   effect: NoSchedule
+
+  # Priority class for Celeborn worker pods.
+  priorityClass:
+    # -- Specifies whether a new priority class for Celeborn worker pods should be created
+    create: false
+    # -- Specifies the name of priority class for Celeborn worker pods to be used (created if `create: true`), empty means `${Release.Name}-worker-priority-class`
+    name: ""
+    # -- Specifies the integer value of this priority class, default is Celeborn master value minus 1000
+    value: 999999000
+
+  # -- DNS policy for Celeborn worker pods.
+  dnsPolicy: ClusterFirst
+
+  # -- Whether to use the host's network namespace in Celeborn worker pods.
+  hostNetwork: false
+
+  # -- Pod-level security configurations for Celeborn worker pods.
+  podSecurityContext:
+    # The user ID to use when running the entrypoint of the container process.
+    runAsUser: 10006
+    # The group ID to use when running the entrypoint of the container process.
+    runAsGroup: 10006
+    # The group ID to use when modifying the ownership and permissions of the mounted volumes.
+    fsGroup: 10006
+
+  # -- Volume claim templates for Celeborn worker pods.
+  volumeClaimTemplates:
+  # - metadata:
+  #     name: disk1
+  #   spec:
+  #     accessModes:
+  #     - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: 100Gi
+  #       limits:
+  #         storage: 100Gi
+  # - metadata:
+  #     name: disk2
+  #   spec:
+  #     accessModes:
+  #     - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: 100Gi
+  #       limits:
+  #         storage: 100Gi
+  # - metadata:
+  #     name: disk3
+  #   spec:
+  #     accessModes:
+  #     - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: 100Gi
+  #       limits:
+  #         storage: 100Gi
+  # - metadata:
+  #     name: disk4
+  #   spec:
+  #     accessModes:
+  #     - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: 100Gi
+  #       limits:
+  #         storage: 100Gi
+
+serviceAccount:
+  # -- Whether to create a service account for Celeborn.
+  create: false
+  # -- (Optional) Name of the Celeborn service account.
+  name: ""
+  # -- (Optional) Additional annotations, example: eks.amazonaws.com/role-arn:  arn:aws:iam::0000000000:role/XXXXXXX
+  annotations: {}
+
+rbac:
+  create: true
+  roleName: default
+  roleBindingName: default
+  rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "list", "delete"]
+
+service:
+  # -- Specifies service type
+  type: ClusterIP
+  # -- Specifies service port
+  port: 9097
+  # -- Specifies service annotations
+  annotations: {}
+
+# -- Specifies whether to create additional NodePort service for each master replica
+additionalNodePortServicePerReplica:
+  enabled: false
+  # -- Specifies service port
+  port: 9097
+  # -- Specifies nodeport start range
+  nodePortStartRange: 30000
+  # -- when using NodePort service type, you can specify map of annotations for each master replica
+  annotations: {}
+
+cluster:
+  # -- Specifies Kubernetes cluster name
+  name: cluster
+
+podMonitor:
+  # -- Specifies whether to enable creating pod monitors for Celeborn pods
+  enable: true
+  # -- Specifies pod metrics endpoint
+  podMetricsEndpoint:
+    # Specifies scheme
+    scheme: http
+    # Specifies scrape interval
+    interval: 5s
+    # Specifies port name
+    portName: metrics

--- a/analytics/terraform/spark-k8s-operator/helm-values/celeborn-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/celeborn-values.yaml
@@ -1,0 +1,64 @@
+image:
+  repository: apache/celeborn
+  tag: "0.6.0"
+
+celeborn:
+  celeborn.worker.rpc.port: "9091"
+  celeborn.worker.fetch.port: "9092"
+  celeborn.worker.push.port: "9093"
+  celeborn.worker.replicate.port: "9094"
+  celeborn.worker.graceful.shutdown.enabled: "true"
+  celeborn.worker.graceful.shutdown.timeout: "600s"
+  celeborn.worker.graceful.shutdown.recoverPath: "/var/celeborn/rocksdb"
+  celeborn.network.bind.preferIpAddress: "false"
+  celeborn.master.heartbeat.worker.timeout: "180s"
+  celeborn.storage.availableTypes: "MEMORY,SSD"
+  celeborn.worker.storage.dirs: "/mnt/disk1:disktype=SSD:capacity=60Gi"
+  celeborn.master.slot.assign.policy: "ROUNDROBIN"
+  celeborn.worker.monitor.disk.enabled: "false"
+
+master:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "1"
+      memory: "4Gi"
+    limits:
+      cpu: "1"
+      memory: "4Gi"
+  nodeSelector:
+    karpenter.sh/capacity-type: "on-demand"
+    NodeGroupType: "SparkComputeGeneral"
+
+worker:
+  replicas: 2
+  terminationGracePeriodSeconds: 720
+  resources:
+    requests:
+      cpu: "1"
+      memory: "8Gi"
+    limits:
+      cpu: "1"
+      memory: "8Gi"
+  nodeSelector:
+    karpenter.sh/capacity-type: "on-demand"
+    NodeGroupType: "SparkComputeGeneral"
+  # Override default hostPath volumes with PVC-backed storage
+  volumeMounts:
+    - name: disk1
+      mountPath: /mnt/disk1
+    - name: rocksdb
+      mountPath: /var/celeborn
+  volumes:
+    - name: rocksdb
+      emptyDir: {}
+  # PVC templates for worker storage
+  volumeClaimTemplates:
+    - metadata:
+        name: disk1
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: gp3
+        resources:
+          requests:
+            storage: 70Gi

--- a/analytics/terraform/spark-k8s-operator/outputs.tf
+++ b/analytics/terraform/spark-k8s-operator/outputs.tf
@@ -81,3 +81,12 @@ output "raydata_config" {
     iam_role_arn      = module.spark_team_irsa["raydata"].iam_role_arn
   } : null
 }
+
+################################################################################
+# Celeborn Configuration
+################################################################################
+
+output "celeborn_master_endpoint" {
+  description = "Celeborn master endpoint for Spark shuffle configuration"
+  value       = var.enable_celeborn ? "celeborn-master-0.celeborn-master-svc.celeborn.svc.cluster.local:9097" : null
+}

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -103,3 +103,9 @@ variable "enable_spark_history_mcp" {
   type        = bool
   default     = true
 }
+
+variable "enable_celeborn" {
+  description = "Enable Apache Celeborn Remote Shuffle Service"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Adds Apache Celeborn as a remote shuffle service option for the Spark on EKS workshop. Celeborn offloads shuffle data from Spark executors to dedicated shuffle workers with persistent EBS storage, improving fault tolerance for Spot instance workloads — executor loss no longer causes shuffle data recomputation.

Changes:
- `celeborn.tf` — Helm release for Celeborn with `enable_celeborn` variable
- `helm-charts/celeborn/` — Celeborn Helm chart (1 master, 2 workers)
- `helm-values/celeborn-values.yaml` — Celeborn configuration with gp3 PVC-backed storage
- `examples/karpenter/spark-app-celeborn.yaml` — SparkApplication using Celeborn shuffle manager
- `variables.tf` — Added `enable_celeborn` variable (default: true)
- `outputs.tf` — Added `celeborn_master_endpoint` output

### Motivation

Workshop attendees need to understand how remote shuffle services improve Spark reliability on Spot instances. Celeborn is a popular open-source option that complements the existing NVMe local shuffle lab by showing an alternative approach where shuffle data survives executor interruptions.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested on a Workshop Studio event. Celeborn master and 2 workers deploy successfully on the `general-purpose` NodePool with on-demand capacity. Spark job completes with shuffle data flowing through Celeborn workers (~6.6 GiB shuffle written). Celeborn client JAR is downloaded from Maven Central at runtime — no custom Spark image required.
