### PR TITLE
fix: drain nodes before terraform destroy to prevent degraded nodes during teardown

### DIFF
--- a/infra/terraform/cleanup.sh
+++ b/infra/terraform/cleanup.sh
@@ -60,6 +60,15 @@ if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
 fi
 
 
+# Drain nodes before terraform destroy. Terraform deletes VPC routes concurrently
+# with EKS cluster deletion, which can strand nodes without network connectivity.
+echo "Draining nodes before terraform destroy..."
+if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
+  echo "Deleting all nodepools..."
+  kubectl delete nodepool --all --wait=true --timeout=300s 2>/dev/null || echo "WARNING: No nodepools found or delete failed"
+  echo "Node drain complete"
+fi
+
 # List of Terraform modules to destroy in sequence
 targets=($(terraform state list | grep "kubectl_manifest\." | grep -v "kubectl_manifest.aws_load_balancer_controller"))
 


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in the cluster teardown sequence where VPC networking infrastructure (routes, NAT gateways) is destroyed while Karpenter nodes are still running, leaving them in a degraded state with no network connectivity.

Changes:
- `infra/terraform/cleanup.sh`: Before running `terraform destroy`, delete all Karpenter nodepools via `kubectl delete nodepool --all --wait=true`. This ensures all nodes are fully terminated before VPC teardown begins.

### Motivation

During cluster deletion, `terraform destroy` deletes VPC route table entries concurrently with EKS cluster deletion. The clusters take several minutes to fully delete, but routes are removed instantly — so nodes lose outbound connectivity to the control plane and go degraded in the interim.

The existing `wait = true` on `kubectl_manifest` resources blocks Terraform on *that resource's* deletion, but doesn't prevent VPC resources from being destroyed concurrently — they run in parallel since there's no dependency edge between them. The existing `-target=module.eks` step helps but runs after the kubectl_manifest phase, during which routes can already be deleted.

This fix deletes all nodepools *before* any `terraform destroy` starts, ensuring no nodes exist when VPC networking is torn down.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested end-to-end: deployed a cluster with 6 Karpenter nodes, ran the fixed cleanup, and verified no degraded nodes appeared during the teardown window. Not a new blueprint — single file change to `infra/terraform/cleanup.sh`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.