### PR TITLE
fix(infra): validate managed_node_groups is map-shaped

### DIFF
--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -137,6 +137,11 @@ variable "managed_node_groups" {
   description = "Map of EKS managed node group definitions to create"
   type        = any
   default     = {}
+
+  validation {
+    condition     = can(keys(var.managed_node_groups))
+    error_message = "managed_node_groups must be a map/object where each key is a managed node group name and each value is that node group's configuration."
+  }
 }
 
 variable "enable_ingress_nginx" {


### PR DESCRIPTION
### What does this PR do?
An attempt to fix #1064. My apologies for the delay in following up.

Adds a validation block to the `managed_node_groups` variable in `infra/terraform/variables.tf` so non-map input (e.g. a string or list) fails at plan time with a clear message, instead of surfacing a cryptic error later when `merge(local.default_node_groups, var.managed_node_groups)` is evaluated in `eks.tf`.

Keeps `type = any` (matching the upstream `terraform-aws-eks` convention) rather than switching to `map(any)`.

### Motivation

`type = any` accepts invalid non-map values and defers the failure to the `merge()` call, where the error is hard to interpret. This change validates the top-level shape up front.

It is purely additive. As far as I know, any configuration that plans successfully today plans identically after this change.


### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes


Local validation I performed:

`terraform fmt -recursive infra/terraform`
`terraform -chdir=infra/terraform init -backend=false`
`terraform -chdir=infra/terraform validate`

`validate` succeeded.

`pre-commit run -a` passes all hooks except `terraform_tflint`, which exits 127 because tflint isn't installed locally; CI runs it with the binary present. If I should run additional tests, please let me know :-)
