### PR TITLE
feat: Enable JupyterHub by default for workshop

### DIFF
--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -63,7 +63,7 @@ variable "enable_yunikorn" {
 }
 
 variable "enable_jupyterhub" {
-  default     = false
+  default     = true
   description = "Enable Jupyter Hub"
   type        = bool
 }


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Flips `enable_jupyterhub` variable default from `false` to `true` so JupyterHub is deployed as part of the workshop infrastructure.

### Motivation

Workshop attendees need JupyterHub available for interactive Spark notebook workflows. The JupyterHub code (namespace, IRSA, service account, Helm config) already exists — this just enables it by default.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

One-line change in `variables.tf`. All JupyterHub resources are gated behind the existing `enable_jupyterhub` conditional — no new resources added.
