### PR TITLE
feat: Add Strimzi Kafka lab using Auto Mode for Analytics on EKS workshop

### DIFF
--- a/analytics/kafka/README.md
+++ b/analytics/kafka/README.md
@@ -1,0 +1,147 @@
+# Kafka on EKS Auto Mode (Strimzi)
+
+A workshop-ready Apache Kafka cluster running on the Spark-on-EKS Auto Mode cluster, deployed with the [Strimzi](https://strimzi.io/) operator in **KRaft mode** (no ZooKeeper).
+
+The shipped configuration runs **3 controllers + 3 brokers** with rack-aware placement across availability zones, JMX Prometheus metrics, Cruise Control, and the Kafka Exporter — right-sized for a workshop.
+
+## How this fits the workshop
+
+This lab runs on the **same EKS Auto Mode cluster** created by `analytics/terraform/spark-k8s-operator/` — no separate infrastructure.
+
+The Terraform stack (with `enable_kafka = true`, the default) provisions two things up front:
+
+1. The **Strimzi Cluster Operator** (Helm), into the `kafka` namespace.
+2. A **dedicated Kafka NodePool** (`NodeGroupType=KafkaBroker`, On-Demand), isolated from the Spark NodePools.
+
+The **Kafka cluster itself is deployed by you during the lab** (`deploy-kafka.sh`), so broker nodes are only provisioned when you actually run it. This keeps idle cost off attendees who don't reach this lab.
+
+## Versions
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| Strimzi Cluster Operator | **1.1.0** | `v1` CRD API; supports Kafka 4.3.0 |
+| Apache Kafka | **4.3.0** (`metadataVersion 4.3-IV0`) | KRaft mode |
+| Client/CLI image | `quay.io/strimzi/kafka:latest-kafka-4.3.0` | must match the cluster version |
+
+> The Strimzi operator version is set by the `strimzi_operator_version` Terraform variable. If you change the Kafka `version` in `kafka-cluster.yaml`, make sure the operator version supports it and update the client image tag in the smoke test to match.
+
+## Prerequisites
+
+- The Spark-on-EKS workshop cluster is running and `kubectl` is configured:
+  ```sh
+  kubectl get nodes
+  ```
+- The Strimzi operator is installed (Terraform did this when `enable_kafka = true`):
+  ```sh
+  kubectl -n kafka rollout status deploy/strimzi-cluster-operator
+  ```
+- The default `gp3` StorageClass exists (created by the workshop Terraform):
+  ```sh
+  kubectl get storageclass
+  ```
+
+## Layout
+
+```
+analytics/kafka/
+├── README.md              # this file
+├── kafka-cluster.yaml     # Kafka CR + KafkaNodePools + JMX metrics ConfigMap
+├── deploy-kafka.sh        # applies the cluster and waits for Ready
+├── cleanup.sh             # tears down the in-lab Kafka cluster (not the operator)
+└── examples/
+    ├── hello-test-topic.yaml   # 3-partition, 3-replica test topic
+    └── kafka-rebalance.yaml    # Cruise Control rebalance demo
+```
+
+## Step 1: Deploy the Kafka cluster
+
+```sh
+./deploy-kafka.sh
+```
+
+This applies `kafka-cluster.yaml`, which contains:
+
+- A `Kafka` resource named `cluster` (KRaft mode, Kafka 4.3.0, plain + TLS internal listeners, rack-aware), pinned to the dedicated `KafkaBroker` NodePool with `karpenter.sh/do-not-disrupt` so brokers are not consolidated.
+- A `KafkaNodePool` named `controller` with **3 replicas** (1 CPU / 2-4 Gi, 20 Gi gp3 each).
+- A `KafkaNodePool` named `broker` with **3 replicas** (1-2 CPU / 6-8 Gi, 20 Gi gp3 each).
+- A `ConfigMap` with the JMX Prometheus exporter rules.
+- The `entityOperator`, `cruiseControl`, and `kafkaExporter` enabled.
+
+Bootstrap servers in the cluster:
+
+- Plain: `cluster-kafka-bootstrap.kafka.svc:9092`
+- TLS: `cluster-kafka-bootstrap.kafka.svc:9093`
+
+## Step 2: Smoke test
+
+Create a topic:
+
+```sh
+kubectl apply -f examples/hello-test-topic.yaml
+kubectl get kafkatopic -n kafka
+```
+
+Produce 3 messages:
+
+```sh
+kubectl run kafka-producer-test -n kafka --rm -i --restart=Never \
+  --image=quay.io/strimzi/kafka:latest-kafka-4.3.0 \
+  -- bash -c 'echo -e "msg-1\nmsg-2\nmsg-3" | /opt/kafka/bin/kafka-console-producer.sh \
+  --bootstrap-server cluster-kafka-bootstrap:9092 --topic hello-test'
+```
+
+Consume them back:
+
+```sh
+kubectl run kafka-consumer-test -n kafka --rm -i --restart=Never \
+  --image=quay.io/strimzi/kafka:latest-kafka-4.3.0 \
+  -- bash -c '/opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server cluster-kafka-bootstrap:9092 --topic hello-test \
+  --from-beginning --timeout-ms 10000'
+```
+
+Expected output:
+
+```console
+msg-1
+msg-2
+msg-3
+```
+
+## Optional: Cruise Control rebalance
+
+```sh
+kubectl apply -f examples/kafka-rebalance.yaml
+kubectl get kafkarebalance rebalance -n kafka -w
+```
+
+When it reaches `ProposalReady`, approve it:
+
+```sh
+kubectl annotate kafkarebalance rebalance -n kafka \
+  strimzi.io/rebalance=approve --overwrite
+```
+
+## Step 3: Tear down
+
+When you're done with the lab:
+
+```sh
+./cleanup.sh
+```
+
+This removes the Kafka topics/users/rebalances, the Kafka CR, the KafkaNodePools, and the broker/controller PVCs. It does **not** uninstall the Strimzi operator or the Kafka NodePool — those are managed by Terraform and removed by the workshop teardown (`terraform destroy`).
+
+## What you learned
+
+- How the Strimzi operator runs on an existing EKS Auto Mode cluster.
+- How to declare a KRaft-mode Kafka cluster with `KafkaNodePool` and pin it to a dedicated, On-Demand NodePool isolated from Spark.
+- How rack awareness + topology spread + pod anti-affinity spread brokers across AZs.
+- How to produce/consume from inside the cluster, and how Cruise Control rebalances partitions.
+
+## Customizing
+
+- **Broker/controller count**: `spec.replicas` on each `KafkaNodePool` (keep controllers odd for KRaft quorum).
+- **Resources**: `spec.resources` on each `KafkaNodePool`.
+- **Storage**: `spec.storage.volumes[0].size` (default 20 Gi, `class: gp3`).
+- **Kafka version**: `spec.kafka.version` / `metadataVersion` on the `Kafka` CR — keep it within the range the installed Strimzi operator supports, and update the client image tag in the smoke test.

--- a/analytics/kafka/cleanup.sh
+++ b/analytics/kafka/cleanup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tears down the in-lab Kafka cluster resources only.
+# The Strimzi Cluster Operator and the Kafka NodePool are managed by
+# Terraform (enable_kafka) and are removed by the workshop's cleanup.sh /
+# terraform destroy - do NOT uninstall the operator here.
+
+NAMESPACE=kafka
+
+echo "Deleting KafkaTopics, KafkaUsers, KafkaRebalances, the Kafka CR, and KafkaNodePools..."
+kubectl delete kafkarebalance --all -n "${NAMESPACE}" --ignore-not-found
+kubectl delete kafkatopic --all -n "${NAMESPACE}" --ignore-not-found
+kubectl delete kafkauser --all -n "${NAMESPACE}" --ignore-not-found
+kubectl delete kafka cluster -n "${NAMESPACE}" --ignore-not-found
+kubectl delete kafkanodepool --all -n "${NAMESPACE}" --ignore-not-found
+
+echo ""
+echo "Deleting kafka-metrics ConfigMap..."
+kubectl delete configmap kafka-metrics -n "${NAMESPACE}" --ignore-not-found
+
+echo ""
+echo "Waiting up to 3 minutes for broker/controller pods to terminate..."
+kubectl wait --for=delete pod -l strimzi.io/cluster=cluster -n "${NAMESPACE}" --timeout=180s || true
+
+echo ""
+echo "Deleting persistent volume claims (broker + controller data)..."
+kubectl delete pvc -l strimzi.io/cluster=cluster -n "${NAMESPACE}" --ignore-not-found
+
+echo ""
+echo "Kafka cluster resources removed. The Strimzi operator and Kafka NodePool"
+echo "remain (managed by Terraform); they are removed by the workshop teardown."

--- a/analytics/kafka/deploy-kafka.sh
+++ b/analytics/kafka/deploy-kafka.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploys the Kafka cluster onto the Spark-on-EKS Auto Mode cluster.
+# The Strimzi Cluster Operator is already installed by Terraform
+# (enable_kafka = true) into the "kafka" namespace, and a dedicated
+# Kafka NodePool (NodeGroupType=KafkaBroker, On-Demand) is provisioned.
+# This script only applies the Kafka + KafkaNodePool custom resources.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE=kafka
+
+echo "Verifying the Strimzi Cluster Operator is running in namespace '${NAMESPACE}'..."
+if ! kubectl -n "${NAMESPACE}" rollout status deploy/strimzi-cluster-operator --timeout=120s; then
+  echo "ERROR: Strimzi operator not found/ready in '${NAMESPACE}'."
+  echo "Ensure the workshop was deployed with enable_kafka = true (Terraform installs the operator)."
+  exit 1
+fi
+
+echo ""
+echo "Applying Kafka cluster + KafkaNodePools (controller, broker)..."
+kubectl apply -f "${SCRIPT_DIR}/kafka-cluster.yaml"
+
+echo ""
+echo "Waiting for the Kafka cluster to become Ready (3-5 minutes typical while nodes provision)..."
+kubectl wait --for=condition=Ready kafka/cluster -n "${NAMESPACE}" --timeout=600s
+
+echo ""
+kubectl get kafka,kafkanodepool -n "${NAMESPACE}"
+echo ""
+kubectl get pods -n "${NAMESPACE}"
+echo ""
+echo "Bootstrap servers:"
+kubectl get kafka cluster -n "${NAMESPACE}" -o jsonpath='{range .status.listeners[*]} {.name}: {.bootstrapServers}{"\n"}{end}'

--- a/analytics/kafka/examples/hello-test-topic.yaml
+++ b/analytics/kafka/examples/hello-test-topic.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: hello-test
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: cluster
+spec:
+  partitions: 3
+  replicas: 3
+  config:
+    retention.ms: 3600000

--- a/analytics/kafka/examples/kafka-rebalance.yaml
+++ b/analytics/kafka/examples/kafka-rebalance.yaml
@@ -6,8 +6,15 @@ metadata:
   labels:
     strimzi.io/cluster: cluster
 spec:
+  # The workshop cluster commonly spans 2 Availability Zones (racks) while topics
+  # use replication factor 3. The strict RackAwareGoal requires racks >= RF and
+  # fails in that case, so we use the soft RackAwareDistributionGoal (best-effort
+  # rack spread) instead. Because RackAwareGoal is a configured hard goal and we
+  # are intentionally not enforcing it, skipHardGoalCheck must be true.
+  skipHardGoalCheck: true
   goals:
-    - RackAwareGoal
+    - RackAwareDistributionGoal
+    - MinTopicLeadersPerBrokerGoal
     - ReplicaCapacityGoal
     - DiskCapacityGoal
     - NetworkInboundCapacityGoal
@@ -22,4 +29,3 @@ spec:
     - TopicReplicaDistributionGoal
     - LeaderReplicaDistributionGoal
     - LeaderBytesInDistributionGoal
-    - PreferredLeaderElectionGoal

--- a/analytics/kafka/examples/kafka-rebalance.yaml
+++ b/analytics/kafka/examples/kafka-rebalance.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaRebalance
+metadata:
+  name: rebalance
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: cluster
+spec:
+  goals:
+    - RackAwareGoal
+    - ReplicaCapacityGoal
+    - DiskCapacityGoal
+    - NetworkInboundCapacityGoal
+    - NetworkOutboundCapacityGoal
+    - CpuCapacityGoal
+    - ReplicaDistributionGoal
+    - PotentialNwOutGoal
+    - DiskUsageDistributionGoal
+    - NetworkInboundUsageDistributionGoal
+    - NetworkOutboundUsageDistributionGoal
+    - CpuUsageDistributionGoal
+    - TopicReplicaDistributionGoal
+    - LeaderReplicaDistributionGoal
+    - LeaderBytesInDistributionGoal
+    - PreferredLeaderElectionGoal

--- a/analytics/kafka/kafka-cluster.yaml
+++ b/analytics/kafka/kafka-cluster.yaml
@@ -1,0 +1,179 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: cluster
+  namespace: kafka
+  annotations:
+    strimzi.io/kraft: enabled
+    strimzi.io/node-pools: enabled
+spec:
+  kafka:
+    version: 4.3.0
+    metadataVersion: 4.3-IV0
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+    jvmOptions:
+      "-Xmx": "3g"
+      "-Xms": "2g"
+    template:
+      pod:
+        # Pin Kafka broker/controller pods to the dedicated Kafka NodePool
+        # (NodeGroupType=KafkaBroker, On-Demand) provisioned by Terraform.
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: NodeGroupType
+                      operator: In
+                      values:
+                        - KafkaBroker
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: "strimzi.io/pool-name"
+                      operator: In
+                      values:
+                        - broker
+                        - controller
+                topologyKey: "kubernetes.io/hostname"
+        topologySpreadConstraints:
+          - labelSelector:
+              matchExpressions:
+                - key: "strimzi.io/pool-name"
+                  operator: In
+                  values:
+                    - broker
+                    - controller
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+        # Prevent EKS Auto Mode / Karpenter from consolidating stateful Kafka nodes
+        metadata:
+          annotations:
+            karpenter.sh/do-not-disrupt: "true"
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics
+          key: kafka-metrics-config.yml
+    rack:
+      topologyKey: topology.kubernetes.io/zone
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  cruiseControl: {}
+  kafkaExporter:
+    topicRegex: ".*"
+    groupRegex: ".*"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kafka-metrics
+  namespace: kafka
+  labels:
+    app: strimzi
+data:
+  kafka-metrics-config.yml: |
+    lowercaseOutputName: true
+    rules:
+      - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+        name: kafka_server_$1_$2
+        type: GAUGE
+        labels:
+          clientId: "$3"
+          topic: "$4"
+          partition: "$5"
+      - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
+        name: kafka_server_$1_$2
+        type: GAUGE
+        labels:
+          clientId: "$3"
+          broker: "$4:$5"
+      - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+        name: kafka_$1_$2_$3_total
+        type: COUNTER
+      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
+        name: kafka_$1_$2_$3
+        type: GAUGE
+      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
+        name: kafka_$1_$2_$3_count
+        type: COUNTER
+    cruise-control-config.yml: |
+      lowercaseOutputName: true
+      rules:
+        - pattern: kafka.cruisecontrol<name=(.+)><>(\w+)
+          name: kafka_cruisecontrol_$1_$2
+          type: GAUGE
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: controller
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  resources:
+    requests:
+      memory: 2Gi
+      cpu: "1"
+    limits:
+      memory: 4Gi
+      cpu: "1"
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        class: gp3
+        kraftMetadata: shared
+        deleteClaim: true
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: broker
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  resources:
+    requests:
+      memory: 6Gi
+      cpu: "1"
+    limits:
+      memory: 8Gi
+      cpu: "2"
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        class: gp3
+        kraftMetadata: shared
+        deleteClaim: true

--- a/analytics/terraform/spark-k8s-operator/kafka.tf
+++ b/analytics/terraform/spark-k8s-operator/kafka.tf
@@ -1,0 +1,28 @@
+#---------------------------------------------------------------
+# Apache Kafka on EKS - Strimzi Cluster Operator
+#---------------------------------------------------------------
+# Installs the Strimzi Cluster Operator only. The Kafka cluster
+# (Kafka + KafkaNodePool custom resources) is deployed by the
+# participant during the lab from analytics/kafka/kafka-cluster.yaml,
+# so broker nodes are only provisioned when the lab is actually run.
+#
+# Strimzi 1.1.0 supports Apache Kafka 4.3.0 and only the v1 CRD API.
+# Reference: https://strimzi.io/
+#---------------------------------------------------------------
+
+resource "helm_release" "strimzi_kafka_operator" {
+  count = var.enable_kafka ? 1 : 0
+
+  name             = "strimzi-kafka-operator"
+  namespace        = "kafka"
+  create_namespace = true
+  repository       = "https://strimzi.io/charts/"
+  chart            = "strimzi-kafka-operator"
+  version          = var.strimzi_operator_version
+  timeout          = 600
+
+  # By default the operator watches the namespace it is deployed into ("kafka"),
+  # which is where the lab deploys the Kafka custom resource. No extra config needed.
+
+  depends_on = [module.eks, kubectl_manifest.auto_mode_nodepools]
+}

--- a/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-kafka.yaml
+++ b/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-kafka.yaml
@@ -1,0 +1,61 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: kafka
+spec:
+  template:
+    metadata:
+      labels:
+        node.kubernetes.io/workload-type: kafka
+        node.kubernetes.io/instance-category: memory
+        node.kubernetes.io/arch: amd64
+        # Kafka brokers/controllers target this pool via nodeSelector in the Kafka CR
+        NodeGroupType: "KafkaBroker"
+
+    spec:
+      nodeClassRef:
+        group: eks.amazonaws.com
+        kind: NodeClass
+        name: ebs-gp3-1000gi-6000iops-1000tp
+
+      requirements:
+        # Kafka is stateful - keep brokers on On-Demand to avoid Spot interruptions
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+
+        # Architecture - x86 only
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+
+        # General purpose (m) and memory optimized (r) families suit Kafka
+        - key: eks.amazonaws.com/instance-category
+          operator: In
+          values: ["m", "r"]
+
+        # Instance sizes - right-sized for a workshop-scale Kafka cluster
+        - key: eks.amazonaws.com/instance-size
+          operator: In
+          values: ["large", "xlarge", "2xlarge", "4xlarge"]
+
+        # Nitro system for better performance
+        - key: eks.amazonaws.com/instance-hypervisor
+          operator: In
+          values: ["nitro"]
+
+        # Generation 4+
+        - key: eks.amazonaws.com/instance-generation
+          operator: Gt
+          values: ["4"]
+
+  # Resource limits for budget control
+  limits:
+    cpu: "200"
+    memory: "800Gi"
+
+  # Node lifecycle - only consolidate genuinely empty nodes so stateful
+  # Kafka brokers are not disrupted while the cluster is running.
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: "1h"

--- a/analytics/terraform/spark-k8s-operator/outputs.tf
+++ b/analytics/terraform/spark-k8s-operator/outputs.tf
@@ -116,3 +116,17 @@ output "celeborn_master_endpoint" {
   description = "Celeborn master endpoint for Spark shuffle configuration"
   value       = var.enable_celeborn ? "celeborn-master-0.celeborn-master-svc.celeborn.svc.cluster.local:9097" : null
 }
+
+################################################################################
+# Kafka Configuration
+################################################################################
+
+output "kafka_bootstrap_plain" {
+  description = "Kafka PLAINTEXT bootstrap servers (internal). Available after the Kafka cluster is deployed in the lab."
+  value       = var.enable_kafka ? "cluster-kafka-bootstrap.kafka.svc:9092" : null
+}
+
+output "kafka_bootstrap_tls" {
+  description = "Kafka TLS bootstrap servers (internal). Available after the Kafka cluster is deployed in the lab."
+  value       = var.enable_kafka ? "cluster-kafka-bootstrap.kafka.svc:9093" : null
+}

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -109,3 +109,15 @@ variable "enable_celeborn" {
   type        = bool
   default     = true
 }
+
+variable "enable_kafka" {
+  description = "Enable Apache Kafka on EKS. Installs the Strimzi Cluster Operator and a dedicated Kafka NodePool; the Kafka cluster itself is deployed by the participant during the lab."
+  type        = bool
+  default     = true
+}
+
+variable "strimzi_operator_version" {
+  description = "Strimzi Kafka Operator Helm chart version. Must support the Kafka version declared in the Kafka custom resource (Strimzi 1.1.0 supports Apache Kafka 4.3.0)."
+  type        = string
+  default     = "1.1.0"
+}


### PR DESCRIPTION
### What does this PR do?
Adds an interactive Apache Kafka lab to the Spark-on-EKS workshop, running   on the **same EKS Auto Mode cluster** as the Spark labs via the Strimzi operator (KRaft mode).
  - `enable_kafka` Terraform toggle installs the Strimzi Cluster Operator (Helm) and a dedicated **On-Demand** Kafka NodePool (`NodeGroupType=KafkaBroker`), isolated from the Spark (Spot) NodePools. The Kafka cluster is deployed
  in-lab, so broker nodes are only provisioned when the lab is run.
  - Pins **Strimzi 1.1.0 / Kafka 4.3.0** (`v1` CRD API) and aligns the client image to `latest-kafka-4.3.0`.
  - Right-sized cluster: 3 brokers + 3 controllers, 20Gi gp3, rack-aware, topology spread, `do-not-disrupt`, JMX metrics, Cruise Control, Kafka Exporter.
  - Adds `analytics/kafka/` (cluster manifest, deploy/cleanup scripts, examples, README) and `kafka_bootstrap_plain/tls` outputs.
  
  This supersedes #1123 (which used a script-driven install); this version wires it through the Terraform toggle and fixes
  the version consistency.
  
  ### Motivation
  
  Extends the Analytics on EKS workshop with a streaming tier alongside the batch Spark labs.
  
  ### More
  
  - [x] Tested end-to-end on a live `spark-workshop` cluster: `terraform apply` → operator + NodePool created →
  Kafka 4.3.0 cluster Ready (3 brokers + 3 controllers across AZs) → produce/consume verified.
  - [x] `terraform validate` passes; manifests validated.
  - [ ] Docs (workshop lab page): follow-up in the workshop content repo.