### PR TITLE
docs(website): Rename Spark workshop to Analytics on EKS

### DIFF
--- a/website/src/components/WorkshopBanner/WorkshopBanner.js
+++ b/website/src/components/WorkshopBanner/WorkshopBanner.js
@@ -29,14 +29,14 @@ const WorkshopBanner = () => {
 
        <div className={styles.workshopCards}>
          <a
-           href="https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=f26b398b-f6b5-458d-bbcc-ab6d18efa5a3&sc_channel=el"
+           href="https://events.eksworkshop.com/workshops/analytics/"
            target="_blank"
            rel="noopener noreferrer"
            className={styles.workshopCard}
          >
            <div className={styles.cardIcon}>⚡</div>
            <div className={styles.cardContent}>
-             <h3 className={styles.cardTitle}>Spark on EKS Workshop</h3>
+             <h3 className={styles.cardTitle}>Analytics on EKS Workshop</h3>
              <p className={styles.cardDescription}>
                Get hands-on with Amazon EKS and learn to run Apache Spark workloads at scale
              </p>


### PR DESCRIPTION
Update the featured workshop banner to point to the Analytics on EKS Workshop and link to the eksworkshop analytics workshop URL.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
