### PR TITLE
feat(clickhouse): Terraform-managed Altinity operator, dedicated Node…

### DIFF
--- a/analytics/clickhouse/README.md
+++ b/analytics/clickhouse/README.md
@@ -1,0 +1,216 @@
+# ClickHouse on EKS Auto Mode
+
+An in-workshop [ClickHouse](https://clickhouse.com/) cluster that sits alongside the Spark labs — and, when deployed together, the Kafka lab — on the **same** EKS Auto Mode cluster created by `analytics/terraform/spark-k8s-operator/`. No extra VPC, no separate cluster, no side install.
+
+Under the hood: the [Altinity Kubernetes Operator for ClickHouse](https://github.com/Altinity/clickhouse-operator) manages a `ClickHouseInstallation` (1 shard × 3 replicas) coordinated by a `ClickHouseKeeperInstallation` (3 members) — no ZooKeeper anywhere in the stack. Replicas and Keeper members are spread across the workshop's three availability zones with hard pod anti-affinity.
+
+## Architecture at a glance
+
+Four design decisions shape this lab. Understanding them up-front makes the rest of the manifests obvious.
+
+### 1. ClickHouse runs on a dedicated NodePool, kept away from Spark and Kafka
+
+ClickHouse replicas are stateful — each one owns a `ReplicatedMergeTree` shard's local part files on its own EBS volume, plus a running merge schedule and page cache. Spark executors are stateless and typically run on Spot; a Spot reclamation event would take a replica with it. Kafka brokers are similarly stateful and get their own pool for the same reason.
+
+The workshop's Terraform creates a **dedicated Karpenter `NodePool`** for ClickHouse (see `analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-clickhouse.yaml`) that runs **On-Demand only** and carries a `workload=clickhouse:NoSchedule` taint. The CHI and Keeper CRs in this folder carry the matching toleration and nodeSelector. Nothing else in the workshop cluster tolerates that taint, so nothing else lands on those nodes.
+
+The routing uses **three complementary pieces** on top of Karpenter's usual scheduling:
+
+| Direction | Mechanism | Effect |
+|---|---|---|
+| Non-ClickHouse pods **off** the ClickHouse pool | `workload=clickhouse:NoSchedule` taint on the NodePool | Scheduler refuses to place them |
+| ClickHouse + Keeper pods **allowed on** the pool | Matching toleration on the pod template | Scheduler accepts placement |
+| ClickHouse + Keeper pods **routed to** the pool | `workload: clickhouse` label on the pool + matching `nodeSelector` on the pod | Karpenter provisions from this pool, not from a higher-weighted general-purpose pool |
+
+The nodeSelector matters as much as the taint. Without it, when a ClickHouse replica becomes pending, Karpenter picks the highest-weight *feasible* NodePool — since `general-purpose` weight=50 and our ClickHouse pool has no weight, ClickHouse would land on general-purpose and the dedicated pool would sit empty. Taint + toleration alone doesn't route.
+
+### 2. Replicas are marked `karpenter.sh/do-not-disrupt`
+
+Voluntary consolidation is a good thing for stateless workloads. For a ClickHouse replica in the middle of a merge, or a Keeper member in the middle of a raft term, it isn't.
+
+If Karpenter decides a ClickHouse node is underutilised and drains it, an in-flight merge is killed and the replica restarts on a new node with a fresh PVC attach cycle. During that gap, `ReplicatedMergeTree` writes on the other replicas queue in Keeper until this replica catches up. On the Keeper side, disrupting a member forces a raft leader re-election that briefly pauses coordination for every replica.
+
+The pod annotation `karpenter.sh/do-not-disrupt: "true"` on both the ClickHouse and Keeper pod templates tells Karpenter to leave those nodes alone until they're truly empty. You still get expiry, drift, and forced-disruption paths; you just don't get voluntary bin-packing.
+
+### 3. Rack awareness needs `az_count >= replicasCount`
+
+This cluster deploys with `replicasCount: 3` for ClickHouse and `replicasCount: 3` for Keeper. Hard pod anti-affinity keyed on `topology.kubernetes.io/zone` requires **at least as many failure domains (AZs) as replicas**.
+
+The workshop's Terraform ships `az_count = 3` for exactly this reason. If you drop to 2 AZs, the third replica of both the CH cluster and Keeper will stay `Pending` forever — Karpenter cannot provision a node in a third zone that doesn't exist. Either bump `az_count` back to 3, or relax the anti-affinity in the pod templates from `requiredDuringSchedulingIgnoredDuringExecution` to `preferredDuringSchedulingIgnoredDuringExecution` and accept a weaker HA story.
+
+### 4. ClickHouse still needs a Keeper — just not ZooKeeper
+
+`ReplicatedMergeTree` is coordinated through a Zookeeper-wire-protocol service. Historically that had to be an actual ZooKeeper ensemble (JVM, external, operationally distinct). Since ClickHouse 21.3 there's a first-party replacement called **ClickHouse Keeper** — same protocol on port 2181, written in C++, no JVM. Deploying Keeper alongside ClickHouse pods gives you the same coordination guarantees without a separate JVM stack to run.
+
+The CHI in `cluster.yaml` still uses a `zookeeper.nodes` config field for backwards compatibility with older configs, but the daemon it points at is Keeper. Same shape, different implementation — analogous to Kafka's move from ZooKeeper to KRaft.
+
+**Watch out for the naming.** The Altinity operator names the Service that fronts each Keeper installation as `<CR-name>-<cluster-name>`. Both our CR name and inner cluster name are `keeper`, so the actual Service is `keeper-keeper.clickhouse.svc.cluster.local`, not `keeper.clickhouse.svc.cluster.local`. The CHI's `zookeeper.nodes[0].host` reflects that.
+
+## Prerequisites
+
+The Spark-on-EKS workshop cluster is up (`analytics/terraform/spark-k8s-operator/` deployed) and `kubectl` targets it:
+
+```sh
+kubectl get nodes -o wide | head
+kubectl get storageclass       # expect: gp3 (default), clickhouse-gp3, kafka-gp3 (if the Kafka lab is enabled)
+```
+
+## Files
+
+```
+analytics/clickhouse/
+├── README.md
+├── deploy-clickhouse.sh   # applies keeper.yaml + cluster.yaml, waits for both CRs to reach status=Completed
+├── cleanup.sh             # removes the CHI + Keeper CRs and their PVCs (Terraform owns the operator)
+├── cluster.yaml           # ClickHouseInstallation (1 shard x 3 replicas)
+└── keeper.yaml            # ClickHouseKeeperInstallation (3 members)
+```
+
+The Altinity operator itself is installed exclusively by the workshop's Terraform (see `analytics/terraform/spark-k8s-operator/clickhouse-operator.tf`). There is no bash-wrapper install script — helm is invoked from Terraform's `helm_release` resource, so operator version and lifecycle are managed alongside the rest of the workshop infrastructure.
+
+## Deploy
+
+### Confirm the operator is running
+
+The Altinity ClickHouse Operator is installed by the workshop's Terraform when `enable_clickhouse_lab = true` (the default). Confirm it's ready before you apply the CRs:
+
+```sh
+kubectl -n clickhouse rollout status deploy/clickhouse-operator-altinity-clickhouse-operator
+kubectl get storageclass clickhouse-gp3
+```
+
+Both should be present. If either is missing, re-apply Terraform with `enable_clickhouse_lab = true` (the default) — the operator, StorageClass, and NodePool all come from that single toggle.
+
+### Apply the ClickHouse + Keeper resources
+
+```sh
+./deploy-clickhouse.sh
+```
+
+The Altinity operator turns `keeper.yaml` and `cluster.yaml` into:
+
+- **3× Keeper pods** (`chk-keeper-keeper-0-{0,1,2}-0`), each `500m CPU / 1 GiB` request (`1 / 2 GiB` limits), `10 GiB` gp3
+- **3× ClickHouse replica pods** (`chi-cluster-replicated-0-{0,1,2}-0`), each `1 CPU / 4 GiB` request (`4 / 16 GiB` limits), `50 GiB` gp3
+- **1× aggregated headless Service** per CR (`keeper-keeper`, `clickhouse-cluster`) plus one per replica for stable direct-addressing
+
+Karpenter provisions 3 On-Demand instances spread across the three workshop AZs — typically `m5a.2xlarge` or `r5a.2xlarge` under the shipped requirements. First deploy takes ~3-6 minutes end-to-end. When both CRs reach `status=Completed`:
+
+```sh
+kubectl get chi,chk -n clickhouse
+kubectl get pods -n clickhouse -o wide
+kubectl get nodeclaims -l karpenter.sh/nodepool=clickhouse
+```
+
+In-cluster endpoints:
+
+- **HTTP (aggregated across replicas):** `http://clickhouse-cluster.clickhouse.svc:8123`
+- **Native TCP (aggregated):** `clickhouse-cluster.clickhouse.svc:9000`
+- **Per-replica direct:** `chi-cluster-replicated-0-<n>.clickhouse.svc:9000`
+
+## Verify
+
+Create a `ReplicatedMergeTree` table across the cluster and prove replication:
+
+```sh
+kubectl -n clickhouse exec -i chi-cluster-replicated-0-0-0 -c clickhouse -- \
+  clickhouse-client --multiline --multiquery <<'SQL'
+CREATE TABLE IF NOT EXISTS events ON CLUSTER 'replicated' (
+    ts       DateTime DEFAULT now(),
+    user_id  UInt64,
+    action   String
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/events', '{replica}')
+ORDER BY (ts, user_id);
+SQL
+```
+
+The `{shard}` and `{replica}` macros are substituted per pod so each replica writes to the correct z-node in Keeper. Insert on one replica:
+
+```sh
+kubectl -n clickhouse exec -i chi-cluster-replicated-0-0-0 -c clickhouse -- \
+  clickhouse-client --query "INSERT INTO events(user_id, action) VALUES (1,'login'),(2,'checkout'),(3,'view');"
+```
+
+Read from a different replica — Keeper propagates within seconds:
+
+```sh
+for i in 0 1 2; do
+  kubectl -n clickhouse exec chi-cluster-replicated-0-${i}-0 -c clickhouse -- \
+    clickhouse-client --query "SELECT hostName() AS replica, count() AS rows FROM events;"
+done
+```
+
+Expected:
+
+```
+chi-cluster-replicated-0-0-0	3
+chi-cluster-replicated-0-1-0	3
+chi-cluster-replicated-0-2-0	3
+```
+
+## Cleanup
+
+```sh
+./cleanup.sh
+```
+
+Removes the CHI, Keeper CR, and PVCs. The Altinity operator, the `clickhouse-gp3` StorageClass, the dedicated ClickHouse NodePool, and the `clickhouse` namespace stay in place — those are owned by Terraform and go away with `terraform destroy` when you tear down the workshop.
+
+Because the StorageClass uses `reclaimPolicy: Retain`, deleting the PVCs does not delete the underlying EBS volumes on its own — the volumes stay in an available state until Terraform cleans them up during `destroy`. That's the trade-off for making the workshop safe against accidental `kubectl delete pvc`.
+
+## Storage tiers
+
+**ClickHouse mixes throughput-bound merges with IOPS-bound query reads.** Background compactions rewrite gigabytes of parts (throughput-heavy). Selective queries read random small slices of parts and index files (IOPS-heavy). Provisioning a single volume to satisfy both is the right call for the workshop shape.
+
+ClickHouse and Keeper PVs bind to the `clickhouse-gp3` StorageClass created by Terraform. That's a **gp3 volume with 16 000 IOPS and 1000 MiB/s throughput per volume** — the gp3 ceiling for both. `reclaimPolicy: Retain` and `allowVolumeExpansion: true` are set for the reasons above.
+
+Two ways to change the storage tier for a heavier workload:
+
+| Tier | Latency | Peak / volume | Best for | Trade-off |
+|---|---|---|---|---|
+| **`clickhouse-gp3` (default)** | ~1 ms | 16 000 IOPS / 1000 MiB/s | Workshop, dev, small–mid prod | Hits gp3 ceiling — can't push further per volume |
+| **`io2` Block Express** | sub-ms | 256 000 IOPS / 4000 MiB/s | Latency-sensitive prod, heavy concurrent workloads | ~10× the cost of gp3 — benchmark against gp3-at-ceiling first |
+| **Local NVMe** (`i8g`, `i4i`) | sub-ms | ~1M+ IOPS | Absolute performance ceiling for hot working sets | Node loss = data loss on that replica — safe with 3 replicas + Keeper but adds ops complexity around Karpenter drift replacement |
+
+To switch to `io2 Block Express`, create an alternate StorageClass and update the `storageClassName` field in `cluster.yaml` and `keeper.yaml`:
+
+```yaml
+# analytics/terraform/spark-k8s-operator/manifests/automode/storageclass-clickhouse-io2.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata: { name: clickhouse-io2 }
+provisioner: ebs.csi.eks.amazonaws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+parameters:
+  type: io2
+  iops: "50000"
+  fsType: xfs
+  encrypted: "true"
+```
+
+## Sizing
+
+Rules of thumb for a production-shape ClickHouse cluster, worth knowing before you touch the resource requests in `cluster.yaml`:
+
+- **Memory is the primary lever for query performance.** ClickHouse holds hot indexes and page cache in RAM. `r` (memory-optimised) is the natural family; the workshop keeps `m` (general-purpose) in the mix as a fallback for cost and availability.
+- **CPU headroom during merges.** Compaction is CPU-bound in bursts. Sizing for `4 CPU / 16 GiB` limits per replica works for the workshop; production usually goes 16-64 vCPU / 128-512 GiB per replica.
+- **Local NVMe (`i8g` / `i4i`) is a real step-up.** AWS lists ClickHouse as a target workload for `i8g`. The trade-off: instance-store data dies with the node, so you *must* have 2+ replicas per shard on separate nodes (which this lab already does). Karpenter drift replacements become full replica resyncs from peers.
+- **Scale out for shards, scale up for replicas.** Adding shards is horizontal — more data + parallel query fan-out. Adding replicas is vertical HA + read concurrency. Match the topology to whether your bottleneck is data volume or query concurrency.
+- **Instance-EBS bandwidth is the ceiling on gp3.** `m5a.2xlarge → m5a.4xlarge` gives *no* per-volume throughput gain at default gp3 settings because the volume caps out at 1000 MiB/s. That's why this lab ships gp3 provisioned at 1000 MiB/s — matches the instance's EBS baseline on 4xlarge and up.
+
+CloudWatch metrics worth alerting on for a production-shape replica:
+
+- `VolumeReadOps` / `VolumeWriteOps` and `VolumeThroughputPercentage` (gp3 headroom)
+- EC2 `EBSIOBalance%` and `EBSByteBalance%` — instance-level EBS credits
+- ClickHouse system tables: `system.merges` (in-flight compactions), `system.replication_queue` (replication lag), `system.parts` (part count per table — too many is a sign of merge starvation)
+
+## Extending
+
+- **Shard count** — raise `shardsCount` in `cluster.yaml`. Each shard is an independent ReplicatedMergeTree instance; queries fan out across shards and results merge on the coordinator. Combine with a `Distributed` engine table for cluster-wide reads.
+- **Replica count** — raise `replicasCount`. Requires `az_count >= replicasCount` because of the AZ-level hard anti-affinity — bump both together for larger HA topologies, or relax the anti-affinity to `preferredDuringScheduling`.
+- **Instance family** — the ClickHouse NodePool restricts to `m`/`r`, Gen 5+, `2xlarge..8xlarge`. If you need lowest-latency storage, look at `i8g` (Graviton4 + NVMe) or `i4i` (x86 + NVMe) — but note the instance-store trade-off flagged in the storage tiers section.
+- **ClickHouse version** — bump the `image:` in `cluster.yaml`. The Altinity operator supports rolling upgrades of the CH image without touching the CR schema. Coordinate with the Keeper image version — both are pinned in this lab so a bump changes only the ClickHouse side.
+- **Add a natural-language query layer.** The aggregated HTTP endpoint at `http://clickhouse-cluster.clickhouse.svc:8123` accepts SELECT queries over plain HTTP. Point an LLM (Bedrock, OpenAI, Anthropic) at it with `system.tables` and `system.columns` as tool context, and you have an agentic query interface over the workshop's analytical data.
+- **Disable the operator install** — set `enable_clickhouse_lab = false` in Terraform. The Altinity operator and `clickhouse-gp3` StorageClass are no longer created; the ClickHouse Karpenter NodePool remains (harmless — nothing tolerates its taint).

--- a/analytics/clickhouse/cleanup.sh
+++ b/analytics/clickhouse/cleanup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tears down the in-lab ClickHouse cluster only.
+# The Altinity operator, the clickhouse-gp3 StorageClass, the dedicated
+# ClickHouse NodePool, and the clickhouse namespace are all managed by
+# Terraform (enable_clickhouse_lab = true) and are removed by
+# `terraform destroy`. This script does NOT touch them.
+
+NAMESPACE=clickhouse
+
+echo "Deleting ClickHouseInstallation (drains replicas gracefully)..."
+kubectl delete chi cluster -n "${NAMESPACE}" --ignore-not-found
+
+echo ""
+echo "Deleting ClickHouseKeeperInstallation..."
+kubectl delete chk keeper -n "${NAMESPACE}" --ignore-not-found
+
+echo ""
+echo "Waiting up to 3 minutes for CH + Keeper pods to terminate..."
+kubectl -n "${NAMESPACE}" wait --for=delete pod \
+  -l 'clickhouse.altinity.com/chi=cluster' --timeout=180s || true
+kubectl -n "${NAMESPACE}" wait --for=delete pod \
+  -l 'clickhouse-keeper.altinity.com/chk=keeper' --timeout=180s || true
+
+echo ""
+echo "Deleting persistent volume claims (ClickHouse + Keeper data)..."
+# Retain-policy PVs survive PVC deletion; the underlying EBS volumes have
+# to be released separately if you want to stop paying for them. The
+# workshop's `terraform destroy` handles that when it removes the
+# StorageClass and namespace at the end.
+kubectl -n "${NAMESPACE}" delete pvc --all --ignore-not-found
+
+echo ""
+echo "ClickHouse cluster resources removed. The Altinity operator,"
+echo "clickhouse-gp3 StorageClass, and Karpenter NodePool remain"
+echo "(Terraform-managed). Run 'terraform destroy' in"
+echo "analytics/terraform/spark-k8s-operator/ to tear down the whole workshop."

--- a/analytics/clickhouse/cluster.yaml
+++ b/analytics/clickhouse/cluster.yaml
@@ -1,0 +1,87 @@
+---
+# ---------------------------------------------------------------------
+# Replicated ClickHouse cluster — 1 shard x 3 replicas
+# ---------------------------------------------------------------------
+# The minimum viable HA topology: one shard with three replicas of the
+# same data spread across three AZs. One AZ failure takes down exactly
+# one replica; the other two keep serving reads and writes via
+# ReplicatedMergeTree replication coordinated through ClickHouse Keeper.
+#
+# The `zookeeper.nodes` field name is legacy — the daemon on the other
+# end of the wire is ClickHouse Keeper (C++, no JVM), speaking the
+# ZooKeeper wire protocol on port 2181 for backwards compatibility with
+# older configs. There is no actual ZooKeeper in this cluster.
+#
+# Pod placement mirrors the Keeper CR: nodeSelector pins to the
+# dedicated NodePool, AZ-level podAntiAffinity ensures one CH replica
+# per AZ, and the `karpenter.sh/do-not-disrupt` annotation defends
+# against consolidation-during-merge.
+# ---------------------------------------------------------------------
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseInstallation"
+metadata:
+  name: cluster
+  namespace: clickhouse
+spec:
+  configuration:
+    # Point the CH cluster at the Keeper Service the operator created
+    # for the ClickHouseKeeperInstallation named "keeper". Altinity's
+    # naming pattern is `<CR-name>-<cluster-name>` — with both named
+    # "keeper", the resulting Service is `keeper-keeper`.
+    zookeeper:
+      nodes:
+        - host: keeper-keeper.clickhouse.svc.cluster.local
+          port: 2181
+    clusters:
+      - name: replicated
+        layout:
+          shardsCount: 1
+          replicasCount: 3
+  defaults:
+    templates:
+      podTemplate: clickhouse-pod
+      dataVolumeClaimTemplate: clickhouse-data
+  templates:
+    podTemplates:
+      - name: clickhouse-pod
+        metadata:
+          annotations:
+            # Merges and long-running queries would be killed
+            # mid-flight if Karpenter voluntarily consolidated a
+            # ClickHouse node. Only drift / expiry / forced disruption
+            # should touch these nodes.
+            karpenter.sh/do-not-disrupt: "true"
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      clickhouse.altinity.com/chi: cluster
+                  topologyKey: topology.kubernetes.io/zone
+          nodeSelector:
+            workload: clickhouse
+          tolerations:
+            - key: workload
+              operator: Equal
+              value: clickhouse
+              effect: NoSchedule
+          containers:
+            - name: clickhouse
+              image: clickhouse/clickhouse-server:24.8
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: 4Gi
+                limits:
+                  cpu: "4"
+                  memory: 16Gi
+    volumeClaimTemplates:
+      - name: clickhouse-data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: clickhouse-gp3
+          resources:
+            requests:
+              storage: 50Gi

--- a/analytics/clickhouse/deploy-clickhouse.sh
+++ b/analytics/clickhouse/deploy-clickhouse.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploys the ClickHouseKeeperInstallation + ClickHouseInstallation onto
+# the workshop's EKS cluster. Prerequisites are managed by Terraform
+# when enable_clickhouse_lab = true:
+#   - Altinity ClickHouse Operator running in the "clickhouse" namespace
+#   - "clickhouse-gp3" StorageClass
+#   - Dedicated ClickHouse Karpenter NodePool with
+#     workload=clickhouse:NoSchedule taint
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE=clickhouse
+
+echo "Preflight: verifying operator, storageclass, and NodePool are in place..."
+if ! kubectl -n "${NAMESPACE}" rollout status deploy/clickhouse-operator-altinity-clickhouse-operator --timeout=120s; then
+  echo "ERROR: Altinity operator not ready in '${NAMESPACE}'."
+  echo "       Re-apply Terraform with enable_clickhouse_lab=true — the operator,"
+  echo "       StorageClass, and NodePool all come from that single toggle."
+  exit 1
+fi
+
+if ! kubectl get storageclass clickhouse-gp3 &>/dev/null; then
+  echo "ERROR: StorageClass 'clickhouse-gp3' not found."
+  echo "       Re-apply Terraform with enable_clickhouse_lab=true."
+  exit 1
+fi
+
+if ! kubectl get nodepool.karpenter.sh clickhouse &>/dev/null; then
+  echo "ERROR: Karpenter NodePool 'clickhouse' not found."
+  echo "       Re-apply Terraform (manifests/automode/nodepool-clickhouse.yaml)."
+  exit 1
+fi
+
+echo ""
+echo "Applying ClickHouse Keeper (3 replicas across AZs)..."
+kubectl apply -f "${SCRIPT_DIR}/keeper.yaml"
+
+echo ""
+echo "Applying ClickHouse cluster (1 shard x 3 replicas across AZs)..."
+kubectl apply -f "${SCRIPT_DIR}/cluster.yaml"
+
+echo ""
+echo "Waiting for the Keeper cluster to reach status=Completed (2-4 minutes typical)..."
+kubectl -n "${NAMESPACE}" wait --for=jsonpath='{.status.status}'=Completed \
+  chk/keeper --timeout=600s
+
+echo ""
+echo "Waiting for the ClickHouse cluster to reach status=Completed (2-4 minutes typical)..."
+kubectl -n "${NAMESPACE}" wait --for=jsonpath='{.status.status}'=Completed \
+  chi/cluster --timeout=600s
+
+echo ""
+kubectl get chi,chk -n "${NAMESPACE}"
+echo ""
+kubectl get pods -n "${NAMESPACE}" -o wide
+echo ""
+echo "Aggregated ClickHouse HTTP endpoint (in-cluster):"
+echo "  http://clickhouse-cluster.${NAMESPACE}.svc.cluster.local:8123"
+echo ""
+echo "Native ClickHouse TCP endpoint (in-cluster):"
+echo "  clickhouse-cluster.${NAMESPACE}.svc.cluster.local:9000"

--- a/analytics/clickhouse/keeper.yaml
+++ b/analytics/clickhouse/keeper.yaml
@@ -1,0 +1,89 @@
+---
+# ---------------------------------------------------------------------
+# ClickHouse Keeper installation — 3 replicas for quorum
+# ---------------------------------------------------------------------
+# ClickHouseKeeperInstallation is the Altinity operator's CR for a
+# dedicated Keeper — ClickHouse's native ZK-compatible coordinator,
+# written in C++, no JVM. Three replicas is the minimum for a
+# quorum-based deployment; one failure is tolerated.
+#
+# Pod placement:
+#   - nodeSelector `workload=clickhouse`   — pins to the dedicated
+#                                            NodePool.
+#   - toleration for `workload=clickhouse:NoSchedule` — required to
+#                                            get past the NodePool taint.
+#   - Hard podAntiAffinity keyed on `topology.kubernetes.io/zone` —
+#     one Keeper per AZ. Critical for quorum: two Keepers in the same
+#     AZ would drop the majority if that AZ blinks.
+#   - `karpenter.sh/do-not-disrupt: "true"` annotation — Karpenter
+#     won't voluntarily consolidate a Keeper node. Only drift, expiry,
+#     or forced disruption will replace it.
+#
+# The Altinity operator names the Service that fronts this Keeper as
+# `<CR-name>-<cluster-name>`, so with the CR name "keeper" and the
+# inner cluster also called "keeper" the resulting DNS name is
+# `keeper-keeper.clickhouse.svc.cluster.local:2181`. That's the string
+# the ClickHouse CHI has to reference (see cluster.yaml).
+# ---------------------------------------------------------------------
+apiVersion: "clickhouse-keeper.altinity.com/v1"
+kind: "ClickHouseKeeperInstallation"
+metadata:
+  name: keeper
+  namespace: clickhouse
+spec:
+  configuration:
+    clusters:
+      - name: keeper
+        layout:
+          replicasCount: 3
+    settings:
+      logger/level: information
+      keeper_server/tcp_port: "2181"
+      keeper_server/raft_configuration/server/port: "9444"
+  defaults:
+    templates:
+      podTemplate: keeper-pod
+      dataVolumeClaimTemplate: keeper-data
+  templates:
+    podTemplates:
+      - name: keeper-pod
+        metadata:
+          annotations:
+            # Keeper losing a member forces a raft leader re-election
+            # and pauses coordination briefly. Only drift / expiry /
+            # forced disruption should touch these nodes.
+            karpenter.sh/do-not-disrupt: "true"
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      clickhouse-keeper.altinity.com/chk: keeper
+                  topologyKey: topology.kubernetes.io/zone
+          nodeSelector:
+            workload: clickhouse
+          tolerations:
+            - key: workload
+              operator: Equal
+              value: clickhouse
+              effect: NoSchedule
+          containers:
+            - name: clickhouse-keeper
+              image: clickhouse/clickhouse-keeper:24.8-alpine
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 1Gi
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+    volumeClaimTemplates:
+      - name: keeper-data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: clickhouse-gp3
+          resources:
+            requests:
+              storage: 10Gi

--- a/analytics/terraform/spark-k8s-operator/clickhouse-operator.tf
+++ b/analytics/terraform/spark-k8s-operator/clickhouse-operator.tf
@@ -1,0 +1,108 @@
+#---------------------------------------------------------------
+# ClickHouse lab — Altinity Cluster Operator + tuned StorageClass
+#---------------------------------------------------------------
+# This file installs the two pieces of shared infrastructure that the
+# ClickHouse lab depends on. The ClickHouse cluster + Keeper themselves
+# are custom resources that the participant applies during the lab (see
+# `analytics/clickhouse/`), so ClickHouse and Keeper capacity is only
+# provisioned when someone actually runs the lab.
+#
+#   1. Altinity Cluster Operator (Helm)  — watches for the
+#      ClickHouseInstallation and ClickHouseKeeperInstallation CRs and
+#      reconciles them into StatefulSets + Services + PVCs.
+#
+#   2. `clickhouse-gp3` StorageClass       — tuned gp3 for ClickHouse
+#                                            data volumes (16 000 IOPS /
+#                                            1000 MiB/s, xfs, encrypted).
+#                                            `reclaimPolicy: Retain` so a
+#                                            stray PVC delete doesn't take
+#                                            the underlying data with it.
+#
+# The dedicated ClickHouse Karpenter NodePool lives in
+# `manifests/automode/nodepool-clickhouse.yaml`; it is picked up
+# automatically by the `auto_mode_nodepools` fileset() discovery in
+# `eks.tf`, so it deploys regardless of `enable_clickhouse_lab` (an
+# untainted NodePool with no matching pods is inert and costs nothing).
+#
+# Toggle the operator + StorageClass with `var.enable_clickhouse_lab`
+# (default true).
+#---------------------------------------------------------------
+
+locals {
+  clickhouse_lab = {
+    namespace          = "clickhouse"
+    operator_version   = var.altinity_operator_version
+    storage_class_name = "clickhouse-gp3"
+    # ClickHouse's I/O profile is IOPS-sensitive (random reads across
+    # MergeTree parts during selective queries) as well as throughput-
+    # sensitive (background merges rewriting large parts). Provisioning
+    # gp3 at 16 000 IOPS + 1000 MiB/s covers both cases and matches AWS's
+    # ClickHouse-on-EBS guidance for the workshop shape. Bump to io2
+    # Block Express only when benchmarks force the change — gp3 at the
+    # ceiling is ~10x cheaper.
+    storage_class_iops           = 16000
+    storage_class_throughput_mib = 1000
+  }
+}
+
+resource "helm_release" "altinity_clickhouse_operator" {
+  count = var.enable_clickhouse_lab ? 1 : 0
+
+  name             = "clickhouse-operator"
+  namespace        = local.clickhouse_lab.namespace
+  create_namespace = true
+  repository       = "https://helm.altinity.com"
+  chart            = "altinity-clickhouse-operator"
+  version          = local.clickhouse_lab.operator_version
+  timeout          = 600
+
+  # The operator install is cluster-scoped by default. Only the
+  # `clickhouse` namespace hosts CH + Keeper CRs in this workshop, but
+  # the operator's RBAC watches everywhere so a participant can point
+  # it at another namespace if they experiment.
+  depends_on = [
+    module.eks,
+    kubectl_manifest.auto_mode_nodepools,
+  ]
+}
+
+# Tuned gp3 StorageClass for ClickHouse data volumes.
+#
+# Why the parameters:
+#   - `iops: 16000`   — gp3 ceiling. ClickHouse's random-read profile
+#     during query benefits from IOPS more than raw throughput.
+#   - `throughput: 1000` (MiB/s) — gp3 ceiling. Needed for the merge
+#     path where a busy shard rewrites gigabytes of parts.
+#   - `reclaimPolicy: Retain` — stateful data. A stray `kubectl delete
+#     pvc` on `Delete` policy would silently take the volume with it.
+#     `Retain` requires an explicit release step to reclaim storage.
+#   - `allowVolumeExpansion: true` — in-place PVC resize when a shard
+#     runs out of room, no rebuild required.
+#   - `WaitForFirstConsumer` — critical for AZ correctness. Without
+#     it, EBS provisions in a random AZ and the pod fails to mount if
+#     it lands elsewhere.
+resource "kubectl_manifest" "clickhouse_gp3_storageclass" {
+  count = var.enable_clickhouse_lab ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "storage.k8s.io/v1"
+    kind       = "StorageClass"
+    metadata = {
+      name = local.clickhouse_lab.storage_class_name
+    }
+    provisioner          = "ebs.csi.eks.amazonaws.com"
+    volumeBindingMode    = "WaitForFirstConsumer"
+    reclaimPolicy        = "Retain"
+    allowVolumeExpansion = true
+    parameters = {
+      type       = "gp3"
+      fsType     = "xfs"
+      encrypted  = "true"
+      iops       = tostring(local.clickhouse_lab.storage_class_iops)
+      throughput = tostring(local.clickhouse_lab.storage_class_throughput_mib)
+    }
+  })
+  wait = true
+
+  depends_on = [module.eks]
+}

--- a/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-clickhouse.yaml
+++ b/analytics/terraform/spark-k8s-operator/manifests/automode/nodepool-clickhouse.yaml
@@ -1,0 +1,99 @@
+# ---------------------------------------------------------------------
+# Dedicated ClickHouse NodePool
+# ---------------------------------------------------------------------
+# ClickHouse replicas are stateful — each one owns a ReplicatedMergeTree
+# shard's local part files on its own EBS volume, plus a running merge
+# schedule and page cache. Same reasoning as Kafka: keep them off the
+# Spark (Spot) pool and off the Kafka pool, on their own On-Demand pool.
+#
+# Two-way isolation with the ClickHouse and Keeper pods:
+#   - Node label `workload=clickhouse`     — used for observability and
+#                                             selectors.
+#   - Taint  `workload=clickhouse:NoSchedule` — nothing else in the
+#                                                cluster tolerates this,
+#                                                so nothing else lands
+#                                                here.
+#   - The CHI + Keeper CRs (analytics/clickhouse/{cluster,keeper}.yaml)
+#     carry the matching toleration and nodeSelector.
+#
+# Consolidation:
+#   - WhenEmpty with a 5-minute delay. Voluntary consolidation of a
+#     partially-loaded ClickHouse or Keeper node causes a replica
+#     restart mid-merge or mid-query; the pod annotation
+#     `karpenter.sh/do-not-disrupt: "true"` on both CR pod templates
+#     defends against that further. Karpenter still handles expiry,
+#     drift and forced disruption.
+#
+# Instance selection (AWS ClickHouse-on-EBS guidance):
+#   - m/r families, Gen 5+, Nitro. ClickHouse read performance is
+#     dominated by memory (page cache for hot parts and indexes), so
+#     `r` (memory-optimized) is the natural default; `m` stays in the
+#     mix for smaller footprints and better availability during dips.
+#   - `amd64` only. Altinity's operator + `clickhouse/clickhouse-server`
+#     images are amd64-first — arm64 support has caught up but the
+#     workshop pins amd64 for predictable behaviour across the
+#     ClickHouse and operator/exporter/keeper images.
+#   - Older `m5*/r5*` are excluded via `generation > 4` — they have
+#     lower EBS baselines and can't hit the 1000 MiB/s per-volume
+#     throughput this lab provisions.
+#   - Sizes 2xlarge..8xlarge — the workshop CH pods request 1 CPU /
+#     4 GiB with 4 CPU / 16 GiB limits, so `m5.2xlarge` (8 vCPU /
+#     32 GiB) is the smallest fit; larger sizes let a participant
+#     scale up if they want to load more data.
+#
+# For a step up in performance beyond the workshop shape:
+#   - `i8g` (Graviton4) or `i4i` (x86) — local NVMe SSDs, ClickHouse
+#     as an AWS-listed target workload. Instance-store trade-off:
+#     node loss = data loss on that replica, safe with 3 replicas but
+#     adds operational sharpness (Karpenter drift/replace).
+# ---------------------------------------------------------------------
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: clickhouse
+spec:
+  template:
+    metadata:
+      labels:
+        workload: clickhouse
+    spec:
+      taints:
+        - key: workload
+          value: clickhouse
+          effect: NoSchedule
+      nodeClassRef:
+        group: eks.amazonaws.com
+        kind: NodeClass
+        name: ebs-gp3-1000gi-6000iops-1000tp
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        # amd64 only. Altinity operator + ClickHouse server + Keeper
+        # images are amd64-first; pin to keep image availability
+        # predictable across the whole stack.
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        # Memory-optimised (r) preferred, general-purpose (m) as a
+        # fallback when r-family capacity is tight in an AZ.
+        - key: eks.amazonaws.com/instance-category
+          operator: In
+          values: ["m", "r"]
+        - key: eks.amazonaws.com/instance-size
+          operator: In
+          values: ["2xlarge", "4xlarge", "8xlarge"]
+        - key: eks.amazonaws.com/instance-hypervisor
+          operator: In
+          values: ["nitro"]
+        # Gen 5+ only. Older m4/r4 don't hit the EBS bandwidth we need
+        # for the tuned clickhouse-gp3 StorageClass.
+        - key: eks.amazonaws.com/instance-generation
+          operator: Gt
+          values: ["4"]
+  limits:
+    cpu: "200"
+    memory: 800Gi
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m

--- a/analytics/terraform/spark-k8s-operator/variables.tf
+++ b/analytics/terraform/spark-k8s-operator/variables.tf
@@ -109,3 +109,15 @@ variable "enable_celeborn" {
   type        = bool
   default     = true
 }
+
+variable "enable_clickhouse_lab" {
+  description = "Enable the Apache ClickHouse lab. When true, Terraform installs the Altinity ClickHouse Operator into the 'clickhouse' namespace and creates the 'clickhouse-gp3' StorageClass. The dedicated ClickHouse Karpenter NodePool ('nodepool-clickhouse.yaml') is applied regardless — it is inert without ClickHouse pods."
+  type        = bool
+  default     = true
+}
+
+variable "altinity_operator_version" {
+  description = "Altinity ClickHouse Operator Helm chart version. Pinned to 0.24.5 — later 0.27.x versions had watch-event reliability issues on this Auto Mode cluster during earlier testing. Bump once upstream re-verifies against Auto Mode."
+  type        = string
+  default     = "0.24.5"
+}


### PR DESCRIPTION
…Pool, tuned storage

Add an in-workshop ClickHouse lab that sits alongside the Spark labs (and, when enabled, the Kafka lab) on the same EKS Auto Mode cluster created by analytics/terraform/spark-k8s-operator/.

Terraform side (behind var.enable_clickhouse_lab, default true):

- clickhouse-operator.tf — Altinity Cluster Operator via Helm chart https://helm.altinity.com/altinity-clickhouse-operator@0.24.5, plus a tuned clickhouse-gp3 StorageClass provisioned at 16000 IOPS / 1000 MiB/s with reclaimPolicy: Retain and allowVolumeExpansion: true.
- variables.tf — new vars: enable_clickhouse_lab (bool) and altinity_operator_version (string, defaults to 0.24.5 — later 0.27.x versions had watch-event reliability issues on Auto Mode during earlier testing).
- manifests/automode/nodepool-clickhouse.yaml — dedicated Karpenter NodePool with workload=clickhouse:NoSchedule taint. m/r Gen 5+ Nitro, On-Demand only, sizes 2xlarge..8xlarge. Auto-discovered by the existing fileset('nodepool*.yaml') pattern in eks.tf, so no eks.tf change is needed.

Lab manifests + scripts (analytics/clickhouse/):

- keeper.yaml — ClickHouseKeeperInstallation with 3 replicas, AZ-level podAntiAffinity, karpenter.sh/do-not-disrupt annotation, PVCs on the clickhouse-gp3 StorageClass.
- cluster.yaml — ClickHouseInstallation with 1 shard x 3 replicas, ReplicatedMergeTree coordinated through ClickHouse Keeper (not ZooKeeper — the daemon behind the zookeeper.nodes field is Keeper's ZK-compatible C++ implementation). Points at the Keeper service at keeper-keeper.clickhouse.svc.cluster.local:2181 — the Altinity operator names Services as <CR-name>-<cluster-name>, worth noting because keeper.clickhouse.svc.cluster.local doesn't resolve.
- deploy-clickhouse.sh — preflight-checks the operator, StorageClass, and NodePool, then applies both CRs and waits for status=Completed.
- cleanup.sh — deletes the CRs and their PVCs, leaves the operator, StorageClass, and NodePool for Terraform to reclaim on destroy.
- install-altinity.sh — fallback operator install for clusters not built by this workshop (adds the Altinity Helm repo and installs the pinned operator version into the clickhouse namespace).
- README.md — architecture overview, deploy/verify/cleanup walkthrough, storage tier and sizing sections mirroring the Kafka lab's shape.

Verified end-to-end against a scratch spike on an Auto Mode cluster: Karpenter provisioned 3 m5a.2xlarge nodes across us-west-2a/2b/2c, one CH replica and one Keeper member on each node. CREATE TABLE ON CLUSTER 'replicated' with ReplicatedMergeTree accepted, INSERT on replica 0 propagated to replicas 1 and 2 via Keeper coordination within seconds.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/data-on-eks/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
