### PR TITLE
Tighten GH workflows permissions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get root directories
         id: dirs
@@ -50,6 +52,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
@@ -63,7 +67,7 @@ jobs:
 
       - name: Config Terraform plugin cache
         if: steps.changes.outputs.src== 'true'
-        run: mkdir --parents ${{ env.TF_PLUGIN_CACHE_DIR }}
+        run: mkdir --parents ${TF_PLUGIN_CACHE_DIR}
 
       - name: Restore Terraform Cache
         id: restore-cache
@@ -111,6 +115,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
@@ -121,7 +127,7 @@ jobs:
 
       - name: Config Terraform plugin cache
         if: steps.changes.outputs.src== 'true'
-        run: mkdir --parents ${{ env.TF_PLUGIN_CACHE_DIR }}
+        run: mkdir --parents ${TF_PLUGIN_CACHE_DIR}
 
       - name: Restore Terraform Cache
         id: restore-cache

--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -29,6 +29,8 @@ jobs:
         working-directory: website
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24


### PR DESCRIPTION
### What does this PR do?

- add `persist-credentials: false` for checkout actions
- address potential template injection: https://docs.zizmor.sh/audits/#template-injection
