### PR TITLE
Use ephemeral EKS cluster auth token

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,4 +1,4 @@
-data "aws_eks_cluster_auth" "this" {
+ephemeral "aws_eks_cluster_auth" "this" {
   name = module.eks.cluster_name
 }
 
@@ -127,20 +127,20 @@ provider "aws" {
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  token                  = data.aws_eks_cluster_auth.this.token
+  token                  = ephemeral.aws_eks_cluster_auth.this.token
 }
 
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    token                  = data.aws_eks_cluster_auth.this.token
+    token                  = ephemeral.aws_eks_cluster_auth.this.token
   }
 }
 provider "kubectl" {
   apply_retry_count      = 30
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  token                  = data.aws_eks_cluster_auth.this.token
+  token                  = ephemeral.aws_eks_cluster_auth.this.token
   load_config_file       = false
 }

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.8.0"
+  required_version = ">= 1.10.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### What does this PR do?

Fixes #1022 (or a first attempt...)

This PR replaces the `aws_eks_cluster_auth` data source in `infra/terraform/main.tf` with the AWS provider's ephemeral `aws_eks_cluster_auth` resource.

The EKS authentication token is used to configure the Kubernetes, Helm, and Kubectl providers. Using the ephemeral resource avoids persisting this short-lived authentication token in Terraform state or plan files.

Because Terraform ephemeral resources require Terraform 1.10 or later, this PR also updates the minimum Terraform version for `infra/terraform` from `>= 1.8.0` to `>= 1.10.0`.

### Motivation

The goal is to reduce the exposure of short-lived EKS authentication tokens in Terraform state and plan files, as explained in #1022.


### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I performed the following local validation:
- `terraform fmt -recursive infra/terraform`
- `terraform -chdir=infra/terraform init -backend=false`
- `terraform -chdir=infra/terraform validate`

`terraform validate` completed successfully. I did not run any other tests. Happy to do this if you believe this is valuable.