### PR TITLE
Server all Jupterhub traffic via one path

### DIFF
--- a/analytics/terraform/spark-k8s-operator/helm-values/jupyterhub-singleuser-values.yaml
+++ b/analytics/terraform/spark-k8s-operator/helm-values/jupyterhub-singleuser-values.yaml
@@ -4,6 +4,9 @@ hub:
       storage: 50Gi
       storageClassName: gp3
   authenticatePrometheus: false
+  config:
+    JupyterHub:
+      base_url: /jupyter/
 proxy:
   https:
     enabled: false


### PR DESCRIPTION
### What does this PR do?

Server all JupyterHub traffic via one path, to allow working seamlessly via workshop CloudFront